### PR TITLE
fix(mt#704): Fix session delete silent failure and add workspace cleanup

### DIFF
--- a/src/adapters/shared/commands/session/management-commands.ts
+++ b/src/adapters/shared/commands/session/management-commands.ts
@@ -21,7 +21,7 @@ export function createSessionDeleteCommand(deps: SessionCommandDependencies): Co
     execute: withErrorLogging("session.delete", async (params: Record<string, unknown>) => {
       const { deleteSessionFromParams } = await import("../../../../domain/session");
 
-      const deleted = await deleteSessionFromParams({
+      const result = await deleteSessionFromParams({
         name: params.name as string | undefined,
         task: params.task as string | undefined,
         force: (params.force as boolean | undefined) ?? false,
@@ -30,8 +30,9 @@ export function createSessionDeleteCommand(deps: SessionCommandDependencies): Co
       });
 
       return {
-        success: deleted,
+        success: result.deleted,
         session: params.name || params.task,
+        ...(result.error ? { error: result.error } : {}),
       };
     }),
   };

--- a/src/domain/session.ts
+++ b/src/domain/session.ts
@@ -233,7 +233,7 @@ export async function startSessionFromParams(
 export async function deleteSessionFromParams(
   params: SessionDeleteParams,
   depsInput?: { sessionDB?: SessionProviderInterface }
-): Promise<boolean> {
+): Promise<import("./session/session-lifecycle-operations").DeleteSessionResult> {
   const service = new SessionService(
     await resolvePartialDeps({ sessionProvider: depsInput?.sessionDB })
   );

--- a/src/domain/session/session-auto-detection-integration.test.ts
+++ b/src/domain/session/session-auto-detection-integration.test.ts
@@ -114,7 +114,7 @@ describe("Session Command Domain Logic", () => {
         }
       );
 
-      expect(result).toBe(true);
+      expect(result.deleted).toBe(true);
     });
 
     test("deletes session by explicit task ID", async () => {
@@ -129,7 +129,7 @@ describe("Session Command Domain Logic", () => {
         }
       );
 
-      expect(result).toBe(true);
+      expect(result.deleted).toBe(true);
     });
 
     test("throws ResourceNotFoundError for non-existent session", async () => {
@@ -157,7 +157,8 @@ describe("Session Command Domain Logic", () => {
         }
       );
 
-      expect(result).toBe(false);
+      expect(result.deleted).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 
@@ -178,7 +179,7 @@ describe("Session Command Domain Logic", () => {
         { task: taskId, force: true, json: false },
         { sessionDB: mockSessionProvider }
       );
-      expect(deleteResult).toBe(true);
+      expect(deleteResult.deleted).toBe(true);
 
       // All commands should have resolved to the same session
     });

--- a/src/domain/session/session-db-adapter.ts
+++ b/src/domain/session/session-db-adapter.ts
@@ -107,19 +107,19 @@ export class SessionDbAdapter implements SessionProviderInterface {
 
   async deleteSession(sessionId: string): Promise<boolean> {
     log.debug(`Deleting session: ${sessionId}`);
-    try {
-      const storage = await this.getStorage();
-      const deleted = await storage.deleteEntity(sessionId);
-      if (deleted) {
-        log.debug(`Session deleted successfully: ${sessionId}`);
-      } else {
-        log.debug(`Session not found: ${sessionId}`);
-      }
-      return deleted;
-    } catch (error) {
-      log.error(`Failed to delete session '${sessionId}': ${getErrorMessage(error)}`);
-      return false;
+    // Note: we do NOT wrap this in a catch-all.  Storage errors (permission denied,
+    // corruption, etc.) must propagate so callers can surface them to the user.
+    // Returning `false` is only appropriate for "session not found" — a legitimate
+    // outcome for idempotent delete — which the underlying storage signals by
+    // returning `false` from `deleteEntity` rather than throwing.
+    const storage = await this.getStorage();
+    const deleted = await storage.deleteEntity(sessionId);
+    if (deleted) {
+      log.debug(`Session deleted successfully: ${sessionId}`);
+    } else {
+      log.debug(`Session not found for deletion: ${sessionId}`);
     }
+    return deleted;
   }
 
   async doesSessionExist(sessionId: string): Promise<boolean> {

--- a/src/domain/session/session-lifecycle-operations.ts
+++ b/src/domain/session/session-lifecycle-operations.ts
@@ -86,16 +86,23 @@ export async function deleteSessionImpl(
 ): Promise<DeleteSessionResult> {
   const { name, task, repo } = params;
 
+  // Delete is destructive — require explicit identification, never auto-detect
+  if (!name && !task && !repo) {
+    return {
+      deleted: false,
+      error: "Session delete requires a session name (--name) or task ID (--task)",
+    };
+  }
+
   let resolvedSessionId: string;
 
   try {
-    // Use unified session context resolver with auto-detection support
     const resolvedContext = await resolveSessionContextWithFeedback({
       session: name,
       task: task,
       repo: repo,
       sessionProvider: deps.sessionDB,
-      allowAutoDetection: true,
+      allowAutoDetection: false,
     });
     resolvedSessionId = resolvedContext.sessionId;
   } catch (error) {

--- a/src/domain/session/session-lifecycle-operations.ts
+++ b/src/domain/session/session-lifecycle-operations.ts
@@ -64,16 +64,29 @@ export async function listSessionsImpl(
 }
 
 /**
+ * Structured result returned by deleteSessionImpl.
+ */
+export interface DeleteSessionResult {
+  deleted: boolean;
+  error?: string;
+}
+
+/**
  * Deletes a session based on parameters
  * Using proper dependency injection for better testability
+ *
+ * Returns a structured result so callers can surface error messages.
+ * Also removes the session's workspace directory from the filesystem.
  */
 export async function deleteSessionImpl(
   params: SessionDeleteParams,
   deps: {
     sessionDB: SessionProviderInterface;
   }
-): Promise<boolean> {
+): Promise<DeleteSessionResult> {
   const { name, task, repo } = params;
+
+  let resolvedSessionId: string;
 
   try {
     // Use unified session context resolver with auto-detection support
@@ -84,21 +97,42 @@ export async function deleteSessionImpl(
       sessionProvider: deps.sessionDB,
       allowAutoDetection: true,
     });
-
-    // Delete the session using the resolved session ID
-    return deps.sessionDB.deleteSession(resolvedContext.sessionId);
+    resolvedSessionId = resolvedContext.sessionId;
   } catch (error) {
-    // Non-existent session is not an error for delete — return false
+    // Non-existent session is not an error for delete — return structured false
     if (error instanceof ResourceNotFoundError) {
-      log.debug(`Session not found for deletion: ${name || task || repo}`);
-      return false;
+      const msg = `Session not found: ${name || task || repo}`;
+      log.debug(msg);
+      return { deleted: false, error: msg };
     }
     if (error instanceof ValidationError) {
-      log.debug(`No session context resolved for deletion: ${name || task || repo}`);
-      return false;
+      const msg = `No session context resolved for deletion: ${name || task || repo}`;
+      log.debug(msg);
+      return { deleted: false, error: msg };
     }
     throw error;
   }
+
+  // Remove workspace directory from filesystem (if it exists)
+  const sessionWorkspaceDir = `${getSessionsDir()}/${resolvedSessionId}`;
+  try {
+    if (existsSync(sessionWorkspaceDir)) {
+      log.debug(`Removing session workspace directory: ${sessionWorkspaceDir}`);
+      rmSync(sessionWorkspaceDir, { recursive: true, force: true });
+      log.debug(`Successfully removed session workspace directory: ${sessionWorkspaceDir}`);
+    } else {
+      log.debug(`Session workspace directory does not exist, skipping: ${sessionWorkspaceDir}`);
+    }
+  } catch (error) {
+    // Filesystem removal failure is non-fatal — log but continue with DB deletion
+    log.warn(
+      `Failed to remove session workspace directory '${sessionWorkspaceDir}': ${getErrorMessage(error)}`
+    );
+  }
+
+  // Delete the session record from the database
+  const deleted = await deps.sessionDB.deleteSession(resolvedSessionId);
+  return { deleted };
 }
 
 /**

--- a/src/domain/session/session-service.ts
+++ b/src/domain/session/session-service.ts
@@ -25,6 +25,7 @@ import {
   deleteSessionImpl,
   getSessionDirImpl,
   inspectSessionImpl,
+  type DeleteSessionResult,
 } from "./session-lifecycle-operations";
 import { startSessionImpl } from "./start-session-operations";
 import { updateSessionImpl } from "./session-update-operations";
@@ -149,7 +150,7 @@ export class SessionService {
   /**
    * Delete a session.
    */
-  async delete(params: SessionDeleteParams): Promise<boolean> {
+  async delete(params: SessionDeleteParams): Promise<DeleteSessionResult> {
     return deleteSessionImpl(params, { sessionDB: this.deps.sessionProvider });
   }
 

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -301,15 +301,10 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
 
   /**
    * Delete a single session by ID (compatibility method for SessionDbAdapter)
+   * Storage errors propagate — only returns false for "not found".
    */
   async delete(id: string): Promise<boolean> {
-    try {
-      return await this.deleteEntity(id);
-    } catch (error) {
-      const typedError = error instanceof Error ? error : new Error(String(error));
-      log.warn(`Failed to delete session from PostgreSQL: ${typedError.message}`);
-      return false;
-    }
+    return await this.deleteEntity(id);
   }
 
   /**

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -398,18 +398,17 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
   }
 
   /**
-   * Delete a session by ID
+   * Delete a session by ID.
+   * Returns true if a row was actually deleted, false if it didn't exist.
+   * Storage errors propagate — callers decide how to handle them.
    */
   async deleteEntity(id: string): Promise<boolean> {
-    try {
-      await this.ensureConnection();
-      await this.drizzle!.delete(postgresSessions).where(eq(postgresSessions.session, id));
-      return true;
-    } catch (error) {
-      const typedError = error instanceof Error ? error : new Error(String(error));
-      log.warn(`Failed to delete session in PostgreSQL: ${typedError.message}`);
-      return false;
-    }
+    await this.ensureConnection();
+    const result = await this.drizzle!.delete(postgresSessions).where(
+      eq(postgresSessions.session, id)
+    );
+    const rowCount = (result as { rowCount?: number }).rowCount ?? 0;
+    return rowCount > 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `deleteSessionImpl` now returns structured `DeleteSessionResult` with error messages instead of bare boolean
- `SessionDbAdapter.deleteSession` no longer swallows storage errors -- only returns false for "not found" cases
- Management command includes `error` field in response when `success: false`
- Session delete now removes workspace directory from filesystem before deleting the DB record
- **mt#706**: Session delete no longer uses auto-detection -- requires explicit name or task ID to prevent wrong-session deletion
- **mt#706**: Postgres storage `delete()` no longer swallows errors either

## Context
During testing, a session DB record silently disappeared. Investigation found:
1. `deleteSessionImpl` used `allowAutoDetection: true` -- if called with wrong parameter names, it could resolve to and delete the wrong session
2. Both JSON and Postgres storage delete methods swallowed all errors, returning `false` with no diagnostics
3. Management command returned `{ success: false }` with no error field

## Test plan
- [x] Type check passes (tsc --noEmit clean)
- [x] All 311 session + storage tests pass
- [ ] Manual test: delete with no name/task returns error message about requiring explicit identification
- [ ] Manual test: delete nonexistent session returns error message
- [ ] Manual test: delete existing session removes both DB record and directory