### PR TITLE
feat(mt#592): add session_diff and session_status MCP tools

### DIFF
--- a/src/adapters/mcp/session-workspace.ts
+++ b/src/adapters/mcp/session-workspace.ts
@@ -11,7 +11,6 @@ import { SessionPathResolver } from "../../domain/session/session-path-resolver"
 import { getErrorMessage } from "../../errors/index";
 import {
   FileReadSchema,
-  BaseFileOperationSchema,
   FileWriteSchema,
   DirectoryListSchema,
   FileExistsSchema,
@@ -682,14 +681,13 @@ export function registerSessionWorkspaceTools(commandMapper: CommandMapper): voi
           outputLength: output.length,
         });
 
-        return {
-          success: true,
+        return createSuccessResponse({
           session: typedArgs.sessionId,
           diff: output,
           staged: typedArgs.staged ?? false,
-          ...(typedArgs.path && { path: typedArgs.path }),
           isEmpty: output.trim().length === 0,
-        };
+          ...(typedArgs.path && { path: typedArgs.path }),
+        });
       } catch (error) {
         const errorMessage = getErrorMessage(error);
         log.error("Session diff failed", {
@@ -770,15 +768,14 @@ export function registerSessionWorkspaceTools(commandMapper: CommandMapper): voi
           untrackedCount: untracked.length,
         });
 
-        return {
-          success: true,
+        return createSuccessResponse({
           session: typedArgs.sessionId,
-          status: output,
           staged,
           unstaged,
           untracked,
-          clean: lines.length === 0,
-        };
+          clean: staged.length === 0 && unstaged.length === 0 && untracked.length === 0,
+          raw: output,
+        });
       } catch (error) {
         const errorMessage = getErrorMessage(error);
         log.error("Session status failed", {


### PR DESCRIPTION
## Summary

- Adds `session.diff` MCP tool: shows git diff for a session workspace (unstaged by default, staged with `staged=true`, optional path filter)
- Adds `session.status` MCP tool: shows structured git status (staged, unstaged, untracked arrays, clean flag, raw output)
- Adds `tests/adapters/mcp/session-diff-status-tools.test.ts` with registration/schema tests

## Coherence Verification

**Files re-read**: `src/adapters/mcp/session-workspace.ts`, `tests/adapters/mcp/session-diff-status-tools.test.ts`

**Q1 single purpose**: pass — file remains a single MCP workspace tools adapter

**Q2 comment honesty**: pass — all comments accurately describe the tools they document

**Q3 naming honesty**: pass — `session.diff` and `session.status` clearly describe what they do; local schemas `SessionDiffSchema`/`SessionStatusSchema` are scoped inside the function and do not conflict with the exported domain `SessionStatusSchema` (different schema, different scope)

**Q4 redundant siblings**: pass — no duplicate tools or files

**Q5 dead exports**: pass — no new exports added; verified `BaseFileOperationSchema` was imported but unused (dead import removed in cleanup commit). `createSuccessResponse` and `createErrorResponse` are both now used by the handlers.

**Q6 orphan code**: pass — no orphan code; cleanup removed dead `BaseFileOperationSchema` import

**Q7 stray artifacts**: pass — no backup or temp files

**Items fixed in this PR (beyond original scope)**:
- Replaced inline `{ success: true, ... }` return objects in `session.diff` and `session.status` with `createSuccessResponse(...)` for consistency with all other handlers in the file
- Fixed `session.status` `clean` flag to use parsed array lengths instead of raw line count (more accurate when lines have whitespace)
- Added `raw` output field to `session.status` response per task spec
- Removed dead `BaseFileOperationSchema` import that was not used anywhere in the file

**Items deferred**: none

Note: Had Claude Code implement this task.

## Test plan
- [ ] `bun test tests/adapters/mcp/session-diff-status-tools.test.ts` — all tool registration tests pass
- [ ] `bun run lint` — no lint errors
- [ ] Verify `session.diff` is registered with `sessionId`, optional `path`, optional `staged` params
- [ ] Verify `session.status` is registered with `sessionId` param