### PR TITLE
chore(mt#509): upgrade Husky v9.1.7 to v10.0.0

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 echo "Running tests before push..."
 
 # Run tests and capture exit code before piping


### PR DESCRIPTION
## Summary

- Remove `#!/usr/bin/env bash` shebang from `.husky/pre-push` hook
- The pre-commit hook already had no shebang; this aligns pre-push with the same convention
- Husky v9 deprecated shebangs and `husky.sh` sourcing as breaking changes — hooks must be plain shell scripts without shebangs

## Test plan

- [x] All pre-commit validations pass (formatter, linting, typecheck, tests, gitleaks)
- [x] Pre-push hook runs tests and passes before push
- [x] Both hooks (pre-commit and pre-push) now have no shebang, consistent with Husky v9+ requirements

Note: Husky v10 does not exist on npm (latest is v9.1.7). The task spec referenced v10 but the actual breaking change (shebang removal) was introduced in v9. The package.json version remains `^9.1.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)