### PR TITLE
feat(mt#504): implement non-interactive CLI mode

### DIFF
--- a/src/adapters/shared/commands/init.ts
+++ b/src/adapters/shared/commands/init.ts
@@ -17,6 +17,7 @@ import { TaskBackend } from "../../../domain/configuration/backend-detection";
 import { log } from "../../../utils/logger";
 import { ValidationError } from "../../../errors/index";
 import { CommonParameters, composeParams } from "../common-parameters";
+import { isInteractive } from "../../../utils/interactive";
 // Removed unused initParamsSchema import
 
 const initParams = composeParams(
@@ -94,7 +95,7 @@ export function registerInitCommands() {
           let backend = params.backend;
           if (!backend) {
             // Check if we're in an interactive environment
-            if (!process.stdout.isTTY) {
+            if (!isInteractive()) {
               throw new ValidationError(
                 `Backend parameter is required in non-interactive mode. Use --backend to specify: ${TaskBackend.MARKDOWN}, ${TaskBackend.JSON_FILE}, or ${TaskBackend.GITHUB_ISSUES}`
               );
@@ -130,7 +131,7 @@ export function registerInitCommands() {
 
           if (backend === TaskBackend.GITHUB_ISSUES) {
             if (!githubOwner) {
-              if (!process.stdout.isTTY) {
+              if (!isInteractive()) {
                 throw new ValidationError(
                   "GitHub owner is required when using github-issues backend. Use --github-owner to specify."
                 );
@@ -156,7 +157,7 @@ export function registerInitCommands() {
             }
 
             if (!githubRepo) {
-              if (!process.stdout.isTTY) {
+              if (!isInteractive()) {
                 throw new ValidationError(
                   "GitHub repository name is required when using github-issues backend. Use --github-repo to specify."
                 );
@@ -185,7 +186,7 @@ export function registerInitCommands() {
           // Interactive rule format selection if not provided
           let ruleFormat = params.ruleFormat;
           if (!ruleFormat) {
-            if (!process.stdout.isTTY) {
+            if (!isInteractive()) {
               // Default to cursor in non-interactive mode
               ruleFormat = "cursor";
             } else {
@@ -226,7 +227,7 @@ export function registerInitCommands() {
               port: params.mcpPort ? Number(params.mcpPort) : undefined,
               host: params.mcpHost,
             };
-          } else if (process.stdout.isTTY && !params.mcpOnly) {
+          } else if (isInteractive() && !params.mcpOnly) {
             // Interactive MCP configuration
             const enableMcp = await confirm({
               message: "Enable MCP (Model Context Protocol) configuration?",
@@ -301,7 +302,7 @@ export function registerInitCommands() {
           const detectedRepo = detectRepositoryBackend(repoPath);
 
           if (detectedRepo.backend !== "local") {
-            if (process.stdout.isTTY) {
+            if (isInteractive()) {
               // Interactive mode: show detection and ask for confirmation
               const detectionLabel =
                 detectedRepo.backend === "github" && detectedRepo.github

--- a/src/adapters/shared/commands/tasks/status-commands.ts
+++ b/src/adapters/shared/commands/tasks/status-commands.ts
@@ -11,6 +11,7 @@ import { ValidationError } from "../../../../errors/index";
 import { TASK_STATUS } from "../../../../domain/tasks/taskConstants";
 import { BaseTaskCommand, type BaseTaskParams } from "./base-task-command";
 import { tasksStatusGetParams, tasksStatusSetParams } from "./task-parameters";
+import { isInteractive } from "../../../../utils/interactive";
 
 /**
  * Parameters for tasks status get command
@@ -131,7 +132,7 @@ export class TasksStatusSetCommand extends BaseTaskCommand<TasksStatusSetParams>
    */
   private async promptForStatus(currentStatus: string): Promise<string> {
     // Check if we're in an interactive environment
-    if (!process.stdout.isTTY) {
+    if (!isInteractive()) {
       throw new ValidationError("Status parameter is required in non-interactive mode");
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,14 @@ import { validateError, getErrorMessage, getErrorStack } from "./schemas/error";
  */
 export const cli = new Command("minsky")
   .description("Minsky development workflow tool")
-  .version("1.0.0");
+  .version("1.0.0")
+  .option("--non-interactive", "Disable interactive prompts, error on missing required parameters")
+  .hook("preAction", (thisCommand) => {
+    const opts = thisCommand.opts();
+    if (opts.nonInteractive) {
+      process.env.MINSKY_NON_INTERACTIVE = "1";
+    }
+  });
 
 /**
  * Create the CLI command structure

--- a/src/utils/interactive.test.ts
+++ b/src/utils/interactive.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the isInteractive() utility function.
+ *
+ * Because isInteractive() reads process.env at call time (not import time),
+ * we can test it by setting env vars before each call.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { isInteractive } from "./interactive";
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {
+    MINSKY_NON_INTERACTIVE: process.env.MINSKY_NON_INTERACTIVE,
+    CI: process.env.CI,
+    TERM: process.env.TERM,
+  };
+  // Clear all relevant env vars before each test
+  delete process.env.MINSKY_NON_INTERACTIVE;
+  delete process.env.CI;
+  delete process.env.TERM;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key as keyof NodeJS.ProcessEnv];
+    } else {
+      process.env[key as keyof NodeJS.ProcessEnv] = value;
+    }
+  }
+});
+
+describe("isInteractive", () => {
+  test("returns false when MINSKY_NON_INTERACTIVE=1", () => {
+    process.env.MINSKY_NON_INTERACTIVE = "1";
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("returns false when MINSKY_NON_INTERACTIVE=true", () => {
+    process.env.MINSKY_NON_INTERACTIVE = "true";
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("returns false when CI=true", () => {
+    process.env.CI = "true";
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("returns false when CI=1", () => {
+    process.env.CI = "1";
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("returns false when TERM=dumb", () => {
+    process.env.TERM = "dumb";
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("MINSKY_NON_INTERACTIVE takes precedence over CI being absent", () => {
+    process.env.MINSKY_NON_INTERACTIVE = "1";
+    // Even with no CI env var, MINSKY_NON_INTERACTIVE alone triggers non-interactive
+    expect(isInteractive()).toBe(false);
+  });
+
+  test("returns false when stdout is not a TTY (typical in test/CI environments)", () => {
+    // In test environments, stdout is not a TTY, so this should return false
+    // regardless of env vars (since isTTY check comes last)
+    if (!process.stdout.isTTY || !process.stdin.isTTY) {
+      expect(isInteractive()).toBe(false);
+    } else {
+      // In a real TTY environment with no env vars set, it returns true
+      expect(isInteractive()).toBe(true);
+    }
+  });
+});

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -1,0 +1,21 @@
+/**
+ * Determine if the current environment supports interactive prompts.
+ *
+ * Returns false in CI, when --non-interactive is set, or when stdin/stdout aren't TTYs.
+ * The MINSKY_NON_INTERACTIVE env var is set by the CLI when --non-interactive flag is used.
+ */
+export function isInteractive(): boolean {
+  if (process.env.MINSKY_NON_INTERACTIVE === "1" || process.env.MINSKY_NON_INTERACTIVE === "true") {
+    return false;
+  }
+  if (process.env.CI === "true" || process.env.CI === "1") {
+    return false;
+  }
+  if (process.env.TERM === "dumb") {
+    return false;
+  }
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- Adds `src/utils/interactive.ts` with an `isInteractive()` utility that returns `false` in CI (`CI=true/1`), when `MINSKY_NON_INTERACTIVE=1/true` is set, when `TERM=dumb`, or when `stdout`/`stdin` are not TTYs
- Adds a global `--non-interactive` CLI flag to `src/cli.ts` that sets `MINSKY_NON_INTERACTIVE=1` via a `preAction` hook so all downstream calls to `isInteractive()` pick it up
- Replaces all `process.stdout.isTTY` checks in `src/adapters/shared/commands/init.ts` (6 occurrences) with `isInteractive()` for consistent behaviour across all detection heuristics
- Replaces `process.stdout.isTTY` check in `src/adapters/shared/commands/tasks/status-commands.ts` with `isInteractive()`
- Adds `src/utils/interactive.test.ts` with 7 tests covering all detection paths

## Test plan

- [ ] `bun test src/utils/interactive.test.ts` — all 7 tests pass
- [ ] `bun run lint` — no errors
- [ ] `minsky init --non-interactive` without `--backend` errors with a helpful message instead of hanging
- [ ] `CI=true minsky init --backend json-file` runs without prompting