### PR TITLE
refactor(mt#710): eliminate remaining [N]! patterns in tests/

### DIFF
--- a/src/domain/configuration/config-writer.ts
+++ b/src/domain/configuration/config-writer.ts
@@ -414,7 +414,10 @@ ${stringify(config, { indent: 2 })}`;
    */
   private setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
     const keys = path.split(".");
-    const lastKey = keys.pop()!;
+    const lastKey = keys.pop();
+    if (!lastKey) {
+      throw new Error(`Invalid config path: "${path}"`);
+    }
 
     let current: Record<string, unknown> = obj;
     for (const key of keys) {
@@ -433,7 +436,10 @@ ${stringify(config, { indent: 2 })}`;
    */
   private unsetNestedValue(obj: Record<string, unknown>, path: string): void {
     const keys = path.split(".");
-    const lastKey = keys.pop()!;
+    const lastKey = keys.pop();
+    if (!lastKey) {
+      throw new Error(`Invalid config path: "${path}"`);
+    }
 
     let current: Record<string, unknown> = obj;
     for (const key of keys) {

--- a/tests/adapters/cli/session-remaining.test.ts
+++ b/tests/adapters/cli/session-remaining.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { firstMatch } from "../../../src/utils/array-safety";
 import { join } from "path";
 import { createSessionTestData, cleanupSessionTestData } from "./session-test-utilities";
 import type { SessionTestData } from "./session-test-utilities";
@@ -135,7 +136,7 @@ describe("session pr command", () => {
         if (command.includes("git switch") || command.includes("git checkout")) {
           const branchMatch = command.match(/(?:switch|checkout)\s+(?:-C\s+)?([^\s]+)/);
           if (branchMatch) {
-            currentBranch = branchMatch[1]!;
+            currentBranch = firstMatch(branchMatch);
             branchHistory.push(currentBranch);
           }
         }

--- a/tests/domain/similarity/task-search-filtering.test.ts
+++ b/tests/domain/similarity/task-search-filtering.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
+import { first } from "../../../src/utils/array-safety";
 import { EmbeddingsSimilarityBackend } from "../../../src/domain/similarity/backends/embeddings-backend";
 import type { SimilarityQuery } from "../../../src/domain/similarity/types";
 import { MemoryVectorStorage } from "../../../src/domain/storage/vector/memory-vector-storage";
@@ -100,9 +101,9 @@ describe("Task Search Server-Side Filtering Integration", () => {
     const results = await backend.search(query);
 
     expect(results).toHaveLength(1);
-    expect(results[0]!.id).toBe("gh#002");
-    expect(results[0]!.metadata?.status).toBe("TODO");
-    expect(results[0]!.metadata?.backend).toBe("github");
+    expect(first(results).id).toBe("gh#002");
+    expect(first(results).metadata?.status).toBe("TODO");
+    expect(first(results).metadata?.backend).toBe("github");
   });
 
   it("should respect limit with filters", async () => {
@@ -115,8 +116,8 @@ describe("Task Search Server-Side Filtering Integration", () => {
     const results = await backend.search(query);
 
     expect(results).toHaveLength(1);
-    expect(["gh#001", "gh#002"]).toContain(results[0]!.id);
-    expect(results[0]!.metadata?.backend).toBe("github");
+    expect(["gh#001", "gh#002"]).toContain(first(results).id);
+    expect(first(results).metadata?.backend).toBe("github");
   });
 
   it("should return empty results for non-matching filters", async () => {

--- a/tests/domain/storage/vector/server-side-filtering.test.ts
+++ b/tests/domain/storage/vector/server-side-filtering.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { first, elementAt } from "../../../../src/utils/array-safety";
 import { MemoryVectorStorage } from "../../../../src/domain/storage/vector/memory-vector-storage";
 import type { SearchOptions } from "../../../../src/domain/storage/vector/types";
 
@@ -71,9 +72,9 @@ describe("VectorStorage Server-Side Filtering", () => {
     const results = await storage.search(queryVector, options);
 
     expect(results).toHaveLength(1);
-    expect(results[0]!.id).toBe("task2");
-    expect(results[0]!.metadata?.status).toBe("IN-PROGRESS");
-    expect(results[0]!.metadata?.backend).toBe("github");
+    expect(first(results).id).toBe("task2");
+    expect(first(results).metadata?.status).toBe("IN-PROGRESS");
+    expect(first(results).metadata?.backend).toBe("github");
   });
 
   it("should return empty results when no matches found", async () => {
@@ -98,7 +99,7 @@ describe("VectorStorage Server-Side Filtering", () => {
     const results = await storage.search(queryVector, options);
 
     expect(results).toHaveLength(1);
-    expect(results[0]!.metadata?.backend).toBe("github");
+    expect(first(results).metadata?.backend).toBe("github");
   });
 
   it("should order results by similarity score", async () => {
@@ -111,8 +112,8 @@ describe("VectorStorage Server-Side Filtering", () => {
     const results = await storage.search(queryVector, options);
 
     expect(results).toHaveLength(3);
-    expect(results[0]!.id).toBe("task1"); // Exact match should be first
-    expect(results[0]!.score).toBe(0); // Distance 0 for exact match
+    expect(first(results).id).toBe("task1"); // Exact match should be first
+    expect(first(results).score).toBe(0); // Distance 0 for exact match
 
     // Verify scores are in ascending order (lower score = better match)
     for (let i = 1; i < results.length; i++) {

--- a/tests/domain/storage/vector/sql-generation-proof.test.ts
+++ b/tests/domain/storage/vector/sql-generation-proof.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { first } from "../../../../src/utils/array-safety";
 
 // Test constants to avoid magic string duplication
 const POSTGRES_VEC_MODULE_PATH = "../../../../src/domain/storage/vector/postgres-vector-storage";
@@ -48,7 +49,7 @@ describe("SQL Generation Proof for Server-Side Filtering", () => {
 
     // PROOF: Verify SQL generation
     expect(capturedQueries).toHaveLength(1);
-    const { query, params } = capturedQueries[0]!;
+    const { query, params } = first(capturedQueries);
 
     // PROOF 1: WHERE clause is generated
     expect(query).toContain("WHERE");
@@ -83,7 +84,7 @@ describe("SQL Generation Proof for Server-Side Filtering", () => {
     });
 
     expect(capturedQueries).toHaveLength(1);
-    const { query, params } = capturedQueries[0]!;
+    const { query, params } = first(capturedQueries);
 
     // PROOF: Multiple conditions with AND
     expect(query).toContain("WHERE");
@@ -115,7 +116,7 @@ describe("SQL Generation Proof for Server-Side Filtering", () => {
     await storage.search(queryVector, { limit: 10 });
 
     expect(capturedQueries).toHaveLength(1);
-    const { query, params } = capturedQueries[0]!;
+    const { query, params } = first(capturedQueries);
 
     // PROOF: No WHERE clause without filters
     expect(query).not.toContain("WHERE");
@@ -147,7 +148,7 @@ describe("SQL Generation Proof for Server-Side Filtering", () => {
     });
 
     expect(capturedQueries).toHaveLength(1);
-    const { query, params } = capturedQueries[0]!;
+    const { query, params } = first(capturedQueries);
 
     // PROOF: Only non-null filters create conditions
     expect(query).toContain("WHERE");
@@ -180,7 +181,7 @@ describe("SQL Generation Proof for Server-Side Filtering", () => {
     });
 
     expect(capturedQueries).toHaveLength(1);
-    const { query } = capturedQueries[0]!;
+    const { query } = first(capturedQueries);
 
     // PERFORMANCE PROOF: Single query with embedded filter
     // No separate filtering step in application code

--- a/tests/domain/tasks/task-routing-service.test.ts
+++ b/tests/domain/tasks/task-routing-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeEach } from "bun:test";
+import { first } from "../../../src/utils/array-safety";
 import {
   TaskRoutingService,
   type AvailableTask,
@@ -328,8 +329,8 @@ describe("TaskRoutingService", () => {
 
       // Should handle missing dependencies gracefully
       expect(availableTasks.length).toBe(1);
-      expect(availableTasks[0]!.taskId).toBe("task-x");
-      expect(availableTasks[0]!.readinessScore).toBe(1.0); // Should be ready since dep doesn't exist
+      expect(first(availableTasks).taskId).toBe("task-x");
+      expect(first(availableTasks).readinessScore).toBe(1.0); // Should be ready since dep doesn't exist
     });
 
     test("handles circular dependency detection in route generation", async () => {

--- a/tests/integration/mock-session-edit-tools.ts
+++ b/tests/integration/mock-session-edit-tools.ts
@@ -1,5 +1,6 @@
 import type { CommandMapper } from "../../src/mcp/command-mapper.js";
 import { dirname } from "path";
+import { first, firstMatch } from "../../src/utils/array-safety";
 import {
   mockFiles,
   createMockFile,
@@ -95,7 +96,7 @@ async function loggingApplyEditPattern(
     let isFastApply = false;
 
     if (fastApplyProviders.length > 0) {
-      provider = fastApplyProviders[0]!; // Use the first available fast-apply provider
+      provider = first(fastApplyProviders); // Use the first available fast-apply provider
       model = aiConfig.providers[provider]?.model;
       isFastApply = true;
       console.log(`   Using fast-apply provider: ${provider} with model: ${model}`);
@@ -109,7 +110,7 @@ async function loggingApplyEditPattern(
         throw new Error("No enabled AI providers found for edit operations");
       }
 
-      provider = enabledProviders[0]!;
+      provider = first(enabledProviders);
       model = aiConfig.providers[provider]?.model;
       console.log(`   Using fallback provider: ${provider} with model: ${model}`);
     }
@@ -266,7 +267,7 @@ require("fs/promises").writeFile = async (
   // Extract session ID from path
   const sessionMatch = path.match(/^([^/]+)\//);
   const sessionId = sessionMatch ? (sessionMatch[1] ?? "") : "";
-  const filePath = sessionMatch ? path.substring(sessionMatch[1]!.length + 1) : path;
+  const filePath = sessionMatch ? path.substring((sessionMatch[1] ?? "").length + 1) : path;
 
   createMockFile(sessionId, filePath, content);
   return Promise.resolve();

--- a/tests/integration/session-edit-file-cursor-parity.integration.test.ts
+++ b/tests/integration/session-edit-file-cursor-parity.integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach, mock } from "bun:test";
 import { createMockFilesystem } from "../../src/utils/test-utils/filesystem/mock-filesystem";
 import { CODE_TEST_PATTERNS } from "../../src/utils/test-utils/test-constants";
+import { first } from "../../src/utils/array-safety";
 
 // Configuration system imports
 import {
@@ -139,7 +140,7 @@ async function loggingApplyEditPattern(
     let model: string | undefined;
 
     if (fastApplyProviders.length > 0) {
-      provider = fastApplyProviders[0]!; // Use the first available fast-apply provider
+      provider = first(fastApplyProviders); // Use the first available fast-apply provider
       model = aiConfig.providers[provider]?.model;
       console.log(`   Using fast-apply provider: ${provider} with model: ${model}`);
     } else {
@@ -152,7 +153,7 @@ async function loggingApplyEditPattern(
         throw new Error("No enabled AI providers found for edit operations");
       }
 
-      provider = enabledProviders[0]!;
+      provider = first(enabledProviders);
       model = aiConfig.providers[provider]?.model;
       console.log(`   Using fallback provider: ${provider} with model: ${model}`);
     }

--- a/tests/unit/domain/changeset/local-git-adapter.test.ts
+++ b/tests/unit/domain/changeset/local-git-adapter.test.ts
@@ -10,6 +10,7 @@ import {
   type LocalGitAdapterDeps,
 } from "../../../../src/domain/changeset/adapters/local-git-adapter";
 import type { Changeset, ChangesetListOptions } from "../../../../src/domain/changeset/types";
+import { first, elementAt } from "../../../../src/utils/array-safety";
 
 // Mock execSync via DI
 const mockExecSync = mock((command: string) => {
@@ -70,9 +71,9 @@ describe("LocalGitChangesetAdapter", () => {
     const changesets = await adapter.list();
 
     expect(changesets).toHaveLength(2);
-    expect(changesets[0]!.id).toBe("pr/test-session");
-    expect(changesets[1]!.id).toBe("pr/feature-123");
-    expect(changesets[0]!.platform).toBe("local-git");
+    expect(first(changesets).id).toBe("pr/test-session");
+    expect(elementAt(changesets, 1).id).toBe("pr/feature-123");
+    expect(first(changesets).platform).toBe("local-git");
   });
 
   test("filters changesets by status", async () => {
@@ -155,10 +156,11 @@ describe("LocalGitChangesetAdapter", () => {
     const changeset = await adapter.get("pr/test-session");
 
     expect(changeset?.commits).toHaveLength(1);
-    expect(changeset?.commits[0]!.sha).toBe("abc123");
-    expect(changeset?.commits[0]!.message).toBe("feat: test commit");
-    expect(changeset?.commits[0]!.author.username).toBe("testuser");
-    expect(changeset?.commits[0]!.filesChanged).toContain("src/test.ts");
+    const firstCommit = changeset?.commits ? first(changeset.commits) : undefined;
+    expect(firstCommit?.sha).toBe("abc123");
+    expect(firstCommit?.message).toBe("feat: test commit");
+    expect(firstCommit?.author.username).toBe("testuser");
+    expect(firstCommit?.filesChanged).toContain("src/test.ts");
   });
 
   test("reports correct feature support", () => {

--- a/tests/utils/result-handling/filters.test.ts
+++ b/tests/utils/result-handling/filters.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { first } from "../../../src/utils/array-safety";
 import {
   parseStatusFilter,
   parseBackendFilter,
@@ -75,7 +76,7 @@ describe("result-handling/filters: filterByBackend", () => {
     ];
     const res = filterByBackend(items, "github");
     expect(res).toHaveLength(1);
-    expect(res[0]!.backendType).toBe("github");
+    expect(first(res).backendType).toBe("github");
   });
 });
 
@@ -91,6 +92,6 @@ describe("result-handling/filters: filterByTimeRange", () => {
     const until = now - 10 * 60000; // 10m ago
     const res = filterByTimeRange(items, since, until);
     expect(res).toHaveLength(1);
-    expect(res[0]!.updatedAt).toBeDefined();
+    expect(first(res).updatedAt).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Replaced all 33 `[N]!` non-null assertion patterns in `tests/` with `first()`, `elementAt()`, and `firstMatch()` from `src/utils/array-safety.ts`
- Fixed 2 `.pop()!` patterns in `src/domain/configuration/config-writer.ts` (`setNestedValue` and `unsetNestedValue`) with safe guard-and-throw alternatives
- Added appropriate imports for `first`, `elementAt`, and `firstMatch` in each affected test file

## Files changed

- `tests/unit/domain/changeset/local-git-adapter.test.ts` — 7 patterns
- `tests/integration/mock-session-edit-tools.ts` — 3 patterns (including regex capture group)
- `tests/integration/session-edit-file-cursor-parity.integration.test.ts` — 2 patterns
- `tests/utils/result-handling/filters.test.ts` — 2 patterns
- `tests/adapters/cli/session-remaining.test.ts` — 1 regex match pattern
- `tests/domain/tasks/task-routing-service.test.ts` — 2 patterns
- `tests/domain/similarity/task-search-filtering.test.ts` — 4 patterns
- `tests/domain/storage/vector/sql-generation-proof.test.ts` — 5 patterns
- `tests/domain/storage/vector/server-side-filtering.test.ts` — 5 patterns
- `src/domain/configuration/config-writer.ts` — 2 `.pop()!` patterns

## Verification

Zero remaining `[N]!` patterns in `tests/` or `src/` (excluding `array-safety.ts` itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude implement mt#710)