### PR TITLE
fix(mt#673): Align CredentialSource values between resolver and validator

### DIFF
--- a/src/domain/configuration/credential-resolver.test.ts
+++ b/src/domain/configuration/credential-resolver.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { DefaultCredentialResolver } from "./credential-resolver";
+import type { CredentialConfig } from "./credential-resolver";
+
+describe("DefaultCredentialResolver.resolveCredentialFromConfig", () => {
+  const resolver = new DefaultCredentialResolver();
+
+  describe('source: "env"', () => {
+    test("returns token when provided", async () => {
+      const config: CredentialConfig = { source: "env", token: "my-token" };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBe("my-token");
+    });
+
+    test("returns api_key when token is absent", async () => {
+      const config: CredentialConfig = { source: "env", api_key: "my-api-key" };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBe("my-api-key");
+    });
+
+    test("returns undefined when neither token nor api_key is set", async () => {
+      const config: CredentialConfig = { source: "env" };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('source: "file"', () => {
+    test("returns token when present (skips file lookup)", async () => {
+      const config: CredentialConfig = { source: "file", token: "direct-token" };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBe("direct-token");
+    });
+
+    test("returns undefined when token_file path does not exist", async () => {
+      const config: CredentialConfig = {
+        source: "file",
+        token_file: "/nonexistent/path/token.txt",
+      };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when no token, api_key, token_file, or api_key_file is set", async () => {
+      const config: CredentialConfig = { source: "file" };
+      const result = await resolver.resolveCredentialFromConfig(config);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('source: "keychain"', () => {
+    test("throws not-implemented error", async () => {
+      const config: CredentialConfig = { source: "keychain" };
+      await expect(resolver.resolveCredentialFromConfig(config)).rejects.toThrow(
+        "System keychain credential resolution not yet implemented"
+      );
+    });
+  });
+
+  describe('source: "manual"', () => {
+    test("throws not-implemented error", async () => {
+      const config: CredentialConfig = { source: "manual" };
+      await expect(resolver.resolveCredentialFromConfig(config)).rejects.toThrow(
+        "Interactive credential prompting not yet implemented"
+      );
+    });
+  });
+});

--- a/src/domain/configuration/credential-resolver.ts
+++ b/src/domain/configuration/credential-resolver.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
-export type CredentialSource = "environment" | "file" | "prompt";
+export type CredentialSource = "env" | "file" | "keychain" | "manual";
 
 export interface CredentialConfig {
   source: CredentialSource;
@@ -25,7 +25,9 @@ export interface CredentialConfig {
 function isCredentialConfig(
   obj: Record<string, unknown>
 ): obj is Record<string, unknown> & CredentialConfig {
-  return typeof obj.source === "string" && ["environment", "file", "prompt"].includes(obj.source);
+  return (
+    typeof obj.source === "string" && ["env", "file", "keychain", "manual"].includes(obj.source)
+  );
 }
 
 export interface CredentialResolver {
@@ -81,15 +83,16 @@ export class DefaultCredentialResolver implements CredentialResolver {
     credentialConfig: CredentialConfig
   ): Promise<string | undefined> {
     switch (credentialConfig.source) {
-      case "environment":
-        // New configuration system will have already resolved environment variables
+      case "env":
         return credentialConfig.token || credentialConfig.api_key;
 
       case "file":
         return this.resolveFileCredential(credentialConfig);
 
-      case "prompt":
-        // TODO: Implement interactive prompting
+      case "keychain":
+        throw new Error("System keychain credential resolution not yet implemented");
+
+      case "manual":
         throw new Error("Interactive credential prompting not yet implemented");
 
       default:

--- a/src/domain/configuration/schemas/base.ts
+++ b/src/domain/configuration/schemas/base.ts
@@ -163,8 +163,8 @@ export const schemaUtils = {
 /**
  * Credential configuration schema (used across multiple domains)
  */
-export const credentialSourceSchema = z.enum(["environment", "file", "prompt"], {
-  errorMap: () => ({ message: "Credential source must be one of: environment, file, prompt" }),
+export const credentialSourceSchema = z.enum(["env", "file", "keychain", "manual"], {
+  errorMap: () => ({ message: "Credential source must be one of: env, file, keychain, manual" }),
 });
 
 export const credentialConfigSchema = z

--- a/src/domain/configuration/schemas/github.ts
+++ b/src/domain/configuration/schemas/github.ts
@@ -88,8 +88,8 @@ export const githubValidation = {
   /**
    * Get the effective token source (for credential resolution)
    */
-  getTokenSource: (config: GitHubConfig): "environment" | "file" | "none" => {
-    if (config?.token) return "environment";
+  getTokenSource: (config: GitHubConfig): "env" | "file" | "none" => {
+    if (config?.token) return "env";
     if (config?.tokenFile) return "file";
     return "none";
   },

--- a/src/domain/configuration/types.ts
+++ b/src/domain/configuration/types.ts
@@ -197,7 +197,7 @@ export interface ValidationWarning {
 
 // Service Interfaces
 
-export type CredentialSource = "environment" | "file" | "prompt";
+export type CredentialSource = "env" | "file" | "keychain" | "manual";
 
 // ConfigurationService interface removed - use direct config.get() instead
 // For validation, use the functions from config-schemas.ts


### PR DESCRIPTION
## Summary
- `CredentialSource` type changed from `"environment" | "file" | "prompt"` to `"env" | "file" | "keychain" | "manual"` to match what `config-validator.ts` accepts
- Updated `isCredentialConfig()` guard, `resolveCredentialFromConfig()` switch cases, `credentialSourceSchema` Zod enum, `getTokenSource()` return type
- `keychain` and `manual` throw explicit not-implemented errors (better than silent fallthrough)
- Added 8 tests covering all four source values

Previously, `source: "env"` would pass validation but silently fall through the resolver's switch. Now the two layers are consistent.

## Test plan
- [x] 8 new tests in `credential-resolver.test.ts` all pass
- [x] TypeScript compiles cleanly
- [x] All pre-commit checks pass (lint, format, security, tests)