### PR TITLE
docs(mt#716): add subagent capacity management guidance

### DIFF
--- a/.claude/agents/refactor.md
+++ b/.claude/agents/refactor.md
@@ -71,6 +71,15 @@ Your final summary MUST include this structured section, not buried in prose:
 - _"Tests pass so it's done"_ → tsc and tests pass even when the structure is incoherent. **Fix**: structural coherence is a separate gate from test correctness.
 - _"That's out of scope for this PR"_ → the cleanup directly caused by your change is _in_ scope. Filing follow-up tasks for trivial cleanup is a tax on the next reader.
 
+# Incremental commits — MANDATORY for large changes
+
+Subagents have limited capacity (tool call budgets, context windows). If you are cut off mid-work, uncommitted changes are lost. To prevent this:
+
+- **Commit after every cohesive chunk of work** (e.g., after finishing each file or group of related files). Do not wait until all work is done to make a single commit.
+- A good rhythm: read a file, edit it, move to the next. After every 5–8 files, commit what you have with a message like `refactor(mt#XXX): [description] (partial N/M)`.
+- If the task touches more than ~15 files, you are likely approaching capacity. Commit what you have, include a summary of what's done vs remaining in your final output, and let the parent agent launch a follow-up for the rest.
+- **Never hold uncommitted work across more than 10 files.** The risk of losing work to a capacity cutoff outweighs the cleanliness of a single commit.
+
 # Commit and PR
 
-After verification passes, commit using `mcp__minsky__session_commit` and create a PR using `mcp__minsky__session_pr_create` with `type: "refactor"`. Include the full Coherence Verification section in the PR body so reviewers can see what was checked.
+After verification passes (or after committing incrementally), create a PR using `mcp__minsky__session_pr_create` with `type: "refactor"`. Use `mcp__minsky__session_commit` for all commits. Include the full Coherence Verification section in the PR body so reviewers can see what was checked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,15 @@ Prefer specialized subagent types over `general-purpose` when one fits:
 - **`subagent_type: "Plan"`** — Designing implementation plans before coding.
 - **`subagent_type: "general-purpose"`** — Fallback for work that doesn't fit a specialized type.
 
+### Subagent Capacity
+
+Subagents have limited tool-call budgets and context windows. They cannot detect when they're approaching limits and get no cleanup chance when cut off. Uncommitted work is lost.
+
+- **Scope subagent work to fit within capacity.** A subagent touching 15+ files is at risk. For large refactors, split into waves of 8–12 files each.
+- **Instruct subagents to commit incrementally**, not in one final commit. The refactor subagent already has this in its system prompt.
+- **If a subagent returns incomplete work** (changes applied but not committed/PR'd), check the session's `git diff` and `git status`, then finish the commit/PR from the main agent.
+- **For cascading changes** (where editing one file forces changes in its callers), the blast radius is unpredictable. Err on the side of smaller scope and let the cascade determine one wave's natural boundary.
+
 ## Minsky Session Workflow
 
 Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID>/` (branch names follow `task/<backend>-<id>` format). The correct working pattern:


### PR DESCRIPTION
## Summary

Adds subagent capacity management guidance based on research into Claude Code platform limitations and the Wave A incident (mt#690 subagent ran out of turns after 123 tool calls across 22 files).

### Changes

**`.claude/agents/refactor.md`** — New "Incremental commits" section:
- Commit after every 5-8 files, not at the end
- Never hold uncommitted work across more than 10 files
- If touching 15+ files, commit partial progress and report remaining work

**`CLAUDE.md`** — New "Subagent Capacity" subsection:
- Scope to 8-12 files per subagent for large refactors
- Instruct subagents to commit incrementally
- Recovery protocol for incomplete subagent work
- Guidance for cascading changes with unpredictable blast radius

### Research context

Platform limitations (from GitHub Issues):
- #33969: per-turn tool call cap at ~20 (regression from 60-80)
- #29567: no graceful degradation on agent termination
- #34280: partial results preserved for background agents (v2.1.76+)
- #25569: subagent output token limit hardcoded at 32K

Subagents cannot detect approaching limits and get no cleanup chance when cut off. The only defense is committing early and often.

## Test plan
- [x] No code changes — documentation and agent definitions only
- [ ] CI passes

(Had Claude look into this — AI-assisted review)