### PR TITLE
feat(mt#668): Add lint and typecheck MCP tools for on-demand validation

### DIFF
--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -299,6 +299,19 @@ export function registerDebugCommandsWithMcp(
 }
 
 /**
+ * Register tools commands with MCP (includes validate.lint, validate.typecheck, and other TOOLS-category commands)
+ */
+export function registerToolsCommandsWithMcp(
+  commandMapper: CommandMapper,
+  config: Omit<McpSharedCommandConfig, "categories"> = {}
+): void {
+  registerSharedCommandsWithMcp(commandMapper, {
+    categories: [CommandCategory.TOOLS],
+    ...config,
+  });
+}
+
+/**
  * Register persistence commands with MCP
  */
 export function registerPersistenceCommandsWithMcp(

--- a/src/adapters/mcp/validate.ts
+++ b/src/adapters/mcp/validate.ts
@@ -1,0 +1,21 @@
+/**
+ * MCP adapter for validate commands (lint and typecheck)
+ */
+import type { CommandMapper } from "../../mcp/command-mapper";
+import { registerToolsCommandsWithMcp } from "./shared-command-integration";
+
+/**
+ * Registers validate tools (lint, typecheck) with the MCP command mapper
+ */
+export function registerValidateTools(commandMapper: CommandMapper): void {
+  registerToolsCommandsWithMcp(commandMapper, {
+    commandOverrides: {
+      "validate.lint": {
+        description: "Run ESLint and return structured results",
+      },
+      "validate.typecheck": {
+        description: "Run TypeScript type checker and return structured results",
+      },
+    },
+  });
+}

--- a/src/adapters/shared/commands/index.ts
+++ b/src/adapters/shared/commands/index.ts
@@ -16,6 +16,7 @@ import { registerPersistenceCommands } from "./persistence";
 import { registerAiCommands } from "./ai";
 import { registerToolsCommands } from "./tools";
 import { registerChangesetCommands } from "./changeset";
+import { registerValidateCommands } from "./validate";
 
 /**
  * Register all shared commands in the shared command registry
@@ -54,6 +55,9 @@ export async function registerAllSharedCommands(): Promise<void> {
   // Register changeset commands
   registerChangesetCommands();
 
+  // Register validate commands (lint and typecheck)
+  registerValidateCommands();
+
   // Additional command categories can be registered here as they're implemented
 }
 
@@ -71,4 +75,5 @@ export {
   registerAiCommands,
   registerToolsCommands,
   registerChangesetCommands,
+  registerValidateCommands,
 };

--- a/src/adapters/shared/commands/validate.ts
+++ b/src/adapters/shared/commands/validate.ts
@@ -1,0 +1,186 @@
+/**
+ * Shared Validate Commands
+ *
+ * This module contains shared validation command implementations (lint, typecheck)
+ * that can be registered in the shared command registry and exposed through
+ * multiple interfaces (CLI, MCP).
+ */
+
+import { z } from "zod";
+import { sharedCommandRegistry, CommandCategory, defineCommand } from "../command-registry";
+
+const workspaceParam = {
+  workspace: {
+    schema: z.string(),
+    description: "Workspace directory to run validation in (defaults to current working directory)",
+    required: false,
+    defaultValue: process.cwd(),
+  },
+};
+
+/**
+ * Result type for validate.lint command
+ */
+interface LintResult {
+  success: boolean;
+  errorCount: number;
+  warningCount: number;
+  fileCount: number;
+  ruleBreakdown: Record<string, number>;
+  status: "pass" | "fail";
+}
+
+/**
+ * Result type for validate.typecheck command
+ */
+interface TypecheckError {
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+  code: string;
+}
+
+interface TypecheckResult {
+  success: boolean;
+  errorCount: number;
+  errors: TypecheckError[];
+  status: "pass" | "fail";
+}
+
+/**
+ * ESLint JSON output file result shape (partial)
+ */
+interface EslintFileResult {
+  filePath: string;
+  messages: Array<{
+    ruleId: string | null;
+    severity: number;
+    message: string;
+  }>;
+  errorCount: number;
+  warningCount: number;
+}
+
+/**
+ * Register the validate commands in the shared command registry
+ */
+export function registerValidateCommands(): void {
+  // Register validate.lint command
+  sharedCommandRegistry.registerCommand(
+    defineCommand({
+      id: "validate.lint",
+      category: CommandCategory.TOOLS,
+      name: "lint",
+      description: "Run ESLint and return structured results",
+      parameters: workspaceParam,
+      execute: async (params): Promise<LintResult> => {
+        const workspacePath = (params.workspace as string | undefined) ?? process.cwd();
+
+        const proc = Bun.spawn(["bunx", "eslint", ".", "--format", "json"], {
+          cwd: workspacePath,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const output = await new Response(proc.stdout).text();
+        // Drain stderr to avoid blocking
+        await new Response(proc.stderr).text();
+        await proc.exited;
+
+        // ESLint returns non-zero when issues are found but still outputs JSON on stdout
+        let fileResults: EslintFileResult[] = [];
+        try {
+          fileResults = JSON.parse(output) as EslintFileResult[];
+        } catch {
+          // If JSON parse fails, treat as a fatal error (eslint itself crashed)
+          return {
+            success: false,
+            errorCount: 1,
+            warningCount: 0,
+            fileCount: 0,
+            ruleBreakdown: {},
+            status: "fail",
+          };
+        }
+
+        let totalErrors = 0;
+        let totalWarnings = 0;
+        const ruleBreakdown: Record<string, number> = {};
+
+        for (const fileResult of fileResults) {
+          totalErrors += fileResult.errorCount;
+          totalWarnings += fileResult.warningCount;
+
+          for (const msg of fileResult.messages) {
+            if (msg.ruleId) {
+              ruleBreakdown[msg.ruleId] = (ruleBreakdown[msg.ruleId] ?? 0) + 1;
+            }
+          }
+        }
+
+        const status: "pass" | "fail" = totalErrors === 0 ? "pass" : "fail";
+
+        return {
+          success: totalErrors === 0,
+          errorCount: totalErrors,
+          warningCount: totalWarnings,
+          fileCount: fileResults.length,
+          ruleBreakdown,
+          status,
+        };
+      },
+    })
+  );
+
+  // Register validate.typecheck command
+  sharedCommandRegistry.registerCommand(
+    defineCommand({
+      id: "validate.typecheck",
+      category: CommandCategory.TOOLS,
+      name: "typecheck",
+      description: "Run TypeScript type checker and return structured results",
+      parameters: workspaceParam,
+      execute: async (params): Promise<TypecheckResult> => {
+        const workspacePath = (params.workspace as string | undefined) ?? process.cwd();
+
+        const proc = Bun.spawn(["bunx", "tsc", "--noEmit"], {
+          cwd: workspacePath,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const output = await new Response(proc.stdout).text();
+        // Drain stderr to avoid blocking
+        await new Response(proc.stderr).text();
+        await proc.exited;
+
+        // Parse tsc output lines matching: file(line,col): error TSxxxx: message
+        const errorPattern = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.+)$/;
+        const errors: TypecheckError[] = [];
+
+        for (const line of output.split("\n")) {
+          const match = errorPattern.exec(line.trim());
+          if (match) {
+            errors.push({
+              file: match[1] as string,
+              line: parseInt(match[2] as string, 10),
+              column: parseInt(match[3] as string, 10),
+              code: match[4] as string,
+              message: match[5] as string,
+            });
+          }
+        }
+
+        const status: "pass" | "fail" = errors.length === 0 ? "pass" : "fail";
+
+        return {
+          success: errors.length === 0,
+          errorCount: errors.length,
+          errors,
+          status,
+        };
+      },
+    })
+  );
+}

--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -23,6 +23,7 @@ import { registerChangesetTools } from "../../adapters/mcp/changeset";
 import { registerConfigTools } from "../../adapters/mcp/config";
 import { registerSessionFileTools } from "../../adapters/mcp/session-files";
 import { registerSessionEditTools } from "../../adapters/mcp/session-edit-tools";
+import { registerValidateTools } from "../../adapters/mcp/validate";
 
 const DEFAULT_HTTP_PORT = 3000;
 const DEFAULT_HTTP_HOST = "localhost";
@@ -56,6 +57,7 @@ function registerAllTools(commandMapper: CommandMapper): void {
   registerRulesTools(commandMapper);
   registerConfigTools(commandMapper);
   registerChangesetTools(commandMapper);
+  registerValidateTools(commandMapper);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `validate.lint` MCP tool: runs `bunx eslint . --format json` in the specified workspace and returns structured results (errorCount, warningCount, fileCount, ruleBreakdown, status)
- Adds `validate.typecheck` MCP tool: runs `bunx tsc --noEmit` and returns parsed structured errors (errorCount, errors[], status)
- Follows the existing shared command registry pattern exactly (same as debug/config/changeset commands)
- Both tools take an optional `workspace` parameter defaulting to `process.cwd()`

## Files Changed

- `src/adapters/shared/commands/validate.ts` (new): command implementations using `Bun.spawn`
- `src/adapters/mcp/validate.ts` (new): MCP adapter exporting `registerValidateTools`
- `src/adapters/mcp/shared-command-integration.ts`: adds `registerToolsCommandsWithMcp` helper
- `src/adapters/shared/commands/index.ts`: calls `registerValidateCommands()` at startup
- `src/commands/mcp/start-command.ts`: calls `registerValidateTools(commandMapper)` in `registerAllTools`

## Test plan

- [ ] Start MCP server and call `validate.lint` against the minsky repo — should return JSON with errorCount, warningCount, ruleBreakdown, status
- [ ] Call `validate.typecheck` — should return JSON with errorCount=0, errors=[], status="pass" on a clean build
- [ ] Call with explicit `workspace` path to verify the parameter is respected

## Coherence Verification

**Files re-read**: 
- `/src/adapters/shared/commands/validate.ts`
- `/src/adapters/mcp/validate.ts`
- `/src/adapters/mcp/shared-command-integration.ts`
- `/src/adapters/shared/commands/index.ts`
- `/src/commands/mcp/start-command.ts`

**Q1 single purpose**: pass — each file has a clear single responsibility; validate.ts implements the two commands, mcp/validate.ts is the thin adapter, shared-command-integration.ts gains one new category helper

**Q2 comment honesty**: pass — all comments accurately describe the code; the TOOLS category note in registerToolsCommandsWithMcp docstring correctly explains it covers all TOOLS-category commands

**Q3 naming honesty**: pass — validate.ts named correctly; registerValidateTools / registerValidateCommands names match their purpose

**Q4 redundant siblings**: pass — no parallel implementations; the shared command + MCP adapter pair is the established pattern

**Q5 dead exports**: pass — registerValidateCommands is imported and called in index.ts; registerValidateTools is imported and called in start-command.ts; registerToolsCommandsWithMcp is imported and called in mcp/validate.ts. Verified via grep showing all 10 reference sites.

**Q6 orphan code**: pass — no orphan code; the workspaceParam is used by both commands in the same file

**Q7 stray artifacts**: pass — no backup or tmp files created

**Items fixed in this PR (beyond original scope)**: TypeScript strict-mode fix: regex match group access typed as `string | undefined` required explicit `as string` casts in the typecheck parser
**Items deferred**: none

🤖 Generated with Claude Code (had Claude implement this task)