### PR TITLE
chore(mt#689): land local workflow infrastructure into version control

### DIFF
--- a/.claude/hooks/require-review-before-merge.sh
+++ b/.claude/hooks/require-review-before-merge.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block session_pr_merge if no review exists on the PR
+# or if the review lacks a spec verification section.
+# Ensures code review AND spec verification are complete before merging.
+
+task=$(jq -r '.tool_input.task // empty')
+[ -z "$task" ] && exit 0
+
+branch="task/$(echo "$task" | sed 's/#/-/')"
+pr=$(gh pr list --repo edobry/minsky --head "$branch" --json number --jq '.[0].number' 2>/dev/null)
+[ -z "$pr" ] && exit 0
+
+# Check that at least one review exists
+reviews=$(gh api "repos/edobry/minsky/pulls/$pr/reviews" --jq 'length' 2>/dev/null)
+if [ "$reviews" = "0" ] || [ -z "$reviews" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"No review on PR #%s. Use /review-pr to submit a review before merging."}}' "$pr"
+  exit 0
+fi
+
+# Check that at least one review contains spec verification
+has_spec=$(gh api "repos/edobry/minsky/pulls/$pr/reviews" --jq '[.[].body] | any(test("Spec verification|spec verification|SPEC VERIFICATION"))' 2>/dev/null)
+if [ "$has_spec" != "true" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Review on PR #%s lacks spec verification section. Use /review-pr to post a review that includes spec verification before merging."}}' "$pr"
+  exit 0
+fi

--- a/.claude/hooks/typecheck-on-edit.sh
+++ b/.claude/hooks/typecheck-on-edit.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
-# PostToolUse hook: run tsc --noEmit after editing TypeScript files
-# Returns additionalContext with type errors so the model sees them immediately
+# PostToolUse hook: INFORMATIONAL type checking after editing TypeScript files
+#
+# Two responsibilities:
+#   1. Track which project root was edited (state file for Stop/SubagentStop hooks)
+#   2. Run incremental tsc in that root, show smart-filtered errors as context
+#
+# Does NOT block — Stop/SubagentStop hooks enforce correctness at turn end.
 
-# Extract file path — handles both direct tools (file_path) and MCP session tools (path)
-file_path=$(jq -r '.tool_input.file_path // .tool_input.path // .tool_response.filePath // empty')
+# Read stdin once
+INPUT=$(cat)
+
+# Extract fields
+file_path=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // .tool_response.filePath // empty')
+session_id=$(echo "$INPUT" | jq -r '.session_id // "default"')
+agent_id=$(echo "$INPUT" | jq -r '.agent_id // empty')
 
 # Only run for TypeScript files
 if ! echo "$file_path" | grep -qE '\.tsx?$'; then
@@ -15,20 +25,50 @@ fi
 # Otherwise, use the main project dir.
 SESSIONS_DIR="$HOME/.local/state/minsky/sessions"
 if echo "$file_path" | grep -q "^$SESSIONS_DIR/"; then
-  # Extract session root: ~/.local/state/minsky/sessions/<UUID>
-  session_root=$(echo "$file_path" | sed "s|^\($SESSIONS_DIR/[^/]*\)/.*|\1|")
-  cd "$session_root" || exit 0
+  project_root=$(echo "$file_path" | sed "s|^\($SESSIONS_DIR/[^/]*\)/.*|\1|")
 else
-  cd "$CLAUDE_PROJECT_DIR" || exit 0
+  project_root="$CLAUDE_PROJECT_DIR"
 fi
 
-output=$(bunx tsc --noEmit 2>&1)
+# Track this project root for Stop/SubagentStop to find later.
+# State file is keyed by session_id and (if subagent) agent_id.
+if [ -n "$agent_id" ]; then
+  state_file="/tmp/claude-typecheck-roots-${session_id}-${agent_id}.txt"
+else
+  state_file="/tmp/claude-typecheck-roots-${session_id}-main.txt"
+fi
+echo "$project_root" >> "$state_file"
+
+# Run tsc with --incremental for fast feedback
+cd "$project_root" || exit 0
+output=$(bunx tsc --incremental 2>&1)
 rc=$?
 
 if [ $rc -ne 0 ]; then
-  # Escape the output for JSON embedding
-  escaped=$(echo "$output" | jq -Rs .)
-  printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"TypeScript errors after edit:\\n%s"}}' "$escaped"
-  # Exit 2 to trigger asyncRewake — surfaces errors to the model
-  exit 2
+  # Compute relative path from project root for matching tsc output
+  rel_path="${file_path#${project_root}/}"
+
+  # Filter: errors in the edited file vs cascade errors in other files
+  file_errors=$(echo "$output" | grep "^${rel_path}(")
+  total_error_count=$(echo "$output" | grep -c '): error TS')
+
+  if [ -n "$file_errors" ]; then
+    file_error_count=$(echo "$file_errors" | wc -l | tr -d ' ')
+    cascade_count=$((total_error_count - file_error_count))
+    file_errors_preview=$(echo "$file_errors" | head -10 | jq -Rs .)
+    if [ "$cascade_count" -gt 0 ]; then
+      jq -n --argjson errors "$file_errors_preview" --arg cascade "$cascade_count" \
+        '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: ("TypeScript errors in edited file:\n" + $errors + "\n(+ " + $cascade + " cascade error(s) in other files)")}}'
+    else
+      jq -n --argjson errors "$file_errors_preview" \
+        '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: ("TypeScript errors in edited file:\n" + $errors)}}'
+    fi
+  else
+    # Only cascade errors in other files — just summarize
+    jq -n --arg count "$total_error_count" \
+      '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: ("TypeScript: " + $count + " error(s) in other files (cascade from ongoing edits, checked at turn end)")}}'
+  fi
 fi
+
+# Always exit 0 — informational only.
+exit 0

--- a/.claude/hooks/typecheck-on-stop.sh
+++ b/.claude/hooks/typecheck-on-stop.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Stop hook: full type check on all project roots edited during this turn.
+#
+# This is the correctness/truthfulness gate — Claude cannot stop with
+# type errors. Exit 2 forces Claude to continue and fix the errors.
+#
+# Reads tracked project roots from the main agent's state file.
+
+# Read stdin to extract session_id
+INPUT=$(cat)
+session_id=$(echo "$INPUT" | jq -r '.session_id // "default"')
+
+state_file="/tmp/claude-typecheck-roots-${session_id}-main.txt"
+
+# Pipe input back into the shared script
+echo "$INPUT" | "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-tracked-roots.sh" "$state_file" "Stop"

--- a/.claude/hooks/typecheck-on-subagent-stop.sh
+++ b/.claude/hooks/typecheck-on-subagent-stop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SubagentStop hook: full type check on all project roots edited by this subagent.
+#
+# Forces subagents to leave clean code before returning to the main agent.
+# Reads tracked project roots from the subagent's per-agent state file.
+
+# Read stdin to extract session_id and agent_id
+INPUT=$(cat)
+session_id=$(echo "$INPUT" | jq -r '.session_id // "default"')
+agent_id=$(echo "$INPUT" | jq -r '.agent_id // empty')
+
+# If for some reason agent_id is missing, fall back to main state file
+if [ -n "$agent_id" ]; then
+  state_file="/tmp/claude-typecheck-roots-${session_id}-${agent_id}.txt"
+else
+  state_file="/tmp/claude-typecheck-roots-${session_id}-main.txt"
+fi
+
+# Pipe input back into the shared script
+echo "$INPUT" | "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-tracked-roots.sh" "$state_file" "SubagentStop"

--- a/.claude/hooks/typecheck-tracked-roots.sh
+++ b/.claude/hooks/typecheck-tracked-roots.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Shared logic: read tracked project roots from a state file, run full tsc
+# in each one. Used by both Stop and SubagentStop hooks.
+#
+# Usage: typecheck-tracked-roots.sh <state_file> <hook_event_name>
+# Reads JSON input from stdin (for cwd fallback).
+# Exits 2 if any root has type errors. Cleans up state file on success.
+
+state_file="$1"
+hook_event="$2"
+
+# Read stdin for cwd fallback
+INPUT=$(cat)
+cwd=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Collect unique project roots from state file
+if [ -f "$state_file" ]; then
+  roots=$(sort -u "$state_file")
+else
+  roots=""
+fi
+
+# Fallback: if no tracked roots, use cwd or CLAUDE_PROJECT_DIR
+if [ -z "$roots" ]; then
+  roots="${cwd:-$CLAUDE_PROJECT_DIR}"
+fi
+
+# Check each root
+all_errors=""
+total_count=0
+failed_roots=()
+
+for root in $roots; do
+  [ -d "$root" ] || continue
+  [ -f "$root/tsconfig.json" ] || continue
+
+  cd "$root" || continue
+  output=$(bunx tsc 2>&1)
+  if [ $? -ne 0 ]; then
+    count=$(echo "$output" | grep -c '): error TS')
+    total_count=$((total_count + count))
+    failed_roots+=("$root")
+    # Prepend root header to errors for clarity
+    all_errors="${all_errors}${all_errors:+\n\n}=== $root ===\n$output"
+  fi
+done
+
+if [ ${#failed_roots[@]} -gt 0 ]; then
+  errors_preview=$(printf '%b' "$all_errors" | head -60 | jq -Rs .)
+  jq -n --argjson preview "$errors_preview" --arg count "$total_count" --arg event "$hook_event" \
+    '{hookSpecificOutput: {hookEventName: $event, additionalContext: ("TypeScript errors must be fixed before completing:\n" + $preview + "\n\nTotal: " + $count + " error(s). Fix all type errors before returning.")}}'
+  exit 2
+fi
+
+# All checks passed — clean up state file
+rm -f "$state_file"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,48 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__minsky__session_pr_merge",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/require-review-before-merge.sh",
+            "timeout": 15,
+            "statusMessage": "Checking for PR review..."
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-on-stop.sh",
+            "timeout": 60,
+            "statusMessage": "Final type check..."
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-on-subagent-stop.sh",
+            "timeout": 60,
+            "statusMessage": "Subagent type check..."
           }
         ]
       }
@@ -18,8 +55,18 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-on-edit.sh",
             "timeout": 30,
-            "statusMessage": "Type checking...",
-            "asyncRewake": true
+            "statusMessage": "Type checking..."
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__minsky__session_pr_merge",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git -C $CLAUDE_PROJECT_DIR pull --ff-only origin main 2>/dev/null || true",
+            "timeout": 15,
+            "statusMessage": "Pulling latest main..."
           }
         ]
       }

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: review-pr
+description: >-
+  Review a pull request with codebase-verified findings and spec verification,
+  posted as an actual GitHub PR review.
+  Use when asked to review a PR, or when a PR is ready for review after subagent work.
+user-invocable: true
+---
+
+# PR Review Skill
+
+Review a pull request thoroughly and post the review to GitHub.
+
+## Arguments
+
+The argument is a PR number (e.g., `/review-pr 328`) or a GitHub PR URL.
+
+## Process
+
+### 1. Gather context
+
+Fetch in parallel:
+
+- PR metadata: `mcp__github__pull_request_read` with `method: "get"`
+- CI status: `mcp__github__pull_request_read` with `method: "get_check_runs"`
+- Changed files list: `mcp__github__pull_request_read` with `method: "get_files"`
+
+### 2. Identify the task
+
+Extract the task ID from the PR title or branch name (e.g., `mt#671` from `task/mt-671`). If there's an associated task, fetch its spec with `mcp__minsky__tasks_spec_get`. This is needed for step 6.
+
+### 3. Read the diff
+
+Use `mcp__github__pull_request_read` with `method: "get_diff"`. For large diffs, the result will be saved to a file — read it in sequential chunks until 100% is covered.
+
+### 4. Analyze changes
+
+For each file changed, understand:
+
+- What was removed and what replaced it
+- Whether the change is purely mechanical or behavioral
+
+### 5. Verify concerns against the codebase
+
+**This is the critical step.** When you identify a potential issue in the diff:
+
+- **DO NOT report it based on the diff alone.** Read the actual source files in the repo to verify.
+- If a function call looks unsafe, read the function's implementation to check for internal guards.
+- If a type/field name looks wrong, read the schema/interface definition to confirm.
+- If behavior looks changed, read the surrounding code to understand the full context.
+- Classify each finding with evidence:
+  - **Blocking** — verified real issue introduced by this PR, with file:line evidence
+  - **Non-blocking** — real concern but low risk or stylistic
+  - **Pre-existing** — real issue but not introduced by this PR (note for follow-up)
+  - **False positive** — concern was disproven by reading the source (do not include in review)
+
+Only include verified findings in the GitHub review. Drop false positives entirely rather than padding the review.
+
+### 6. Verify against task spec
+
+**This step is mandatory.** If a task spec exists:
+
+1. Read every success criterion in the spec
+2. For each criterion, verify the PR actually delivers it by checking the code
+3. Classify each criterion:
+   - **Met** — the code change satisfies it, with evidence
+   - **Not met** — the PR does not deliver this criterion
+   - **Not applicable** — criterion was stale or already satisfied before this PR
+4. If any criteria are **not met**, this must be flagged as blocking. Before the PR can merge:
+   - The task spec must be updated to reflect actual scope
+   - Follow-up tasks must be created for deferred items
+   - The review must explicitly list what was deferred and why
+
+### 7. Post to GitHub
+
+Use `mcp__github__pull_request_review_write` to post the review:
+
+- `method: "create"` with `event` to submit immediately
+- For line-level comments: create a pending review first, add comments with `add_comment_to_pending_review`, then `submit_pending`
+- Use `event: "APPROVE"` only if you are not the PR author and there are no blocking issues
+- Use `event: "COMMENT"` if you are the PR author or there are only non-blocking issues
+- Use `event: "REQUEST_CHANGES"` if there are blocking issues or unmet spec criteria
+
+### 8. Review body format
+
+```markdown
+## Review: <short description>
+
+**CI status:** <pass/fail/pending>
+
+### Findings
+
+<For each verified finding:>
+**[BLOCKING/NON-BLOCKING/PRE-EXISTING]** <file:line> — <description>
+<evidence from source code that confirms this is real>
+
+### Checked and clear
+
+<Brief list of areas reviewed with no issues — shows coverage>
+
+### Spec verification
+
+**Task:** <task ID>
+
+| Criterion             | Status          | Evidence                   |
+| --------------------- | --------------- | -------------------------- |
+| <criterion from spec> | Met/Not met/N/A | <file:line or explanation> |
+
+<If any criteria not met:>
+**Action required:** <spec update needed / follow-up task needed / blocking>
+
+(Had Claude look into this — AI-assisted review)
+```
+
+## Key principles
+
+- **A review that isn't on GitHub isn't a review.** Always post via GitHub MCP tools.
+- **Never flag unverified concerns.** Every finding must be confirmed by reading the actual source, not just the diff.
+- **The diff shows what changed; the codebase shows whether the change is correct.** Always check both.
+- **Include CI status.** Don't approve with failing checks.
+- **Spec verification is mandatory.** The review must include a spec verification table. The pre-merge hook will reject merges without it.
+- **Attribute AI involvement** per user preferences.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,12 @@ Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID
 2. **Main agent** orchestrates: create tasks, start sessions, launch subagents, review PRs, merge.
 3. **Subagents** do the full workflow in session directories: edit code → `mcp__minsky__session_commit` → `mcp__minsky__session_pr_create`. They do NOT merge — that happens after review.
 4. **Before creating a PR**, always ensure the session is up-to-date with main. `mcp__minsky__session_pr_create` automatically calls `session_update` (which rebases the session on latest main) before creating the PR — this prevents merge-induced formatting drift and ensures clean fast-forward merges. You can also call `mcp__minsky__session_update` explicitly before committing if needed.
-5. **Main agent reviews** the PR by reading the actual diff (via GitHub MCP `pull_request_read` with `get_diff`), then merges with `mcp__minsky__session_pr_merge`. Never approve without reviewing.
-6. **When merging multiple PRs sequentially**, each merge may cause conflicts in remaining PRs. Update remaining sessions (`session_update`) after each merge, or resolve conflicts with `session_search_replace` on the conflict markers.
-7. All file operations in sessions MUST use absolute paths.
-8. **NEVER use bare git CLI** (`git add`, `git commit`, `git push`, `git pull`, `git -C`). Always use MCP tools. Shell `#` in task paths causes parsing issues and permission prompts.
-9. **Always quote all Bash arguments** containing `#`, `$`, or special chars if Bash is unavoidable.
+5. **Main agent reviews** the PR using the `/review-pr` skill, which verifies findings against the actual codebase and posts the review to GitHub. Never merge without a posted GitHub review.
+6. **After merging a PR**, the local workspace is stale (merge happens on GitHub). A PostToolUse hook auto-pulls after `session_pr_merge`. If starting a fresh conversation after prior merges, verify the workspace is current before analyzing code.
+7. **When merging multiple PRs sequentially**, each merge may cause conflicts in remaining PRs. Update remaining sessions (`session_update`) after each merge, or resolve conflicts with `session_search_replace` on the conflict markers.
+8. All file operations in sessions MUST use absolute paths.
+9. **NEVER use bare git CLI** (`git add`, `git commit`, `git push`, `git pull`, `git -C`). Always use MCP tools. Shell `#` in task paths causes parsing issues and permission prompts.
+10. **Always quote all Bash arguments** containing `#`, `$`, or special chars if Bash is unavoidable.
 
 ### Session lifecycle: one session, one merge
 
@@ -53,6 +54,10 @@ When launching multiple subagents in parallel, **check for file overlap** betwee
 
 Merging parallel PRs that touch the same files causes cascading conflicts that require session recreation.
 
+## PR Reviews
+
+**Always use the `/review-pr` skill when reviewing any PR.** This includes "review PR #X", "check this PR", "look at the diff", or reviewing after subagent work. A review that isn't posted to GitHub is not a review.
+
 ## Task Completion Protocol
 
 A PR merging is NOT the same as a task being complete. Before marking any task DONE:
@@ -63,6 +68,30 @@ A PR merging is NOT the same as a task being complete. Before marking any task D
 4. **If criteria can't be verified**, the task is not DONE — use IN-REVIEW or create follow-up tasks
 
 Never treat "code merged" as equivalent to "task complete." The spec defines completeness, not the PR.
+
+### Pre-flight: Verify spec before starting work
+
+Task specs may be stale — written in a prior conversation when the codebase was different. Before starting a session:
+
+1. Fetch the task spec with `tasks_spec_get`
+2. For each specific item (file:line references, counts, etc.), verify against the **current** codebase
+3. If items are already done or no longer applicable, update the spec before starting work
+4. This prevents wasted effort on stale targets and ensures subagents get accurate instructions
+
+### Spec verification gates merge
+
+The `/review-pr` skill requires a **Spec verification** section in every review. The pre-merge hook (`require-review-before-merge.sh`) blocks merges if the review lacks this section. This ensures:
+
+- Every spec criterion is checked before merge
+- Scope reductions are caught and documented
+- Follow-up tasks are created for deferred work
+
+## Work Completion
+
+- **Do not defer identified, actionable work.** If the current task's success criteria have unmet items and the work to address them is known (not blocked, not requiring new research), complete it. Do not create follow-up tasks, update specs to reduce scope, or propose partial PRs without explicitly asking the user.
+- **The user decides scope, not the agent.** Never unilaterally decide "this is a good stopping point." If uncertain whether to continue, ask.
+- **Artifact creation is not progress.** Creating tasks, updating specs, writing rules, and process discussion are not substitutes for doing the work. If you can describe exactly what needs to be done, do it.
+- **Before proposing to ship**, check the task spec's success criteria. If items are unmet and actionable, keep working.
 
 ## MCP Tools
 


### PR DESCRIPTION
## Summary

Commits previously-uncommitted local work from multiple conversations into version control via a proper session.

### Type checking hooks (3-tier architecture)
- `typecheck-on-edit.sh`: PostToolUse — informational with smart filtering (errors in edited file vs cascade count) + state tracking for Stop hooks
- `typecheck-on-stop.sh`: Stop hook — full tsc, blocking (prevents returning broken code to user)
- `typecheck-on-subagent-stop.sh`: SubagentStop hook — full tsc, blocking (prevents subagents returning broken code)
- `typecheck-tracked-roots.sh`: shared logic for the Stop/SubagentStop hooks (reads tracked project roots, runs tsc in each)

### PR review infrastructure
- `require-review-before-merge.sh`: PreToolUse hook blocking merges without a posted review
- `.claude/skills/review-pr/SKILL.md`: the review-pr slash command skill
- `settings.json`: Stop, SubagentStop, PreToolUse hook wiring; removed asyncRewake from PostToolUse

### CLAUDE.md additions
- PR Reviews section (require /review-pr skill for all reviews)
- Pre-flight spec verification guidance
- Spec verification gates merge section
- Work Completion section (anti-deferral rules)
- Post-merge auto-pull guidance

## Why this was uncommitted

These changes were made directly in the main workspace across multiple conversations, violating the "ALL work goes through sessions" rule. The rationalization was "this is hook configuration, not Minsky code." That was wrong — the rule applies to all repo files. This PR fixes the workflow violation.

## Test plan
- [x] Hooks are working in the current Claude Code instance (used throughout today's session)
- [x] Smart filtering tested with synthetic type errors (documented earlier in conversation)
- [ ] CI passes

(Had Claude review and prepare this PR.)