### PR TITLE
refactor(mt#605): eliminate [0]! patterns with type-safe array utilities

### DIFF
--- a/src/adapters/shared/commands/rules.test.ts
+++ b/src/adapters/shared/commands/rules.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, test, expect } from "bun:test";
 import { mock } from "bun:test";
 import { createSharedCommandRegistry } from "../command-registry";
 import { registerRulesCommands, type RulesCommandsDeps } from "./rules";
+import { first, elementAt } from "../../../utils/array-safety";
 
 /** Shape returned by rules.generate command */
 interface RulesGenerateResult {
@@ -81,7 +82,7 @@ describe("Rules Commands", () => {
         expect(result.rules).toHaveLength(1);
         expect(result.generated).toBe(1);
         expect(result.errors).toHaveLength(0);
-        expect(result.rules[0]!.id).toBe("test-rule");
+        expect(first(result.rules).id).toBe("test-rule");
       }
     });
 
@@ -288,13 +289,15 @@ describe("Rules Commands", () => {
         }
 
         // Verify specific rule properties are preserved
-        expect(result.rules[0]!.id).toBe("test-rule-1");
-        expect(result.rules[0]!.name).toBe("Test Rule 1");
-        expect(result.rules[0]!.tags).toEqual(["test"]);
-        expect(result.rules[0]!.globs).toEqual(["*.ts"]);
+        const firstRule = first(result.rules);
+        expect(firstRule.id).toBe("test-rule-1");
+        expect(firstRule.name).toBe("Test Rule 1");
+        expect(firstRule.tags).toEqual(["test"]);
+        expect(firstRule.globs).toEqual(["*.ts"]);
 
-        expect(result.rules[1]!.id).toBe("test-rule-2");
-        expect(result.rules[1]!.name).toBe("Test Rule 2");
+        const secondRule = elementAt(result.rules, 1);
+        expect(secondRule.id).toBe("test-rule-2");
+        expect(secondRule.name).toBe("Test Rule 2");
       }
     });
 

--- a/src/commands/context/generate-comparison.ts
+++ b/src/commands/context/generate-comparison.ts
@@ -13,6 +13,7 @@ import type {
   ComponentBreakdown,
 } from "./generate-types";
 import { generateContext, getDefaultComponents } from "./generate-core";
+import { first } from "../../utils/array-safety";
 import { analyzeGeneratedContext } from "./generate-analysis";
 import { displayContextVisualization } from "./generate-visualization";
 
@@ -110,8 +111,9 @@ export async function displayModelComparison(models: string[], options: Generate
     });
 
     if (options.visualize && comparisons.length > 0) {
-      log.cli(`\n📊 Visualization for ${comparisons[0]!.model}`);
-      displayContextVisualization(comparisons[0]!.result, options);
+      const firstComparison = first(comparisons, "comparisons");
+      log.cli(`\n📊 Visualization for ${firstComparison.model}`);
+      displayContextVisualization(firstComparison.result, options);
     }
   }
 }

--- a/src/commands/context/suggest-rules.integration.test.ts
+++ b/src/commands/context/suggest-rules.integration.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeAll, mock } from "bun:test";
 import { DefaultRuleSuggestionService } from "../../domain/context/rule-suggestion";
 import type { RuleSuggestionRequest } from "../../domain/context/types";
 import type { Rule } from "../../domain/rules/types";
+import { first, elementAt } from "../../utils/array-safety";
 import { RULES_TEST_PATTERNS } from "../../utils/test-utils/test-constants";
 
 describe("suggest-rules service integration", () => {
@@ -136,9 +137,10 @@ describe("suggest-rules service integration", () => {
     // Verify response structure
     expect(response.suggestions).toBeArray();
     expect(response.suggestions.length).toBe(1);
-    expect(response.suggestions[0]!.ruleId).toBe("test-driven-bugfix");
-    expect(response.suggestions[0]!.relevanceScore).toBe(0.9);
-    expect(response.suggestions[0]!.confidenceLevel).toBe("high");
+    const firstSuggestion = first(response.suggestions);
+    expect(firstSuggestion.ruleId).toBe("test-driven-bugfix");
+    expect(firstSuggestion.relevanceScore).toBe(0.9);
+    expect(firstSuggestion.confidenceLevel).toBe("high");
     expect(response.queryAnalysis.intent).toContain("bug");
     expect(response.totalRulesAnalyzed).toBe(3);
   });
@@ -153,8 +155,9 @@ describe("suggest-rules service integration", () => {
 
     expect(response.suggestions).toBeArray();
     expect(response.suggestions.length).toBe(1);
-    expect(response.suggestions[0]!.ruleId).toBe(RULES_TEST_PATTERNS.DOMAIN_ORIENTED_MODULES);
-    expect(response.suggestions[0]!.relevanceScore).toBe(0.8);
+    const firstSuggestion = first(response.suggestions);
+    expect(firstSuggestion.ruleId).toBe(RULES_TEST_PATTERNS.DOMAIN_ORIENTED_MODULES);
+    expect(firstSuggestion.relevanceScore).toBe(0.8);
     expect(response.queryAnalysis.intent).toContain("modules");
   });
 
@@ -237,8 +240,8 @@ describe("suggest-rules service integration", () => {
     const response = await limitedService.suggestRules(request);
 
     expect(response.suggestions).toHaveLength(2); // Limited to 2
-    expect(response.suggestions[0]!.relevanceScore).toBeGreaterThan(
-      response.suggestions[1]!.relevanceScore
+    expect(first(response.suggestions).relevanceScore).toBeGreaterThan(
+      elementAt(response.suggestions, 1).relevanceScore
     ); // Sorted by relevance
   });
 

--- a/src/commands/context/suggest-rules.ts
+++ b/src/commands/context/suggest-rules.ts
@@ -13,6 +13,7 @@ import { log } from "../../utils/logger";
 import { exit } from "../../utils/process";
 import fs from "fs/promises";
 import { RuleSimilarityService } from "../../domain/rules/rule-similarity-service";
+import { first } from "../../utils/array-safety";
 
 interface SuggestRulesOptions {
   json?: boolean;
@@ -260,7 +261,7 @@ function outputHumanReadableResults(
   // Usage hints
   if (response.suggestions.length > 0) {
     log.debug(`💡 To use a rule: Add it to your Cursor Rules or check its content with:`);
-    log.debug(`   minsky rules get ${response.suggestions[0]!.ruleId}`);
+    log.debug(`   minsky rules get ${first(response.suggestions, "suggestions").ruleId}`);
   }
 }
 

--- a/src/domain/ai/edit-pattern-service.ts
+++ b/src/domain/ai/edit-pattern-service.ts
@@ -11,6 +11,7 @@ import { EnhancedAICompletionService } from "./enhanced-completion-service";
 import { DefaultAICompletionService } from "./completion-service";
 import { IntelligentRetryService } from "./intelligent-retry-service";
 import { RateLimitError, AuthenticationError, ServerError } from "./enhanced-error-types";
+import { first } from "../../utils/array-safety";
 import {
   analyzeEditPattern,
   createMorphCompletionParams,
@@ -66,7 +67,7 @@ export async function applyEditPattern(
 
   if (fastApplyProviders.length > 0) {
     // Use fast-apply provider
-    provider = fastApplyProviders[0]!;
+    provider = first(fastApplyProviders, "fast-apply providers");
     model = provider === "morph" ? "morph-v3-large" : undefined;
     isFastApply = true;
     log.debug(`Using fast-apply provider: ${provider}`);

--- a/src/domain/ai/tokenization/registry.ts
+++ b/src/domain/ai/tokenization/registry.ts
@@ -9,6 +9,7 @@ import type { LocalTokenizer, TokenizerRegistry, TokenizerConfig } from "./types
 import { GptTokenizer } from "./gpt-tokenizer";
 import { TiktokenTokenizer } from "./tiktoken-tokenizer";
 import { log } from "../../../utils/logger";
+import { first } from "../../../utils/array-safety";
 
 /**
  * Default tokenizer registry implementation
@@ -92,7 +93,7 @@ export class DefaultTokenizerRegistry implements TokenizerRegistry {
       );
 
     if (candidates.length > 0) {
-      const selected = candidates[0]!;
+      const selected = first(candidates, "tokenizer candidates");
       log.debug(`Selected tokenizer for ${modelId}: ${selected.id}`);
       return selected;
     }

--- a/src/domain/changeset/adapters/local-git-adapter.ts
+++ b/src/domain/changeset/adapters/local-git-adapter.ts
@@ -32,6 +32,7 @@ import {
 import { MinskyError, getErrorMessage } from "../../../errors/index";
 import { log } from "../../../utils/logger";
 import { execSync as defaultExecSync } from "child_process";
+import { first } from "../../../utils/array-safety";
 
 /**
  * Dependencies for LocalGitChangesetAdapter (injectable for testing)
@@ -422,8 +423,10 @@ export class LocalGitChangesetAdapter implements ChangesetAdapter {
       }
 
       // Get creation date from first commit
-      const createdAt = commits.length > 0 ? commits[commits.length - 1]!.timestamp : new Date();
-      const updatedAt = commits.length > 0 ? commits[0]!.timestamp : new Date();
+      const lastCommit = commits.length > 0 ? commits[commits.length - 1] : undefined;
+      const createdAt = lastCommit ? lastCommit.timestamp : new Date();
+      const updatedAt =
+        commits.length > 0 ? first(commits, "changeset commits").timestamp : new Date();
 
       return {
         id: prBranch,

--- a/src/domain/configuration/config-writer.test.ts
+++ b/src/domain/configuration/config-writer.test.ts
@@ -8,6 +8,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { ConfigWriter, createConfigWriter } from "./config-writer";
 import type { SyncFs } from "./config-writer";
 import matter from "gray-matter";
+import { first } from "../../utils/array-safety";
 import { createMockFilesystem } from "../../utils/test-utils/filesystem/mock-filesystem";
 import { CONFIG_TEST_PATTERNS } from "../../utils/test-utils/test-constants";
 import { log } from "../../utils/logger";
@@ -69,7 +70,7 @@ describe("ConfigWriter", () => {
 
       // Should create backup with timestamp
       expect(mockFs.copyFileSync).toHaveBeenCalled();
-      const copyCall = mockFs.copyFileSync.mock.calls[0]!;
+      const copyCall = first(mockFs.copyFileSync.mock.calls as unknown[][]);
       expect(copyCall[0]).toBe(mockConfigFile);
       expect(copyCall[1]).toMatch(/config\.yaml\.backup\./);
       expect(result.success).toBe(true);
@@ -87,7 +88,7 @@ describe("ConfigWriter", () => {
 
       // Should have written the nested structure
       expect(mockFs.writeFileSync).toHaveBeenCalled();
-      const writeCall = mockFs.writeFileSync.mock.calls[0]!;
+      const writeCall = first(mockFs.writeFileSync.mock.calls as unknown[][]);
       expect(writeCall[0]).toBe(mockConfigFile);
     });
 

--- a/src/domain/configuration/schemas/ai.ts
+++ b/src/domain/configuration/schemas/ai.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 import { baseSchemas, enumSchemas } from "./base";
 import { log } from "../../../utils/logger";
+import { first } from "../../../utils/array-safety";
 
 /**
  * Detect unknown fields in an object and log warnings
@@ -243,7 +244,7 @@ export const aiValidation = {
 
     // Fall back to first ready provider
     const readyProviders = aiValidation.getReadyProviders(config);
-    return readyProviders.length > 0 ? readyProviders[0]! : null;
+    return readyProviders.length > 0 ? first(readyProviders, "ready AI providers") : null;
   },
 
   /**

--- a/src/domain/configuration/sources/environment.ts
+++ b/src/domain/configuration/sources/environment.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PartialConfiguration } from "../schemas";
+import { elementAt } from "../../../utils/array-safety";
 
 /**
  * Environment variable to configuration path mappings
@@ -167,7 +168,7 @@ function envVarToConfigPath(envVar: string): string | null {
   // Handle known patterns
   if (parts[0] === "ai" && parts[1] === "providers" && parts.length >= 3) {
     // AI_PROVIDERS_OPENAI_API_KEY -> ai.providers.openai.apiKey
-    const provider = parts[2]!;
+    const provider = elementAt(parts, 2, "env var AI provider part");
     const field = parts.slice(3).join("_");
     return `ai.providers.${provider}.${camelCase(field)}`;
   }
@@ -176,9 +177,9 @@ function envVarToConfigPath(envVar: string): string | null {
     // SESSIONDB_BACKEND -> sessiondb.backend
     // SESSIONDB_SQLITE_PATH -> sessiondb.sqlite.path
     if (parts.length === 2) {
-      return `sessiondb.${camelCase(parts[1]!)}`;
+      return `sessiondb.${camelCase(elementAt(parts, 1, "sessiondb field"))}`;
     } else if (parts.length === 3) {
-      return `sessiondb.${parts[1]}.${camelCase(parts[2]!)}`;
+      return `sessiondb.${parts[1]}.${camelCase(elementAt(parts, 2, "sessiondb subfield"))}`;
     }
   }
 

--- a/src/domain/persistence/providers/postgres-provider.test.ts
+++ b/src/domain/persistence/providers/postgres-provider.test.ts
@@ -6,11 +6,12 @@ import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { PostgresPersistenceProvider } from "./postgres-provider";
 import { PostgresStorage } from "../../storage/backends/postgres-storage";
 import type { PersistenceConfig } from "../../../domain/configuration/types";
+import { first } from "../../../utils/array-safety";
 
 // Mock SQL client — injected via initialize()
 const mockSqlFunction = mock((strings: TemplateStringsArray, ...values: any[]) => {
   // Handle pgvector extension check specifically
-  const queryString = strings[0]!;
+  const queryString = first(strings as unknown as string[], "SQL template strings");
   if (queryString.includes("pg_extension") && queryString.includes("vector")) {
     return Promise.resolve([{ exists: true }]); // Mock pgvector as available
   }

--- a/src/domain/rules.test.ts
+++ b/src/domain/rules.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import matter from "gray-matter";
 import { createMockFilesystem } from "../utils/test-utils/filesystem/mock-filesystem";
 import { RULES_TEST_PATTERNS } from "../utils/test-utils/test-constants";
+import { first } from "../utils/array-safety";
 
 // No global module mocks. Each test creates its own mock filesystem and injects it
 
@@ -94,8 +95,9 @@ describe("RuleService", () => {
       const rules = await ruleService.listRules({ format: "cursor" });
 
       expect(rules.length).toBe(1);
-      expect(rules[0]!.id).toBe("test-cursor");
-      expect(rules[0]!.format).toBe("cursor");
+      const firstRule = first(rules);
+      expect(firstRule.id).toBe("test-cursor");
+      expect(firstRule.format).toBe("cursor");
     });
 
     test("lists only generic rules when format is generic", async () => {
@@ -115,8 +117,9 @@ describe("RuleService", () => {
       const rules = await ruleService.listRules({ format: "generic" });
 
       expect(rules.length).toBe(1);
-      expect(rules[0]!.id).toBe("test-generic");
-      expect(rules[0]!.format).toBe("generic");
+      const firstRule = first(rules);
+      expect(firstRule.id).toBe("test-generic");
+      expect(firstRule.format).toBe("generic");
     });
   });
 

--- a/src/domain/rules/compile/targets/cursor-rules.test.ts
+++ b/src/domain/rules/compile/targets/cursor-rules.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { cursorRulesTarget, buildCursorRulesContent, serializeRuleToMdc } from "./cursor-rules";
 import type { Rule } from "../../types";
 import { SOME_RULE_CONTENT } from "./test-fixtures";
+import { first } from "../../../../utils/array-safety";
 
 // Helper to create a minimal Rule object
 function makeRule(id: string, content: string, opts: Partial<Rule> = {}): Rule {
@@ -137,15 +138,16 @@ describe("cursor-rules target", () => {
     it("each file path is in the output directory with .mdc extension", () => {
       const rules = [makeRule("my-rule", "Content")];
       const { files } = buildCursorRulesContent(rules, "/output/dir");
-      expect(files[0]!.path).toBe("/output/dir/my-rule.mdc");
+      expect(first(files).path).toBe("/output/dir/my-rule.mdc");
     });
 
     it("file content is the serialized .mdc for the rule", () => {
       const rules = [makeRule("test-rule", "Rule body text", { name: "Test Rule" })];
       const { files } = buildCursorRulesContent(rules, "/output");
-      expect(files[0]!.content).toContain("name:");
-      expect(files[0]!.content).toContain("Test Rule");
-      expect(files[0]!.content).toContain("Rule body text");
+      const file = first(files);
+      expect(file.content).toContain("name:");
+      expect(file.content).toContain("Test Rule");
+      expect(file.content).toContain("Rule body text");
     });
 
     it("all rules are included in rulesIncluded", () => {
@@ -171,8 +173,9 @@ describe("cursor-rules target", () => {
     it("uses the rule id as the filename (not the path or name)", () => {
       const rule = makeRule("my-rule-id", "Content", { name: "Some Other Name" });
       const { files } = buildCursorRulesContent([rule], "/output");
-      expect(files[0]!.path).toContain("my-rule-id.mdc");
-      expect(files[0]!.path).not.toContain("Some Other Name");
+      const file = first(files);
+      expect(file.path).toContain("my-rule-id.mdc");
+      expect(file.path).not.toContain("Some Other Name");
     });
   });
 });

--- a/src/domain/rules/enforcement-mapping.test.ts
+++ b/src/domain/rules/enforcement-mapping.test.ts
@@ -5,6 +5,7 @@ import {
   getEnforcedRules,
   getUnenforced,
 } from "./enforcement-mapping";
+import { first } from "../../utils/array-safety";
 
 const TEMPLATE_LITERALS_RULE_ID = "template-literals";
 
@@ -24,7 +25,7 @@ describe("getEnforcement", () => {
   it("returned mapping contains well-formed mechanisms", () => {
     const result = getEnforcement(TEMPLATE_LITERALS_RULE_ID);
     expect(result).toBeDefined();
-    const mechanism = result!.mechanisms[0]!;
+    const mechanism = first(result!.mechanisms);
     expect(mechanism.type).toBe("eslint");
     expect(typeof mechanism.name).toBe("string");
     expect(mechanism.name.length).toBeGreaterThan(0);

--- a/src/domain/rules/rule-suggestion-enhanced.test.ts
+++ b/src/domain/rules/rule-suggestion-enhanced.test.ts
@@ -4,6 +4,7 @@ import { RuleType } from "./rule-classifier";
 
 // TODO: This enhanced suggest function should be implemented
 import { suggestRules, type RuleSuggestOptions } from "./rule-suggestion-enhanced";
+import { first } from "../../utils/array-safety";
 
 // Test constants to avoid magic string duplication
 const AGENT_RULE_REACT = "agent-rule-react";
@@ -84,7 +85,7 @@ describe("Enhanced Rule Suggestion with Type Awareness", () => {
 
       const alwaysRules = suggestions.filter((r) => r.id === "always-rule-1");
       expect(alwaysRules).toHaveLength(1);
-      expect(alwaysRules[0]!.id).toBe("always-rule-1");
+      expect(first(alwaysRules).id).toBe("always-rule-1");
     });
 
     it("should include AUTO_ATTACHED rules when files match globs", async () => {
@@ -272,7 +273,7 @@ describe("Enhanced Rule Suggestion with Type Awareness", () => {
 
       // Should only have always-apply rules
       expect(suggestions).toHaveLength(1);
-      expect(suggestions[0]!.id).toBe("always-rule-1");
+      expect(first(suggestions).id).toBe("always-rule-1");
     });
 
     it("should handle similarity service errors gracefully", async () => {

--- a/src/domain/rules/rule-template-service.test.ts
+++ b/src/domain/rules/rule-template-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { log } from "../../utils/logger";
 import path from "path";
+import { first } from "../../utils/array-safety";
 import {
   RuleTemplateService,
   createRuleTemplateService,
@@ -221,8 +222,8 @@ describe("RuleTemplateService", () => {
       }
       expect(result.success).toBe(true);
       expect(result.rules).toHaveLength(1);
-      expect(result.rules[0]!.id).toBe("cli-rule");
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
+      expect(first(result.rules).id).toBe("cli-rule");
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
     });
 
     test("generates rule with MCP configuration", async () => {
@@ -245,7 +246,7 @@ describe("RuleTemplateService", () => {
 
       expect(result.success).toBe(true);
       expect(result.rules).toHaveLength(1);
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
     });
 
     test("generates rule with hybrid configuration preferring CLI", async () => {
@@ -268,7 +269,7 @@ describe("RuleTemplateService", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
     });
 
     test("generates rule with hybrid configuration preferring MCP", async () => {
@@ -291,7 +292,7 @@ describe("RuleTemplateService", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
     });
   });
 
@@ -418,7 +419,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
         log.error("Helper test failed:", { errors: cliResult.errors });
       }
       expect(cliResult.success).toBe(true);
-      const cliContent = cliResult.rules[0]!.content;
+      const cliContent = first(cliResult.rules).content;
       expect(cliContent).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
       expect(cliContent).toContain(CLI_COMMANDS.MINSKY_SESSION_START_TASK);
       expect(cliContent).toContain("check task status");
@@ -434,7 +435,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
       });
 
       expect(mcpResult.success).toBe(true);
-      const mcpContent = mcpResult.rules[0]!.content;
+      const mcpContent = first(mcpResult.rules).content;
       expect(mcpContent).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
       expect(mcpContent).toContain(CLI_COMMANDS.MINSKY_SESSION_START_TASK);
       expect(mcpContent).toContain("mcp_minsky-server_tasks_status_get");
@@ -508,7 +509,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
 
       expect(result.success).toBe(true);
       expect(result.config!.interface).toBe("cli");
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
     });
 
     test("generateMcpRules uses MCP configuration", async () => {
@@ -528,7 +529,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
 
       expect(result.success).toBe(true);
       expect(result.config!.interface).toBe("mcp");
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MCP_MINSKY_TASKS_LIST);
     });
 
     test("generateHybridRules uses hybrid configuration", async () => {
@@ -549,7 +550,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
       expect(result.success).toBe(true);
       expect(result.config!.interface).toBe("hybrid");
       // Should prefer CLI by default (preferMcp: false)
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
     });
   });
 
@@ -578,7 +579,7 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
       }
       expect(result.success).toBe(true);
       expect(result.rules).toHaveLength(1);
-      expect(result.rules[0]!.id).toBe("minsky-workflow");
+      expect(first(result.rules).id).toBe("minsky-workflow");
       expect(result.config).toEqual(DEFAULT_CLI_CONFIG);
     });
   });
@@ -601,9 +602,9 @@ ${helpers.conditionalSection(context.config.interface === "mcp", CODE_TEST_PATTE
       }
       expect(result.success).toBe(true);
       expect(result.rules).toHaveLength(1);
-      expect(result.rules[0]!.id).toBe("test-template");
-      expect(result.rules[0]!.content).toContain("# Test Rule");
-      expect(result.rules[0]!.content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
+      expect(first(result.rules).id).toBe("test-template");
+      expect(first(result.rules).content).toContain("# Test Rule");
+      expect(first(result.rules).content).toContain(CLI_COMMANDS.MINSKY_TASKS_LIST);
 
       // Verify that dryRun: false was respected (files would be created in real scenario)
       expect(result.config!.interface).toBe("cli");

--- a/src/domain/session-git-clone-bug-regression.test.ts
+++ b/src/domain/session-git-clone-bug-regression.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, mock } from "bun:test";
+import { first } from "../utils/array-safety";
 import { startSessionFromParams } from "./session";
 import { TEST_PATHS } from "../utils/test-utils/test-constants";
 import { FakeSessionProvider } from "./session/fake-session-provider";
@@ -161,7 +162,7 @@ describe("Session Git Clone Bug Regression Test", () => {
       })
     );
     // Verify the session ID in the record is a UUID
-    const addedRecord = (addSessionSpy.mock.calls as unknown[][])[0]![0] as any;
+    const addedRecord = first(addSessionSpy.mock.calls as unknown[][])[0] as any;
     expect(addedRecord.session).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );

--- a/src/domain/session/commands/pr-get-subcommand.ts
+++ b/src/domain/session/commands/pr-get-subcommand.ts
@@ -12,6 +12,7 @@ import {
   getErrorMessage,
 } from "../../../errors/index";
 import { log } from "../../../utils/logger";
+import { first } from "../../../utils/array-safety";
 
 /**
  * Shape of the live PR data returned from GitHub Octokit pulls.get / pulls.list responses.
@@ -149,7 +150,8 @@ export async function sessionPrGet(
 
         if (pulls.length > 0) {
           // Found a PR! Repair the session record with essential workflow state only
-          const githubPr = pulls[0]!; // Non-null assertion safe because we checked length > 0
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const githubPr: any = first(pulls, "GitHub PRs for branch");
           const repairedPrData: PullRequestInfo = {
             number: githubPr.number,
             url: githubPr.html_url,

--- a/src/domain/session/migration-command.test.ts
+++ b/src/domain/session/migration-command.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import type { SessionProviderInterface, SessionRecord } from "./types";
 import { SessionMigrationService, type SessionMigrationOptions } from "./migration-command";
 import { isUuidSessionId } from "../tasks/task-id";
+import { first, elementAt } from "../../utils/array-safety";
 
 // Mock session data for testing
 const createMockSessionData = () => {
@@ -150,13 +151,13 @@ describe("Session Migration Command", () => {
 
       it("should show detailed changes for each session", async () => {
         const mockData = createMockSessionData();
-        const sessionDB = createMockSessionDB([mockData.legacy[0]!]); // Just one legacy session
+        const sessionDB = createMockSessionDB([first(mockData.legacy)]); // Just one legacy session
         const migrationService = new SessionMigrationService(sessionDB);
 
         const report = await migrationService.preview();
 
         expect(report.results).toHaveLength(1);
-        const result = report.results[0]!;
+        const result = first(report.results);
 
         // Ensure result exists before checking properties
         expect(result).toBeDefined();
@@ -275,7 +276,7 @@ describe("Session Migration Command", () => {
 
         // Should only process the session that would become 'md' backend
         expect(report.results).toHaveLength(1);
-        expect(report.results[0]!.original.session).toBe("task123");
+        expect(first(report.results).original.session).toBe("task123");
       });
 
       it("should filter by date", async () => {
@@ -305,7 +306,7 @@ describe("Session Migration Command", () => {
 
         // Should only process sessions created before the cutoff
         expect(report.results).toHaveLength(1);
-        expect(report.results[0]!.original.session).toBe("task123");
+        expect(first(report.results).original.session).toBe("task123");
       });
 
       it("should filter by session ID pattern", async () => {
@@ -348,8 +349,8 @@ describe("Session Migration Command", () => {
         const report = await migrationService.migrate({ backup: false });
 
         expect(report.progress.failed).toBe(1);
-        expect(report.results[0]!.success).toBe(false);
-        expect(report.results[0]!.error).toBe("Migration failed");
+        expect(first(report.results).success).toBe(false);
+        expect(first(report.results).error).toBe("Migration failed");
       });
 
       it("should handle database update failures", async () => {

--- a/src/domain/session/session-db-adapter.test.ts
+++ b/src/domain/session/session-db-adapter.test.ts
@@ -4,6 +4,7 @@
  * Uses dependency injection instead of mock.module().
  */
 import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { first } from "../../utils/array-safety";
 import {
   createSessionProvider,
   SessionDbAdapter,
@@ -101,7 +102,7 @@ describe("createSessionProvider", () => {
     // Verify it calls the persistence layer
     expect(mockStorage.readState).toHaveBeenCalledTimes(1);
     expect(sessions).toHaveLength(2);
-    expect(sessions[0]!.session).toBe("test-session-1");
+    expect(first(sessions).session).toBe("test-session-1");
   });
 
   test("SessionDbAdapter.getSessionByTaskId() filters correctly", async () => {

--- a/src/domain/session/session-db.test.ts
+++ b/src/domain/session/session-db.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { SESSION_TEST_PATTERNS, PATH_TEST_PATTERNS } from "../../utils/test-utils/test-constants";
+import { first, elementAt } from "../../utils/array-safety";
 import {
   addSessionFn,
   deleteSessionFn,
@@ -106,8 +107,8 @@ describe("SessionDB Functional Implementation", () => {
       const state = createTestState();
       const sessions = listSessionsFn(state);
       expect(sessions).toHaveLength(2);
-      expect(sessions[0]!.session).toBe("test-session-1");
-      expect(sessions[1]!.session).toBe("test-session-2");
+      expect(first(sessions).session).toBe("test-session-1");
+      expect(elementAt(sessions, 1).session).toBe("test-session-2");
     });
   });
 
@@ -163,8 +164,9 @@ describe("SessionDB Functional Implementation", () => {
 
       const newState = addSessionFn(state, newSession);
       expect(newState.sessions).toHaveLength(3);
-      expect(newState.sessions[2]!.session).toBe("test-session-3");
-      expect(newState.sessions[2]!.taskId).toBe("103");
+      const thirdSession = elementAt(newState.sessions, 2);
+      expect(thirdSession.session).toBe("test-session-3");
+      expect(thirdSession.taskId).toBe("103");
     });
   });
 
@@ -212,7 +214,7 @@ describe("SessionDB Functional Implementation", () => {
       expect(newState.sessions).toHaveLength(1);
       expect(getSessionFn(newState, "test-session-1")).toBeNull();
       // Check that only test-session-2 remains
-      expect(newState.sessions[0]!.session).toBe("test-session-2");
+      expect(first(newState.sessions).session).toBe("test-session-2");
     });
 
     it("should not modify state if session not found", () => {

--- a/src/domain/session/session-start-operations.test.ts
+++ b/src/domain/session/session-start-operations.test.ts
@@ -7,6 +7,7 @@ import { FakeSessionProvider } from "./fake-session-provider";
 import { FakeGitService } from "../git/fake-git-service";
 import { FakeTaskService } from "../tasks/fake-task-service";
 import { FakeWorkspaceUtils } from "../workspace/fake-workspace-utils";
+import { first } from "../../utils/array-safety";
 
 function createDeps(repoUrl: string): StartSessionDependencies & {
   addSessionSpy: ReturnType<typeof mock>;
@@ -58,7 +59,7 @@ describe("startSessionImpl - backendType", () => {
     const deps = createDeps("https://github.com/owner/repo.git");
     const params = { task: "md#999" } as unknown as SessionStartParameters;
     await startSessionImpl(params, deps);
-    const added = deps.addSessionSpy.mock.calls[0]![0] as SessionRecord;
+    const added = first(deps.addSessionSpy.mock.calls as unknown[][])[0] as SessionRecord;
     expect(added.backendType).toBe("github");
   });
 
@@ -66,7 +67,7 @@ describe("startSessionImpl - backendType", () => {
     const deps = createDeps("/Users/test/Projects/repo");
     const params = { task: "md#999" } as unknown as SessionStartParameters;
     await startSessionImpl(params, deps);
-    const added = deps.addSessionSpy.mock.calls[0]![0] as SessionRecord;
+    const added = first(deps.addSessionSpy.mock.calls as unknown[][])[0] as SessionRecord;
     expect(added.backendType).toBe("local");
   });
 });

--- a/src/domain/session/session-task-association.test.ts
+++ b/src/domain/session/session-task-association.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { first, elementAt } from "../../utils/array-safety";
 import {
   updateSessionTaskAssociation,
   findSessionsByTaskId,
@@ -48,8 +49,8 @@ describe("Session Task Association", () => {
     // Make updateSession a spy so tests can assert on calls
     mockProvider.updateSession = mock(() => Promise.resolve());
     // Reset the mock sessions to original state
-    mockSessions[0]!.taskId = "123";
-    mockSessions[1]!.taskId = "456";
+    first(mockSessions).taskId = "123";
+    elementAt(mockSessions, 1).taskId = "456";
   });
 
   describe("updateSessionTaskAssociation", () => {

--- a/src/domain/similarity/task-similarity-service.core.test.ts
+++ b/src/domain/similarity/task-similarity-service.core.test.ts
@@ -3,6 +3,7 @@ import { TaskSimilarityService } from "../tasks/task-similarity-service";
 import type { EmbeddingService } from "../ai/embeddings/types";
 import type { VectorStorage } from "../storage/vector/types";
 import { EmbeddingsSimilarityBackend } from "./backends/embeddings-backend";
+import { first } from "../../utils/array-safety";
 
 // Repoint task similarity to generic core by disabling embeddings backend and exercising lexical backend
 
@@ -58,7 +59,7 @@ describe("TaskSimilarityService → SimilaritySearchService (lexical fallback)",
   it("searchByText returns top-k ordered by lexical similarity", async () => {
     const results = await service.searchByText("refactor modules and organization", 2);
     expect(results.length).toBe(2);
-    expect(results[0]!.id).toBe("md#102"); // best lexical match
+    expect(first(results).id).toBe("md#102"); // best lexical match
   });
 
   it("similarToTask finds similar tasks by content using lexical backend", async () => {

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -10,6 +10,7 @@ import { eq } from "drizzle-orm";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 import { log } from "../../../utils/logger";
+import { first } from "../../../utils/array-safety";
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
 import { getMinskyStateDir } from "../../../utils/paths";
@@ -324,7 +325,7 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
         .where(eq(postgresSessions.session, id))
         .limit(1);
 
-      return result.length > 0 ? fromPostgresSelect(result[0]!) : null;
+      return result.length > 0 ? fromPostgresSelect(first(result, "session query")) : null;
     } catch (error) {
       const typedError = error instanceof Error ? error : new Error(String(error));
       log.warn(`Failed to get session from PostgreSQL: ${typedError.message}`);

--- a/src/domain/storage/monitoring/health-monitor.ts
+++ b/src/domain/storage/monitoring/health-monitor.ts
@@ -12,6 +12,7 @@ import { SessionDbConfig } from "../../configuration/types";
 
 import { getConfiguration } from "../../configuration/index";
 import { getErrorMessage } from "../../../errors";
+import { first } from "../../../utils/array-safety";
 
 export interface HealthStatus {
   healthy: boolean;
@@ -319,24 +320,25 @@ export class SessionDbHealthMonitor {
       try {
         // Check server version
         const versionResult = await sql`SELECT version()`;
-        // These are single-row aggregate queries — [0]! is safe
-        status.details!.serverVersion = versionResult[0]!.version;
+        status.details!.serverVersion = first(versionResult, "pg version query").version;
 
         // Check connection count
         const connectionsResult = await sql`
           SELECT count(*) as active_connections FROM pg_stat_activity WHERE state = 'active'
         `;
-        status.details!.activeConnections = parseInt(connectionsResult[0]!.active_connections);
+        status.details!.activeConnections = parseInt(
+          first(connectionsResult, "pg connections query").active_connections
+        );
 
         // Check database size
         const sizeResult = await sql`
           SELECT pg_size_pretty(pg_database_size(current_database())) as size
         `;
-        status.details!.databaseSize = sizeResult[0]!.size;
+        status.details!.databaseSize = first(sizeResult, "pg size query").size;
 
         // Check for locks
         const locksResult = await sql`SELECT count(*) as locks FROM pg_locks WHERE NOT granted`;
-        const lockCount = parseInt(locksResult[0]!.locks);
+        const lockCount = parseInt(first(locksResult, "pg locks query").locks);
         status.details!.blockedQueries = lockCount;
 
         if (lockCount > 0) {

--- a/src/domain/tasks.ts
+++ b/src/domain/tasks.ts
@@ -9,6 +9,7 @@
 import { log } from "../utils/logger";
 import { createConfiguredTaskService } from "./tasks/taskService";
 import { ResourceNotFoundError } from "../errors/index";
+import { first } from "../utils/array-safety";
 import {
   taskListParamsSchema,
   taskGetParamsSchema,
@@ -90,7 +91,9 @@ export async function getTaskFromParams(params: Record<string, unknown>) {
   log.debug("tasks.get created TaskService", {
     backend: taskService.listBackends!().find((b) => b.prefix === backend)?.name || "default",
   });
-  const taskId = Array.isArray(validParams.taskId) ? validParams.taskId[0]! : validParams.taskId;
+  const taskId = Array.isArray(validParams.taskId)
+    ? first(validParams.taskId, "taskId array")
+    : validParams.taskId;
   const task = await taskService.getTask(taskId);
   if (!task) {
     throw new ResourceNotFoundError(`Task ${taskId} not found`, "task", taskId);

--- a/src/domain/tasks/backend-filtering-regression.test.ts
+++ b/src/domain/tasks/backend-filtering-regression.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { TASK_STATUS } from "./taskConstants";
 import type { Task, TaskListOptions } from "./types";
+import { first } from "../../utils/array-safety";
 
 /**
  * Regression test for CLOSED task filtering bug
@@ -99,8 +100,8 @@ describe("Backend CLOSED task filtering regression test", () => {
 
     expect(closedTasks).toHaveLength(1);
     expect(closedTasks[0]).toBeDefined();
-    expect(closedTasks[0]!.status).toBe(TASK_STATUS.CLOSED);
-    expect(closedTasks[0]!.title).toBe("Closed Task");
+    expect(first(closedTasks).status).toBe(TASK_STATUS.CLOSED);
+    expect(first(closedTasks).title).toBe("Closed Task");
   });
 
   it("should filter to DONE status specifically", () => {

--- a/src/domain/tasks/jsonFileTaskBackend.ts
+++ b/src/domain/tasks/jsonFileTaskBackend.ts
@@ -24,6 +24,7 @@ import { getTaskSpecRelativePath, readTaskSpecFile } from "./taskIO";
 import { validateQualifiedTaskId } from "./task-id-utils";
 import { getNextTaskId } from "./taskFunctions";
 import { get as getConfig, has as hasConfig } from "../configuration";
+import { firstMatch } from "../../utils/array-safety";
 
 // TaskState is now imported from schemas/storage
 
@@ -96,7 +97,7 @@ export class JsonFileTaskBackend implements TaskBackend {
     const tasks = await this.getAllTasks();
     const maxId = tasks.reduce((max, task) => {
       const match = task.id.match(/^json-file#(\d+)$/);
-      return match ? Math.max(max, parseInt(match[1]!, 10)) : max;
+      return match ? Math.max(max, parseInt(firstMatch(match, "json-file task ID"), 10)) : max;
     }, 0);
 
     const newId = `json-file#${maxId + 1}`;

--- a/src/domain/tasks/markdown-backend-create-helpers.ts
+++ b/src/domain/tasks/markdown-backend-create-helpers.ts
@@ -12,6 +12,7 @@ import type { TaskData, TaskSpecData } from "../../types/tasks/taskData";
 import { TASK_STATUS, type TaskStatus } from "./taskConstants";
 import { getTaskIdNumber, formatTaskIdForDisplay } from "./task-id-utils";
 import { getTaskSpecRelativePath } from "./taskIO";
+import { elementAt } from "../../utils/array-safety";
 
 /**
  * Determine the next local ID from existing tasks.
@@ -32,7 +33,7 @@ export function resolveLocalId(specId: string | undefined, existingTasks: TaskDa
   if (specId) {
     // If spec.id is qualified (md#123), extract local part (123)
     if (specId.includes("#")) {
-      return specId.split("#")[1]!;
+      return elementAt(specId.split("#"), 1, "qualified task ID local part");
     }
     return specId;
   }

--- a/src/domain/tasks/markdown-task-backend-integration.test.ts
+++ b/src/domain/tasks/markdown-task-backend-integration.test.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { TASK_STATUS } from "./taskConstants";
 import { createMockFilesystem } from "../../utils/test-utils/filesystem/mock-filesystem";
 import type { TaskBackend, TaskBackendConfig } from "./types";
+import { first, elementAt, firstMatch } from "../../utils/array-safety";
 describe("MarkdownTaskBackend Multi-Backend Integration", () => {
   let mockFs: any;
   let backend: TaskBackend & Record<string, any>;
@@ -91,7 +92,7 @@ describe("MarkdownTaskBackend Multi-Backend Integration", () => {
         const normalizeId = (taskId: string) => {
           // Extract just the numeric part, removing leading zeros
           const match = taskId.match(/(\d+)$/);
-          return match ? parseInt(match[1]!, 10).toString() : taskId;
+          return match ? parseInt(firstMatch(match, "task ID number"), 10).toString() : taskId;
         };
 
         const searchIdNormalized = normalizeId(id);
@@ -332,7 +333,7 @@ describe("MarkdownTaskBackend Multi-Backend Integration", () => {
     const title = titleMatch ? titleMatch[1] : "Untitled Task";
 
     const contextMatch = content.match(/## Context\n\n(.+)/s);
-    const description = contextMatch ? contextMatch[1]!.trim() : "";
+    const description = contextMatch ? firstMatch(contextMatch, "context section").trim() : "";
 
     return { title, description };
   }
@@ -433,20 +434,20 @@ describe("MarkdownTaskBackend Multi-Backend Integration", () => {
       expect(tasks).toHaveLength(3);
 
       // Should convert to qualified IDs
-      expect(tasks[0]).toBeDefined();
-      expect(tasks[0]!.id).toBe("md#001");
-      expect(tasks[0]!.title).toBe("Legacy Task One");
-      expect(tasks[0]!.status).toBe(TASK_STATUS.TODO);
+      const task0 = first(tasks);
+      expect(task0.id).toBe("md#001");
+      expect(task0.title).toBe("Legacy Task One");
+      expect(task0.status).toBe(TASK_STATUS.TODO);
 
-      expect(tasks[1]).toBeDefined();
-      expect(tasks[1]!.id).toBe("md#002");
-      expect(tasks[1]!.title).toBe("Legacy Task Two");
-      expect(tasks[1]!.status).toBe(TASK_STATUS.DONE);
+      const task1 = elementAt(tasks, 1);
+      expect(task1.id).toBe("md#002");
+      expect(task1.title).toBe("Legacy Task Two");
+      expect(task1.status).toBe(TASK_STATUS.DONE);
 
-      expect(tasks[2]).toBeDefined();
-      expect(tasks[2]!.id).toBe("md#003");
-      expect(tasks[2]!.title).toBe("Legacy Task Three");
-      expect(tasks[2]!.status).toBe(TASK_STATUS.TODO);
+      const task2 = elementAt(tasks, 2);
+      expect(task2.id).toBe("md#003");
+      expect(task2.title).toBe("Legacy Task Three");
+      expect(task2.status).toBe(TASK_STATUS.TODO);
     });
 
     it("should retrieve legacy tasks by various ID formats", async () => {
@@ -512,14 +513,11 @@ describe("MarkdownTaskBackend Multi-Backend Integration", () => {
       const inProgressTasks = await backend.listTasks({ status: TASK_STATUS.IN_PROGRESS });
 
       expect(todoTasks).toHaveLength(2);
-      expect(todoTasks[0]).toBeDefined();
-      expect(todoTasks[0]!.title).toBe("Todo Task");
-      expect(todoTasks[1]).toBeDefined();
-      expect(todoTasks[1]!.title).toBe("Another Todo Task");
+      expect(first(todoTasks).title).toBe("Todo Task");
+      expect(elementAt(todoTasks, 1).title).toBe("Another Todo Task");
 
       expect(doneTasks).toHaveLength(1);
-      expect(doneTasks[0]).toBeDefined();
-      expect(doneTasks[0]!.title).toBe("Done Task");
+      expect(first(doneTasks).title).toBe("Done Task");
 
       // IN-PROGRESS not supported in markdown format
       expect(inProgressTasks).toHaveLength(0);
@@ -532,8 +530,7 @@ describe("MarkdownTaskBackend Multi-Backend Integration", () => {
       const ghTasks = await backend.listTasks({ backend: "gh" });
 
       expect(mdTasks).toHaveLength(1);
-      expect(mdTasks[0]).toBeDefined();
-      expect(mdTasks[0]!.title).toBe("Markdown Task");
+      expect(first(mdTasks).title).toBe("Markdown Task");
 
       expect(ghTasks).toHaveLength(0);
     });

--- a/src/domain/tasks/minskyTaskBackend.ts
+++ b/src/domain/tasks/minskyTaskBackend.ts
@@ -9,6 +9,7 @@ import {
   taskSpecsTable,
   tasksEmbeddingsTable,
 } from "../storage/schemas/task-embeddings";
+import { first } from "../../utils/array-safety";
 import type {
   Task,
   TaskBackend,
@@ -177,7 +178,7 @@ export class MinskyTaskBackend implements TaskBackend {
       .where(eq(taskSpecsTable.taskId, id))
       .limit(1);
 
-    const spec = specRows.length > 0 ? specRows[0]!.content : "";
+    const spec = specRows.length > 0 ? first(specRows, "task spec query").content : "";
 
     return {
       id: task.id,
@@ -230,7 +231,7 @@ export class MinskyTaskBackend implements TaskBackend {
       .where(eq(taskSpecsTable.taskId, taskId))
       .limit(1);
 
-    const content = specRows.length > 0 ? specRows[0]!.content : "";
+    const content = specRows.length > 0 ? first(specRows, "task spec content query").content : "";
 
     return {
       task,

--- a/src/domain/tasks/task-id-integration.test.ts
+++ b/src/domain/tasks/task-id-integration.test.ts
@@ -12,6 +12,7 @@ import { FakeTaskService } from "./fake-task-service";
 import { FakeSessionProvider } from "../session/fake-session-provider";
 import { FakeWorkspaceUtils } from "../workspace/fake-workspace-utils";
 import { RULES_TEST_PATTERNS, PATH_TEST_PATTERNS } from "../../utils/test-utils/test-constants";
+import { first, elementAt } from "../../utils/array-safety";
 
 // Import domain functions to test
 import { listTasksFromParams } from "./taskCommands";
@@ -81,9 +82,9 @@ describe("Task ID Integration Issues (Domain Layer Testing)", () => {
 
       // Verify qualified task IDs are handled correctly
       expect(tasks).toHaveLength(2);
-      expect(tasks[0]!.id).toBe("md#999");
-      expect(tasks[1]!.id).toBe("gh#888");
-      expect(tasks[0]!.title).toContain("Test Qualified Task md#999");
+      expect(first(tasks).id).toBe("md#999");
+      expect(elementAt(tasks, 1).id).toBe("gh#888");
+      expect(first(tasks).title).toContain("Test Qualified Task md#999");
     });
 
     test("should retrieve specific qualified task by ID", async () => {
@@ -165,7 +166,9 @@ describe("Task ID Integration Issues (Domain Layer Testing)", () => {
       expect(addSessionSpy).toHaveBeenCalled();
 
       // Verify the session record contains the qualified task ID
-      const addSessionCall = addSessionSpy.mock.calls[0]![0] as { taskId: string };
+      const addSessionCall = first(addSessionSpy.mock.calls as unknown[][])[0] as {
+        taskId: string;
+      };
       expect(addSessionCall.taskId).toBe("md#999");
     });
   });
@@ -235,7 +238,7 @@ describe("Task ID Integration Issues (Domain Layer Testing)", () => {
       // Step 2: Verify task appears in list
       const tasks = await mockTaskService.listTasks();
       expect(tasks).toHaveLength(1);
-      expect(tasks[0]!.id).toBe(qualifiedId);
+      expect(first(tasks).id).toBe(qualifiedId);
 
       // Step 3: Verify session can be created (mocked)
       const sessionCreated = true; // Simplified for this test

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -5,6 +5,7 @@ import type { VectorStorage, SearchResult } from "../storage/vector/types";
 import type { PersistenceProvider } from "../persistence/types";
 import { createHash } from "crypto";
 import { createTaskSimilarityCore } from "../similarity/create-task-similarity-core";
+import { first } from "../../utils/array-safety";
 
 export interface TaskSimilarityServiceConfig {
   similarityThreshold?: number;
@@ -84,7 +85,7 @@ export class TaskSimilarityService {
     const uniqueTerms = Array.from(new Set(terms.map((t) => t.toLowerCase())));
 
     if (uniqueTerms.length === 1) {
-      return uniqueTerms[0]!;
+      return first(uniqueTerms, "search query terms");
     }
 
     // For multiple terms, create a coherent query

--- a/src/domain/tasks/taskCommands.test.ts
+++ b/src/domain/tasks/taskCommands.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock, beforeAll, afterAll } from "bun:test";
+import { first, elementAt } from "../../utils/array-safety";
 import {
   getTaskStatusFromParams,
   getTaskFromParams,
@@ -596,7 +597,7 @@ describe("Interface-Agnostic Task Command Functions", () => {
       };
 
       const result = await listTasksFromParams(params, mockDeps as any);
-      expect(result).toEqual([mockTasks[0]!]);
+      expect(result).toEqual([first(mockTasks)]);
     });
 
     test("should filter out DONE tasks when all is false", async () => {
@@ -640,7 +641,7 @@ describe("Interface-Agnostic Task Command Functions", () => {
       };
 
       const result = await listTasksFromParams(params, mockDeps as any);
-      expect(result).toEqual([mockTasks[0]!, mockTasks[1]!]);
+      expect(result).toEqual([first(mockTasks), elementAt(mockTasks, 1)]);
     });
   });
 

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -18,6 +18,7 @@ import { ValidationError, ResourceNotFoundError } from "../../errors/index";
 import { readTextFile } from "../../utils/fs";
 import { createTaskIdParsingErrorMessage } from "../../errors/enhanced-error-templates";
 import { resolve, join } from "path";
+import { first } from "../../utils/array-safety";
 
 /**
  * Module-level wrapper that lazily creates a sessionProvider for bare resolveRepoPath calls.
@@ -175,7 +176,7 @@ export async function getTaskFromParams(
     // Get the task
     log.debug("[getTaskFromParams] About to get task");
     const taskIdStr = Array.isArray(validParams.taskId)
-      ? validParams.taskId[0]!
+      ? first(validParams.taskId, "taskId array")
       : validParams.taskId;
     const task = await taskService.getTask(taskIdStr);
     log.debug("[getTaskFromParams] Task retrieved", { taskExists: !!task });

--- a/src/domain/tasks/taskFunctions.test.ts
+++ b/src/domain/tasks/taskFunctions.test.ts
@@ -8,6 +8,7 @@ const TEST_ARRAY_SIZE = 3;
 import { describe, test, expect } from "bun:test";
 import type { TaskData } from "../../types/tasks/taskData";
 import { TaskStatus } from "./taskConstants";
+import { first, elementAt } from "../../utils/array-safety";
 import { RULES_TEST_PATTERNS, TEST_DATA_PATTERNS } from "../../utils/test-utils/test-constants";
 import {
   parseTasksFromMarkdown,
@@ -54,16 +55,19 @@ describe("Task Functions", () => {
       const tasks = parseTasksFromMarkdown(markdown);
       expect(tasks).toHaveLength(3);
 
-      expect(tasks[0]!.id).toBe("#001");
-      expect(tasks[0]!.title).toBe("First task");
-      expect(tasks[0]!.status).toBe(TaskStatus.TODO);
-      expect(tasks[0]!.description).toBe("Description line 1\nDescription line 2");
+      const task0 = first(tasks);
+      expect(task0.id).toBe("#001");
+      expect(task0.title).toBe("First task");
+      expect(task0.status).toBe(TaskStatus.TODO);
+      expect(task0.description).toBe("Description line 1\nDescription line 2");
 
-      expect(tasks[1]!.id).toBe("#002");
-      expect(tasks[1]!.status).toBe(TaskStatus.DONE);
+      const task1 = elementAt(tasks, 1);
+      expect(task1.id).toBe("#002");
+      expect(task1.status).toBe(TaskStatus.DONE);
 
-      expect(tasks[2]!.id).toBe("#003");
-      expect(tasks[2]!.status).toBe(TaskStatus.IN_PROGRESS);
+      const task2 = elementAt(tasks, 2);
+      expect(task2.id).toBe("#003");
+      expect(task2.status).toBe(TaskStatus.IN_PROGRESS);
     });
 
     test("should ignore tasks in code blocks", () => {
@@ -80,8 +84,8 @@ Code block with task-like content:
 
       const tasks = parseTasksFromMarkdown(markdown);
       expect(tasks).toHaveLength(2);
-      expect(tasks[0]!.id).toBe("#001");
-      expect(tasks[1]!.id).toBe("#003");
+      expect(first(tasks).id).toBe("#001");
+      expect(elementAt(tasks, 1).id).toBe("#003");
     });
   });
 
@@ -205,13 +209,13 @@ Code block with task-like content:
 
     test("should update a task's status", () => {
       const updatedTasks = setTaskStatus(testTasks, "md#001", TaskStatus.DONE);
-      expect(updatedTasks[0]!.status).toBe(TaskStatus.DONE);
-      expect(updatedTasks[1]!.status).toBe(TaskStatus.IN_PROGRESS); // unchanged
+      expect(first(updatedTasks).status).toBe(TaskStatus.DONE);
+      expect(elementAt(updatedTasks, 1).status).toBe(TaskStatus.IN_PROGRESS); // unchanged
     });
 
     test("should work with task ID variations", () => {
       const updatedTasks = setTaskStatus(testTasks, "md#002", TaskStatus.DONE);
-      expect(updatedTasks[1]!.status).toBe(TaskStatus.DONE);
+      expect(elementAt(updatedTasks, 1).status).toBe(TaskStatus.DONE);
     });
 
     test("should return original array if task not found", () => {
@@ -256,8 +260,9 @@ Code block with task-like content:
       const updatedTasks = addTask(testTasks, taskWithoutId);
 
       expect(updatedTasks).toHaveLength(3);
-      expect(updatedTasks[2]!.id).toBe("003"); // Next available ID in storage format
-      expect(updatedTasks[2]!.title).toBe("New Task");
+      const newTask = elementAt(updatedTasks, 2);
+      expect(newTask.id).toBe("003"); // Next available ID in storage format
+      expect(newTask.title).toBe("New Task");
     });
   });
 
@@ -275,7 +280,7 @@ Code block with task-like content:
     test("should filter by status", () => {
       const filtered = filterTasks(testTasks, { status: TaskStatus.TODO });
       expect(filtered).toHaveLength(1);
-      expect(filtered[0]!.id).toBe("#001");
+      expect(first(filtered).id).toBe("#001");
     });
 
     test("should filter by ID", () => {

--- a/src/domain/tasks/tasks-importer-service.ts
+++ b/src/domain/tasks/tasks-importer-service.ts
@@ -5,6 +5,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { log } from "../../utils/logger";
 import { getTasksFilePath, getTaskSpecFilePath } from "./taskIO";
 import { parseTasksFromMarkdown } from "./taskFunctions";
+import { elementAt } from "../../utils/array-safety";
 
 export interface ImportOptions {
   dryRun?: boolean;
@@ -36,8 +37,8 @@ function deriveBackendAndSource(id: string): { backend: string; sourceTaskId: st
   if (parts.length !== 2) {
     throw new Error(`Invalid qualified task ID: ${id}`);
   }
-  const prefix = parts[0]!;
-  const sourceTaskId = parts[1]!;
+  const prefix = elementAt(parts, 0, "task ID prefix");
+  const sourceTaskId = elementAt(parts, 1, "task ID source");
 
   const backendMap: Record<string, string> = {
     md: "markdown",
@@ -46,7 +47,7 @@ function deriveBackendAndSource(id: string): { backend: string; sourceTaskId: st
     jf: "json-file",
   };
 
-  const backend = backendMap[prefix]!;
+  const backend = backendMap[prefix];
   if (!backend) {
     throw new Error(`Unknown task ID prefix: ${prefix}`);
   }

--- a/src/domain/tools/similarity/tool-similarity-service.core.test.ts
+++ b/src/domain/tools/similarity/tool-similarity-service.core.test.ts
@@ -4,6 +4,7 @@ import { createToolSimilarityCore } from "./create-tool-similarity-core";
 
 // Ensure embeddings path does not short-circuit core behavior in test
 import { EmbeddingsSimilarityBackend } from "../../similarity/backends/embeddings-backend";
+import { first } from "../../../utils/array-safety";
 
 describe("ToolSimilarityService → SimilaritySearchService (lexical fallback)", () => {
   beforeAll(async () => {
@@ -63,7 +64,7 @@ describe("ToolSimilarityService → SimilaritySearchService (lexical fallback)",
       return;
     }
 
-    const targetToolId = searchResults[0]!.id;
+    const targetToolId = first(searchResults).id;
     const results = await service.similarToTool(targetToolId, 2);
 
     expect(Array.isArray(results)).toBe(true);

--- a/src/errors/message-templates.test.ts
+++ b/src/errors/message-templates.test.ts
@@ -25,6 +25,7 @@ import {
   type ErrorTemplate,
 } from "./message-templates";
 import { CLI_COMMANDS, TEST_PATHS } from "../utils/test-utils/test-constants";
+import { first, elementAt } from "../utils/array-safety";
 
 // Set up automatic mock cleanup
 setupTestMocks();
@@ -341,8 +342,9 @@ describe("Error Message Templates", () => {
       const context = createErrorContext().addCurrentDirectory().build();
 
       expect(context).toHaveLength(1);
-      expect(context[0]!.label).toBe("Current directory");
-      expect(context[0]!.value).toBe("/mock/projects/minsky");
+      const firstCtx = first(context);
+      expect(firstCtx.label).toBe("Current directory");
+      expect(firstCtx.value).toBe("/mock/projects/minsky");
     });
 
     test("adds session information", () => {
@@ -404,10 +406,10 @@ describe("Error Message Templates", () => {
         .build();
 
       expect(context).toHaveLength(4);
-      expect(context[0]!.label).toBe("Session");
-      expect(context[1]!.label).toBe("Task ID");
-      expect(context[2]!.label).toBe("Repository");
-      expect(context[3]!.label).toBe("Current directory");
+      expect(first(context).label).toBe("Session");
+      expect(elementAt(context, 1).label).toBe("Task ID");
+      expect(elementAt(context, 2).label).toBe("Repository");
+      expect(elementAt(context, 3).label).toBe("Current directory");
     });
   });
 

--- a/src/utils/array-safety.ts
+++ b/src/utils/array-safety.ts
@@ -1,0 +1,39 @@
+/**
+ * Type-safe array access utilities.
+ * Replace [0]! non-null assertions with runtime-checked alternatives.
+ */
+
+/**
+ * Get the first element of an array, throwing if empty.
+ * Use for cases where the code assumes an array has elements (SQL single-row queries, etc.)
+ */
+export function first<T>(arr: T[], context?: string): T {
+  if (arr.length === 0) {
+    throw new Error(context ? `Expected non-empty array: ${context}` : "Expected non-empty array");
+  }
+  return arr[0] as T;
+}
+
+/**
+ * Get the first capture group from a regex match, throwing if no match.
+ */
+export function firstMatch(match: RegExpMatchArray | null, context?: string): string {
+  if (!match || match.length < 2) {
+    throw new Error(context ? `Expected regex match: ${context}` : "Expected regex match");
+  }
+  return match[1] as string;
+}
+
+/**
+ * Get an element at a specific index, throwing if out of bounds.
+ */
+export function elementAt<T>(arr: T[], index: number, context?: string): T {
+  if (index < 0 || index >= arr.length) {
+    throw new Error(
+      context
+        ? `Index ${index} out of bounds (length ${arr.length}): ${context}`
+        : `Index ${index} out of bounds (length ${arr.length})`
+    );
+  }
+  return arr[index] as T;
+}

--- a/src/utils/zod-error-formatter.ts
+++ b/src/utils/zod-error-formatter.ts
@@ -4,6 +4,7 @@
 import { ZodError, ZodIssue } from "zod";
 import { createValidationErrorMessage } from "../errors/message-templates";
 import { TASK_STATUS_VALUES } from "../domain/tasks/taskConstants";
+import { first } from "./array-safety";
 
 /**
  * Format a Zod validation error into a user-friendly message
@@ -18,7 +19,7 @@ export function formatZodError(error: ZodError, context?: string): string {
 
   // Handle single issue
   if (error.issues.length === 1) {
-    return formatSingleZodIssue(error.issues[0]!, context);
+    return formatSingleZodIssue(first(error.issues, "zod error issues"), context);
   }
 
   // Handle multiple issues


### PR DESCRIPTION
## Summary

- Adds `src/utils/array-safety.ts` with `first()`, `firstMatch()`, and `elementAt()` utilities that provide runtime bounds checking with descriptive error context
- Replaces all 136 `[N]!` non-null assertions on array index access across 41 files with type-safe alternatives
- Zero remaining `[N]!` patterns in the codebase (verified via grep)

## Approach

**Production code**: Each `[N]!` replaced with the appropriate utility (`first()` for `[0]!`, `elementAt()` for other indices, `firstMatch()` for regex capture groups). Context strings describe the data source (e.g., "task spec query", "pg version query") for better error messages.

**Test code**: Same utilities used for consistency. Where mock `.calls[0]!` patterns existed, cast through `unknown[][]` to preserve type compatibility with Bun's mock types.

**Special cases**:
- `backendMap[prefix]!` followed by a null check: removed the `!` since the check handles undefined
- `commits[commits.length - 1]!`: restructured to use optional variable binding
- Octokit `pulls[0]!`: used explicit `any` annotation since Octokit types come through `require()`

## Coherence Verification

**Files re-read**: All 42 modified files verified via grep for remaining patterns

**Q1 single purpose**: pass — `array-safety.ts` has a single clear purpose
**Q2 comment honesty**: pass — removed stale comment "Non-null assertion safe because we checked length > 0" from pr-get-subcommand.ts; removed "These are single-row aggregate queries — [0]! is safe" from health-monitor.ts
**Q3 naming honesty**: pass — all names reflect their purpose
**Q4 redundant siblings**: pass — no duplicate utility files
**Q5 dead exports**: pass — all three exports (`first`, `firstMatch`, `elementAt`) are imported by consumer files (verified via grep: 41 files import from array-safety)
**Q6 orphan code**: pass — no unused utilities
**Q7 stray artifacts**: pass — no TODO/FIXME left from this refactor

**Items fixed in this PR (beyond original scope)**: none
**Items deferred (with justification)**: Variable-index `]!` patterns (e.g., `chain[i]!`, `sessions[sessionIndex]!`) were not in scope per the task spec which targets literal `[N]!` patterns

## Test plan

- [ ] Pre-commit hooks pass (tsc, lint, tests) — verified by successful commit
- [ ] `grep -rn '\[[0-9]\+\]!' src/ --include="*.ts"` returns only the comment in array-safety.ts
- [ ] CI build and test checks pass