### PR TITLE
refactor(mt#690): DI threading in domain code (Wave B)

### DIFF
--- a/src/domain/changeset/adapters/github-adapter.ts
+++ b/src/domain/changeset/adapters/github-adapter.ts
@@ -30,10 +30,8 @@ import type {
 import { createRepositoryBackend, RepositoryBackendType } from "../../repository/index";
 import type { RepositoryBackend } from "../../repository/index";
 import { extractGitHubInfoFromUrl } from "../../session/repository-backend-detection";
-import {
-  createSessionProvider as defaultCreateSessionProvider,
-  type SessionProviderInterface,
-} from "../../session/index";
+import { type SessionProviderInterface } from "../../session/index";
+import { getSharedSessionProvider } from "../../session/session-provider-cache";
 import { MinskyError, getErrorMessage } from "../../../errors/index";
 import { log } from "../../../utils/logger";
 import { Octokit } from "@octokit/rest";
@@ -56,11 +54,11 @@ export class GitHubChangesetAdapter implements ChangesetAdapter {
   private owner?: string;
   private repo?: string;
   private sessionProvider: SessionProviderInterface | null = null;
-  private readonly createSessionProvider: typeof defaultCreateSessionProvider;
+  private readonly resolveSessionProvider: () => Promise<SessionProviderInterface>;
 
   private async getSessionProvider(): Promise<SessionProviderInterface> {
     if (!this.sessionProvider) {
-      this.sessionProvider = await this.createSessionProvider();
+      this.sessionProvider = await this.resolveSessionProvider();
     }
     return this.sessionProvider;
   }
@@ -68,14 +66,16 @@ export class GitHubChangesetAdapter implements ChangesetAdapter {
   constructor(
     private repositoryUrl: string,
     private config?: { token?: string; workdir?: string },
-    deps?: { createSessionProvider?: typeof defaultCreateSessionProvider }
+    deps?: { sessionProvider?: SessionProviderInterface }
   ) {
     // Extract GitHub owner/repo from URL
     const githubInfo = extractGitHubInfoFromUrl(repositoryUrl);
     this.owner = githubInfo?.owner;
     this.repo = githubInfo?.repo;
 
-    this.createSessionProvider = deps?.createSessionProvider ?? defaultCreateSessionProvider;
+    this.resolveSessionProvider = deps?.sessionProvider
+      ? () => Promise.resolve(deps.sessionProvider!)
+      : () => getSharedSessionProvider();
 
     // Initialize Octokit
     this.octokit = new Octokit({

--- a/src/domain/changeset/adapters/local-git-adapter.ts
+++ b/src/domain/changeset/adapters/local-git-adapter.ts
@@ -25,10 +25,8 @@ import type {
 
 import { createRepositoryBackend, RepositoryBackendType } from "../../repository/index";
 import type { RepositoryBackend } from "../../repository/index";
-import {
-  createSessionProvider as defaultCreateSessionProvider,
-  type SessionProviderInterface,
-} from "../../session/index";
+import { type SessionProviderInterface } from "../../session/index";
+import { getSharedSessionProvider } from "../../session/session-provider-cache";
 import { MinskyError, getErrorMessage } from "../../../errors/index";
 import { log } from "../../../utils/logger";
 import { execSync as defaultExecSync } from "child_process";
@@ -39,7 +37,7 @@ import { first } from "../../../utils/array-safety";
  */
 export interface LocalGitAdapterDeps {
   execSync?: typeof defaultExecSync;
-  createSessionProvider?: typeof defaultCreateSessionProvider;
+  sessionProvider?: SessionProviderInterface;
 }
 
 /**
@@ -52,11 +50,11 @@ export class LocalGitChangesetAdapter implements ChangesetAdapter {
   private repositoryBackend!: RepositoryBackend;
   private sessionProvider: SessionProviderInterface | null = null;
   private readonly execSync: typeof defaultExecSync;
-  private readonly createSessionProvider: typeof defaultCreateSessionProvider;
+  private readonly resolveSessionProvider: () => Promise<SessionProviderInterface>;
 
   private async getSessionProvider(): Promise<SessionProviderInterface> {
     if (!this.sessionProvider) {
-      this.sessionProvider = await this.createSessionProvider();
+      this.sessionProvider = await this.resolveSessionProvider();
     }
     return this.sessionProvider;
   }
@@ -67,7 +65,9 @@ export class LocalGitChangesetAdapter implements ChangesetAdapter {
     deps?: LocalGitAdapterDeps
   ) {
     this.execSync = deps?.execSync ?? defaultExecSync;
-    this.createSessionProvider = deps?.createSessionProvider ?? defaultCreateSessionProvider;
+    this.resolveSessionProvider = deps?.sessionProvider
+      ? () => Promise.resolve(deps.sessionProvider!)
+      : () => getSharedSessionProvider();
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/domain/context/components/session-context.ts
+++ b/src/domain/context/components/session-context.ts
@@ -6,7 +6,7 @@ import {
 } from "./types";
 // Reuse existing Minsky session utilities
 import { getCurrentSessionContext, isSessionWorkspace } from "../../workspace";
-import { createSessionProvider } from "../../session";
+import { getSharedSessionProvider } from "../../session/session-provider-cache";
 
 interface SessionContextInputs {
   workspacePath: string;
@@ -46,7 +46,7 @@ export const SessionContextComponent: ContextComponent = {
 
       if (isInSession) {
         // Get current session context
-        const sessionDB = await createSessionProvider();
+        const sessionDB = await getSharedSessionProvider();
         const sessionContext = await getCurrentSessionContext(workspacePath, {
           sessionDbOverride: sessionDB,
         });
@@ -57,7 +57,7 @@ export const SessionContextComponent: ContextComponent = {
 
           // Get full session record with additional metadata
           try {
-            const sessionProvider = await createSessionProvider();
+            const sessionProvider = await getSharedSessionProvider();
             const fullSessionRecord = await sessionProvider.getSession(sessionId);
 
             if (fullSessionRecord) {

--- a/src/domain/git/commands/checkout-command.ts
+++ b/src/domain/git/commands/checkout-command.ts
@@ -1,4 +1,4 @@
-import { createSessionProvider } from "../../session";
+import type { SessionProviderInterface } from "../../session/types";
 import { log } from "../../../utils/logger";
 import { createGitService } from "../../git";
 import { execGitWithTimeout } from "../../../utils/git-exec";
@@ -6,14 +6,17 @@ import { execGitWithTimeout } from "../../../utils/git-exec";
 /**
  * Checkout a branch from parameters
  */
-export async function checkoutFromParams(params: {
-  branch: string;
-  session?: string;
-  repo?: string;
-  preview?: boolean;
-  autoResolve?: boolean;
-  conflictStrategy?: string;
-}): Promise<{
+export async function checkoutFromParams(
+  params: {
+    branch: string;
+    session?: string;
+    repo?: string;
+    preview?: boolean;
+    autoResolve?: boolean;
+    conflictStrategy?: string;
+  },
+  deps: { sessionProvider: SessionProviderInterface }
+): Promise<{
   workdir: string;
   switched: boolean;
   conflicts: boolean;
@@ -25,14 +28,13 @@ export async function checkoutFromParams(params: {
   let repoPath = params.repo;
 
   if (params.session && !repoPath) {
-    const sessionProvider = await createSessionProvider();
-    const session = await sessionProvider.getSession(params.session);
+    const session = await deps.sessionProvider.getSession(params.session);
 
     if (!session) {
       throw new Error(`Session not found: ${params.session}`);
     }
 
-    repoPath = await sessionProvider.getSessionWorkdir(params.session);
+    repoPath = await deps.sessionProvider.getSessionWorkdir(params.session);
   }
 
   // Default to current directory if no repo specified

--- a/src/domain/git/commands/commit-command.ts
+++ b/src/domain/git/commands/commit-command.ts
@@ -1,31 +1,33 @@
-import { createSessionProvider } from "../../session";
+import type { SessionProviderInterface } from "../../session/types";
 import { log } from "../../../utils/logger";
 import { createGitService } from "../../git";
 
 /**
  * Commits changes from parameters
  */
-export async function commitChangesFromParams(params: {
-  message: string;
-  session?: string;
-  repo?: string;
-  all?: boolean;
-  amend?: boolean;
-  noStage?: boolean;
-}): Promise<{ commitHash: string; message: string }> {
+export async function commitChangesFromParams(
+  params: {
+    message: string;
+    session?: string;
+    repo?: string;
+    all?: boolean;
+    amend?: boolean;
+    noStage?: boolean;
+  },
+  deps: { sessionProvider: SessionProviderInterface }
+): Promise<{ commitHash: string; message: string }> {
   const gitService = createGitService();
 
   let repoPath = params.repo;
 
   if (params.session && !repoPath) {
-    const sessionProvider = await createSessionProvider();
-    const session = await sessionProvider.getSession(params.session);
+    const session = await deps.sessionProvider.getSession(params.session);
 
     if (!session) {
       throw new Error(`Session not found: ${params.session}`);
     }
 
-    repoPath = await sessionProvider.getSessionWorkdir(params.session);
+    repoPath = await deps.sessionProvider.getSessionWorkdir(params.session);
   }
 
   // Default to current directory if no repo specified

--- a/src/domain/git/commands/merge-command.ts
+++ b/src/domain/git/commands/merge-command.ts
@@ -1,4 +1,4 @@
-import { createSessionProvider } from "../../session";
+import type { SessionProviderInterface } from "../../session/types";
 import { log } from "../../../utils/logger";
 import { createGitService } from "../../git";
 import { EnhancedMergeResult } from "../types";
@@ -6,28 +6,30 @@ import { EnhancedMergeResult } from "../types";
 /**
  * Merge branches from parameters
  */
-export async function mergeFromParams(params: {
-  sourceBranch: string;
-  targetBranch?: string;
-  session?: string;
-  repo?: string;
-  preview?: boolean;
-  autoResolve?: boolean;
-  conflictStrategy?: string;
-}): Promise<EnhancedMergeResult> {
+export async function mergeFromParams(
+  params: {
+    sourceBranch: string;
+    targetBranch?: string;
+    session?: string;
+    repo?: string;
+    preview?: boolean;
+    autoResolve?: boolean;
+    conflictStrategy?: string;
+  },
+  deps: { sessionProvider: SessionProviderInterface }
+): Promise<EnhancedMergeResult> {
   const gitService = createGitService();
 
   let repoPath = params.repo;
 
   if (params.session && !repoPath) {
-    const sessionProvider = await createSessionProvider();
-    const session = await sessionProvider.getSession(params.session);
+    const session = await deps.sessionProvider.getSession(params.session);
 
     if (!session) {
       throw new Error(`Session not found: ${params.session}`);
     }
 
-    repoPath = await sessionProvider.getSessionWorkdir(params.session);
+    repoPath = await deps.sessionProvider.getSessionWorkdir(params.session);
   }
 
   // Default to current directory if no repo specified

--- a/src/domain/git/commands/rebase-command.ts
+++ b/src/domain/git/commands/rebase-command.ts
@@ -1,4 +1,4 @@
-import { createSessionProvider } from "../../session";
+import type { SessionProviderInterface } from "../../session/types";
 import { log } from "../../../utils/logger";
 import { createGitService } from "../../git";
 import { execGitWithTimeout } from "../../../utils/git-exec";
@@ -6,15 +6,18 @@ import { execGitWithTimeout } from "../../../utils/git-exec";
 /**
  * Rebase branches from parameters
  */
-export async function rebaseFromParams(params: {
-  baseBranch: string;
-  featureBranch?: string;
-  session?: string;
-  repo?: string;
-  preview?: boolean;
-  autoResolve?: boolean;
-  conflictStrategy?: string;
-}): Promise<{
+export async function rebaseFromParams(
+  params: {
+    baseBranch: string;
+    featureBranch?: string;
+    session?: string;
+    repo?: string;
+    preview?: boolean;
+    autoResolve?: boolean;
+    conflictStrategy?: string;
+  },
+  deps: { sessionProvider: SessionProviderInterface }
+): Promise<{
   workdir: string;
   rebased: boolean;
   conflicts: boolean;
@@ -30,14 +33,13 @@ export async function rebaseFromParams(params: {
   let repoPath = params.repo;
 
   if (params.session && !repoPath) {
-    const sessionProvider = await createSessionProvider();
-    const session = await sessionProvider.getSession(params.session);
+    const session = await deps.sessionProvider.getSession(params.session);
 
     if (!session) {
       throw new Error(`Session not found: ${params.session}`);
     }
 
-    repoPath = await sessionProvider.getSessionWorkdir(params.session);
+    repoPath = await deps.sessionProvider.getSessionWorkdir(params.session);
   }
 
   // Default to current directory if no repo specified

--- a/src/domain/git/commands/subcommands/checkout-subcommand.ts
+++ b/src/domain/git/commands/subcommands/checkout-subcommand.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
 } from "../../../../adapters/shared/command-registry";
 import { checkoutFromParams } from "../checkout-command";
+import { getSharedSessionProvider } from "../../../session/session-provider-cache";
 import { log } from "../../../../utils/logger";
 import {
   REPO_DESCRIPTION,
@@ -60,14 +61,18 @@ export async function executeCheckoutCommand(
 ): Promise<unknown> {
   const { branch, session, repo, preview, autoResolve, conflictStrategy } = parameters;
 
-  const result = await checkoutFromParams({
-    branch,
-    session,
-    repo,
-    preview,
-    autoResolve,
-    conflictStrategy,
-  });
+  const sessionProvider = await getSharedSessionProvider();
+  const result = await checkoutFromParams(
+    {
+      branch,
+      session,
+      repo,
+      preview,
+      autoResolve,
+      conflictStrategy,
+    },
+    { sessionProvider }
+  );
 
   if (context.debug) {
     log.debug("Checkout command executed successfully", { result });

--- a/src/domain/git/commands/subcommands/commit-subcommand.ts
+++ b/src/domain/git/commands/subcommands/commit-subcommand.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
 } from "../../../../adapters/shared/command-registry";
 import { commitChangesFromParams } from "../commit-command";
+import { getSharedSessionProvider } from "../../../session/session-provider-cache";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -68,14 +69,18 @@ export async function executeCommitCommand(
 ): Promise<{ commitHash: string; message: string }> {
   const { message, all, amend, noStage, repo, session } = context.parameters;
 
-  const result = await commitChangesFromParams({
-    message,
-    session,
-    repo,
-    all,
-    amend,
-    noStage,
-  });
+  const sessionProvider = await getSharedSessionProvider();
+  const result = await commitChangesFromParams(
+    {
+      message,
+      session,
+      repo,
+      all,
+      amend,
+      noStage,
+    },
+    { sessionProvider }
+  );
 
   if (context.debug) {
     log.debug("Commit command executed successfully", { result });

--- a/src/domain/git/commands/subcommands/merge-subcommand.ts
+++ b/src/domain/git/commands/subcommands/merge-subcommand.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
 } from "../../../../adapters/shared/command-registry";
 import { mergeFromParams } from "../merge-command";
+import { getSharedSessionProvider } from "../../../session/session-provider-cache";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -62,15 +63,19 @@ export async function executeMergeCommand(
   const { sourceBranch, targetBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;
 
-  const result = await mergeFromParams({
-    sourceBranch,
-    targetBranch,
-    session,
-    repo,
-    preview,
-    autoResolve,
-    conflictStrategy,
-  });
+  const sessionProvider = await getSharedSessionProvider();
+  const result = await mergeFromParams(
+    {
+      sourceBranch,
+      targetBranch,
+      session,
+      repo,
+      preview,
+      autoResolve,
+      conflictStrategy,
+    },
+    { sessionProvider }
+  );
 
   if (context.debug) {
     log.debug("Merge command executed successfully", { result });

--- a/src/domain/git/commands/subcommands/rebase-subcommand.ts
+++ b/src/domain/git/commands/subcommands/rebase-subcommand.ts
@@ -4,6 +4,7 @@ import {
   type CommandExecutionContext,
 } from "../../../../adapters/shared/command-registry";
 import { rebaseFromParams } from "../rebase-command";
+import { getSharedSessionProvider } from "../../../session/session-provider-cache";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -62,15 +63,19 @@ export async function executeRebaseCommand(
   const { baseBranch, featureBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;
 
-  const result = await rebaseFromParams({
-    baseBranch,
-    featureBranch,
-    session,
-    repo,
-    preview,
-    autoResolve,
-    conflictStrategy,
-  });
+  const sessionProvider = await getSharedSessionProvider();
+  const result = await rebaseFromParams(
+    {
+      baseBranch,
+      featureBranch,
+      session,
+      repo,
+      preview,
+      autoResolve,
+      conflictStrategy,
+    },
+    { sessionProvider }
+  );
 
   if (context.debug) {
     log.debug("Rebase command executed successfully", { result });

--- a/src/domain/session/commands/subcommands/pr-subcommand.ts
+++ b/src/domain/session/commands/subcommands/pr-subcommand.ts
@@ -1,6 +1,6 @@
 import { CommandExecutionHandler } from "../../../../adapters/shared/command-registry";
 import { sessionPr } from "../pr-command";
-import { createSessionProvider } from "../../session-db-adapter";
+import { getSharedSessionProvider } from "../../session-provider-cache";
 import { createGitService } from "../../../git";
 
 export const prSessionSubcommand: CommandExecutionHandler = async (params) => {
@@ -14,7 +14,7 @@ export const prSessionSubcommand: CommandExecutionHandler = async (params) => {
   const noStatusUpdate = options?.["no-status-update"] === true;
 
   try {
-    const sessionDB = await createSessionProvider();
+    const sessionDB = await getSharedSessionProvider();
     const gitService = createGitService();
     const prDescription = await sessionPr(
       {

--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -103,10 +103,10 @@ export async function pureSessionApprove(params: SessionApproveParams): Promise<
   log.debug("Pure session approve command", { session: params.session });
 
   const { approveSessionPr } = await import("./session-approval-operations.js");
-  const { createSessionProvider } = await import("./session-db-adapter.js");
+  const { getSharedSessionProvider } = await import("./session-provider-cache.js");
 
   try {
-    const sessionDB = await createSessionProvider();
+    const sessionDB = await getSharedSessionProvider();
     const result = await approveSessionPr(
       {
         session: params.session,
@@ -165,9 +165,9 @@ export async function sessionCommit(params: {
   });
 
   // Enforce merged-PR-freeze invariant
-  const { createSessionProvider } = await import("./session-db-adapter.js");
+  const { getSharedSessionProvider } = await import("./session-provider-cache.js");
   const { assertSessionMutable } = await import("./session-mutability.js");
-  const sessionDBForFreeze = await createSessionProvider();
+  const sessionDBForFreeze = await getSharedSessionProvider();
   const sessionRecordForFreeze = await sessionDBForFreeze.getSession(params.session);
   if (sessionRecordForFreeze) {
     assertSessionMutable(sessionRecordForFreeze, "commit changes");

--- a/src/domain/session/session-conflicts-operations.ts
+++ b/src/domain/session/session-conflicts-operations.ts
@@ -7,7 +7,7 @@
 
 import { analyzeConflictRegions } from "../git/conflict-analysis-operations";
 import { getCurrentSessionContext } from "../workspace";
-import { createSessionProvider } from "./session-db-adapter";
+import { getSharedSessionProvider } from "./session-provider-cache";
 import { getSessionDirFromParams } from "../session";
 import { getCurrentWorkingDirectory } from "../../utils/process";
 import { execAsync } from "../../utils/exec";
@@ -84,7 +84,7 @@ export async function scanSessionConflicts(
     } else {
       // Auto-detect current session from working directory
       const cwd = getCurrentWorkingDirectory();
-      const sessionDB = await createSessionProvider();
+      const sessionDB = await getSharedSessionProvider();
       const context = await getCurrentSessionContext(cwd, { sessionDbOverride: sessionDB });
 
       if (!context) {

--- a/src/domain/tasks/operations/base-task-operation.ts
+++ b/src/domain/tasks/operations/base-task-operation.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 import type { Task } from "../types";
 import { resolveRepoPath } from "../../repo-utils";
 import { resolveMainWorkspacePath } from "../../workspace";
-import { createSessionProvider } from "../../session";
+import { getSharedSessionProvider } from "../../session/session-provider-cache";
 import { ValidationError, ResourceNotFoundError } from "../../../errors/index";
 // normalizeTaskId removed: strict qualified IDs expected upstream
 import {
@@ -34,7 +34,7 @@ export interface TaskOperationDependencies {
  * Note: This is a composition boundary — sessionProvider is created here.
  */
 export async function createDefaultTaskOperationDependencies(): Promise<TaskOperationDependencies> {
-  const sessionDB = await createSessionProvider();
+  const sessionDB = await getSharedSessionProvider();
   return {
     resolveRepoPath: (options) => resolveRepoPath(options, { sessionProvider: sessionDB }),
     resolveMainWorkspacePath: () => resolveMainWorkspacePath(sessionDB),

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -4,7 +4,7 @@
  */
 import { z } from "zod";
 import { resolveRepoPath as resolveRepoPathBase } from "../repo-utils";
-import { createSessionProvider } from "../session";
+import { getSharedSessionProvider } from "../session/session-provider-cache";
 import { getErrorMessage } from "../../errors/index";
 import { log } from "../../utils/logger";
 import {
@@ -24,7 +24,7 @@ import { first } from "../../utils/array-safety";
  * This is a composition boundary — domain functions above should receive deps injected.
  */
 async function resolveRepoPath(options: { repo?: string; session?: string }): Promise<string> {
-  const sessionProvider = await createSessionProvider();
+  const sessionProvider = await getSharedSessionProvider();
   return resolveRepoPathBase(options, { sessionProvider });
 }
 

--- a/src/utils/repo.ts
+++ b/src/utils/repo.ts
@@ -1,5 +1,5 @@
 import { resolveRepoPath as resolveRepoPathInternal } from "../domain/repo-utils";
-import { createSessionProvider } from "../domain/session";
+import { getSharedSessionProvider } from "../domain/session/session-provider-cache";
 
 export interface RepoResolutionOptions {
   session?: string;
@@ -10,9 +10,9 @@ export interface RepoResolutionOptions {
  * Resolve the repository path from session or explicit path
  * If neither is provided, attempt to determine from current directory
  *
- * Note: This is a composition boundary — creates a sessionProvider for the domain function.
+ * Note: This is a composition boundary — uses the shared session provider cache.
  */
 export async function resolveRepoPath(options: RepoResolutionOptions = {}): Promise<string> {
-  const sessionProvider = await createSessionProvider();
+  const sessionProvider = await getSharedSessionProvider();
   return resolveRepoPathInternal(options, { sessionProvider });
 }

--- a/tests/unit/domain/changeset/local-git-adapter.test.ts
+++ b/tests/unit/domain/changeset/local-git-adapter.test.ts
@@ -35,24 +35,22 @@ const mockExecSync = mock((command: string) => {
   return "";
 });
 
-// Mock createSessionProvider via DI
-const mockCreateSessionProvider = () =>
-  Promise.resolve({
-    getSession: mock((sessionId: string) => {
-      if (sessionId === "test-session") {
-        return Promise.resolve({
-          session: sessionId,
-          taskId: "mt#123",
-        });
-      }
-      return Promise.resolve(null);
-    }),
-  });
+// Mock sessionProvider via DI
+const mockSessionProvider = {
+  getSession: mock((sessionId: string) => {
+    if (sessionId === "test-session") {
+      return Promise.resolve({
+        session: sessionId,
+        taskId: "mt#123",
+      });
+    }
+    return Promise.resolve(null);
+  }),
+};
 
 const mockDeps: LocalGitAdapterDeps = {
   execSync: mockExecSync as unknown as LocalGitAdapterDeps["execSync"],
-  createSessionProvider:
-    mockCreateSessionProvider as unknown as LocalGitAdapterDeps["createSessionProvider"],
+  sessionProvider: mockSessionProvider as unknown as LocalGitAdapterDeps["sessionProvider"],
 };
 
 describe("LocalGitChangesetAdapter", () => {


### PR DESCRIPTION
## Summary

Eliminates 15 `createSessionProvider()` singleton calls across domain code, replacing them with injected dependencies or the shared session provider cache (`getSharedSessionProvider()`).

### Changes by group

**Git commands (4 files):** `checkout-command.ts`, `commit-command.ts`, `merge-command.ts`, `rebase-command.ts` — added `deps: { sessionProvider: SessionProviderInterface }` as a required second parameter. Their callers (subcommand files) now obtain the provider from `getSharedSessionProvider()`.

**Session internals (3 files):** `pr-subcommand.ts`, `session-commands.ts` (2 calls), `session-conflicts-operations.ts` — replaced `createSessionProvider()` with `getSharedSessionProvider()`.

**Changeset adapters (2 files):** `github-adapter.ts`, `local-git-adapter.ts` — replaced the `createSessionProvider` factory pattern with `getSharedSessionProvider()` default and optional injected `sessionProvider` for testing.

**Context/tasks/utils (4 files):** `session-context.ts`, `base-task-operation.ts`, `taskCommands.ts`, `utils/repo.ts` — replaced `createSessionProvider()` with `getSharedSessionProvider()`.

### Preserved

- `session-service.ts:73` — legitimate composition root, untouched.

## Coherence Verification

**Files re-read**: All 15 modified files re-read end-to-end after changes.

**Q1 single purpose**: pass
**Q2 comment honesty**: pass — `utils/repo.ts` comment updated to reflect shared cache usage
**Q3 naming honesty**: pass
**Q4 redundant siblings**: pass
**Q5 dead exports**: pass — `createSessionProvider` still exported from `session/index.ts` for legitimate callers (session-service.ts, session-provider-cache.ts, session.ts)
**Q6 orphan code**: pass — no orphaned helpers or types from the removed calls
**Q7 stray artifacts**: pass — no .backup/.bak/.old/.tmp files

**Items fixed in this PR (beyond original scope)**: Updated `LocalGitAdapterDeps` interface and test file to match new `sessionProvider` field (was `createSessionProvider`)
**Items deferred (with justification)**: none