### PR TITLE
refactor(mt#690): DI threading for PersistenceService in domain code (Wave C remainder)

### DIFF
--- a/src/domain/persistence/validation-operations.ts
+++ b/src/domain/persistence/validation-operations.ts
@@ -11,7 +11,7 @@ import { getErrorMessage } from "../../errors/index";
 import { log } from "../../utils/logger";
 import { getDefaultSqliteDbPath } from "../../utils/paths";
 import { getEffectivePersistenceConfig } from "../configuration/persistence-config";
-import { PersistenceService } from "./service";
+import type { PersistenceProvider } from "./types";
 import { getPostgresMigrationsStatus } from "./migration-operations";
 
 /**
@@ -93,7 +93,7 @@ export async function validateSqliteBackend(filePath: string | undefined): Promi
 /**
  * Validate PostgreSQL backend
  */
-export async function validatePostgresBackend(): Promise<{
+export async function validatePostgresBackend(persistenceProvider?: PersistenceProvider): Promise<{
   success: boolean;
   details: string;
   issues?: string[];
@@ -129,10 +129,14 @@ export async function validatePostgresBackend(): Promise<{
       `Testing connection to: ${connectionString.replace(/:\/\/[^:]+:[^@]+@/, "://***:***@")}`
     );
 
-    // Basic connection test
-    // Use PersistenceService for connection testing
-    // PersistenceService should already be initialized at CLI startup
-    const provider = PersistenceService.getProvider();
+    // Use injected provider or fall back to PersistenceService singleton
+    let provider: PersistenceProvider;
+    if (persistenceProvider) {
+      provider = persistenceProvider;
+    } else {
+      const { PersistenceService } = await import("./service");
+      provider = PersistenceService.getProvider();
+    }
 
     // Test basic connectivity
     if (provider.getCapabilities().sql) {

--- a/src/domain/rules/rule-similarity-service.ts
+++ b/src/domain/rules/rule-similarity-service.ts
@@ -130,14 +130,19 @@ export class RuleSimilarityService {
 /**
  * Create a configured RuleSimilarityService instance with PersistenceProvider
  */
-export async function createRuleSimilarityService(): Promise<RuleSimilarityService> {
+export async function createRuleSimilarityService(
+  persistenceProvider?: PersistenceProvider
+): Promise<RuleSimilarityService> {
   const workspacePath = await resolveWorkspacePath({});
 
-  // Use PersistenceService instead of direct dependencies
-  const { PersistenceService } = await import("../persistence/service");
-
-  // PersistenceService should already be initialized at application startup
-  const provider = PersistenceService.getProvider();
+  // Use injected provider or fall back to PersistenceService singleton
+  let provider: PersistenceProvider;
+  if (persistenceProvider) {
+    provider = persistenceProvider;
+  } else {
+    const { PersistenceService } = await import("../persistence/service");
+    provider = PersistenceService.getProvider();
+  }
 
   const service = new RuleSimilarityService(provider, workspacePath);
 

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -21,6 +21,7 @@ import type {
 } from "../database-storage";
 import type { SessionRecord, SessionDbState } from "../../session/session-db";
 import { postgresSessions, toPostgresInsert, fromPostgresSelect } from "../schemas/session-schema";
+import type { PersistenceProvider } from "../../persistence/types";
 
 /**
  * PostgreSQL storage configuration
@@ -54,9 +55,11 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
   private sql: ReturnType<typeof postgres> | null = null;
   private drizzle: ReturnType<typeof drizzle> | null = null;
   private readonly connectionString: string;
+  private readonly persistenceProvider?: PersistenceProvider;
 
-  constructor(config: PostgresStorageConfig) {
+  constructor(config: PostgresStorageConfig, persistenceProvider?: PersistenceProvider) {
     this.connectionString = config.connectionString;
+    this.persistenceProvider = persistenceProvider;
   }
 
   /**
@@ -67,11 +70,14 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
       return; // Already initialized
     }
 
-    // Get connection from PersistenceService
-    const { PersistenceService } = await import("../../persistence/service");
-
-    // PersistenceService should already be initialized at application startup
-    const provider = PersistenceService.getProvider();
+    // Use injected provider or fall back to PersistenceService singleton
+    let provider: PersistenceProvider;
+    if (this.persistenceProvider) {
+      provider = this.persistenceProvider;
+    } else {
+      const { PersistenceService } = await import("../../persistence/service");
+      provider = PersistenceService.getProvider();
+    }
 
     const capabilities = provider.getCapabilities();
     if (!capabilities.sql) {

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -63,7 +63,7 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
   }
 
   /**
-   * Initialize connections using PersistenceService
+   * Initialize connections using injected PersistenceProvider or PersistenceService fallback
    */
   private async ensureConnection(): Promise<void> {
     if (this.drizzle && this.sql) {

--- a/src/domain/storage/vector/postgres-vector-storage.ts
+++ b/src/domain/storage/vector/postgres-vector-storage.ts
@@ -29,12 +29,17 @@ export class PostgresVectorStorage implements VectorStorage {
 
   static async fromPersistenceProvider(
     dimension: number,
-    config: PostgresVectorStorageConfig
+    config: PostgresVectorStorageConfig,
+    persistenceProvider?: import("../../persistence/types").PersistenceProvider
   ): Promise<PostgresVectorStorage> {
-    const { PersistenceService } = await import("../../persistence/service");
-
-    // PersistenceService should already be initialized at application startup
-    const provider = PersistenceService.getProvider();
+    // Use injected provider or fall back to PersistenceService singleton
+    let provider: import("../../persistence/types").PersistenceProvider;
+    if (persistenceProvider) {
+      provider = persistenceProvider;
+    } else {
+      const { PersistenceService } = await import("../../persistence/service");
+      provider = PersistenceService.getProvider();
+    }
 
     if (!provider.capabilities.sql || !provider.capabilities.vectorStorage) {
       throw new Error("Current persistence provider does not support SQL or vector storage");

--- a/src/domain/storage/vector/vector-storage-factory.ts
+++ b/src/domain/storage/vector/vector-storage-factory.ts
@@ -7,15 +7,24 @@
 
 import type { VectorStorage } from "./types";
 import { MemoryVectorStorage } from "./memory-vector-storage";
-import { PersistenceService } from "../../persistence/service";
+import type { PersistenceProvider } from "../../persistence/types";
 import { log } from "../../../utils/logger";
 
 /**
  * Create vector storage using persistence provider
  */
-export async function createVectorStorageFromConfig(dimension: number): Promise<VectorStorage> {
-  // Get PersistenceService provider (should already be initialized at application startup)
-  const provider = PersistenceService.getProvider();
+export async function createVectorStorageFromConfig(
+  dimension: number,
+  persistenceProvider?: PersistenceProvider
+): Promise<VectorStorage> {
+  // Use injected provider or fall back to PersistenceService singleton
+  let provider: PersistenceProvider;
+  if (persistenceProvider) {
+    provider = persistenceProvider;
+  } else {
+    const { PersistenceService } = await import("../../persistence/service");
+    provider = PersistenceService.getProvider();
+  }
 
   // Check if provider supports vector storage
   if (!provider.capabilities.vectorStorage) {
@@ -39,12 +48,13 @@ export async function createVectorStorageFromConfig(dimension: number): Promise<
  * Domain-specific convenience that keeps vector storage generic.
  */
 export async function createRulesVectorStorageFromConfig(
-  dimension: number
+  dimension: number,
+  persistenceProvider?: PersistenceProvider
 ): Promise<VectorStorage> {
   // For now, use the same implementation as tasks
   // In the future, this could create a separate vector storage instance
   // with different table/collection names
-  return createVectorStorageFromConfig(dimension);
+  return createVectorStorageFromConfig(dimension, persistenceProvider);
 }
 
 /**
@@ -52,12 +62,13 @@ export async function createRulesVectorStorageFromConfig(
  * Domain-specific convenience for tools embeddings.
  */
 export async function createToolsVectorStorageFromConfig(
-  dimension: number
+  dimension: number,
+  persistenceProvider?: PersistenceProvider
 ): Promise<VectorStorage> {
   // For now, use the same implementation as tasks
   // In the future, this could create a separate vector storage instance
   // with different table/collection names
-  return createVectorStorageFromConfig(dimension);
+  return createVectorStorageFromConfig(dimension, persistenceProvider);
 }
 
 /** Minimal interface for providers that may offer vector storage, avoiding circular dependency */

--- a/src/domain/tasks/github-issues-api.ts
+++ b/src/domain/tasks/github-issues-api.ts
@@ -288,7 +288,8 @@ export async function deleteIssue(
   owner: string,
   repo: string,
   taskId: string,
-  statusLabels: Record<string, string>
+  statusLabels: Record<string, string>,
+  persistenceProvider?: import("../persistence/types").PersistenceProvider
 ): Promise<boolean> {
   try {
     const issueNumber = getTaskIdNumber(taskId);
@@ -298,8 +299,13 @@ export async function deleteIssue(
 
     // Attempt to remove from database
     try {
-      const { PersistenceService } = await import("../persistence/service");
-      const provider = PersistenceService.getProvider();
+      let provider: import("../persistence/types").PersistenceProvider;
+      if (persistenceProvider) {
+        provider = persistenceProvider;
+      } else {
+        const { PersistenceService } = await import("../persistence/service");
+        provider = PersistenceService.getProvider();
+      }
 
       if (provider.capabilities.sql) {
         const db = await provider.getDatabaseConnection?.();

--- a/src/domain/tasks/taskService.ts
+++ b/src/domain/tasks/taskService.ts
@@ -47,6 +47,7 @@ export interface TaskServiceOptions {
 export async function createConfiguredTaskService(options: {
   workspacePath: string;
   backend?: string;
+  persistenceProvider?: import("../persistence/types").PersistenceProvider;
 }): Promise<TaskServiceInterface> {
   // Create task service - handles single or multiple backends based on options
   const service = createTaskService({ workspacePath: options.workspacePath });
@@ -77,12 +78,16 @@ export async function createConfiguredTaskService(options: {
 
       case TaskBackend.MINSKY: {
         try {
-          const { PersistenceService } = await import("../persistence/service");
-
-          // PersistenceService should already be initialized at application startup
-          // Cast to SqlCapablePersistenceProvider to get a typed database connection
-          const persistence =
-            PersistenceService.getProvider() as import("../persistence/types").SqlCapablePersistenceProvider;
+          // Use injected provider or fall back to PersistenceService singleton
+          let persistence: import("../persistence/types").SqlCapablePersistenceProvider;
+          if (options.persistenceProvider) {
+            persistence =
+              options.persistenceProvider as import("../persistence/types").SqlCapablePersistenceProvider;
+          } else {
+            const { PersistenceService } = await import("../persistence/service");
+            persistence =
+              PersistenceService.getProvider() as import("../persistence/types").SqlCapablePersistenceProvider;
+          }
           const db = await persistence.getDatabaseConnection?.();
           if (!db) {
             throw new Error(
@@ -115,20 +120,25 @@ export async function createConfiguredTaskService(options: {
   } else {
     // No specific backend requested - register all available backends for multi-backend mode
     try {
-      // Get PersistenceService (should already be initialized at application startup)
-      const { PersistenceService } = await import("../persistence/service");
+      // Use injected provider or fall back to PersistenceService singleton
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- getDatabaseConnection return type varies across provider implementations (PostgreSQL vs SQLite)
       let persistenceProvider: { getDatabaseConnection?: () => Promise<any> } | null = null;
-      try {
-        persistenceProvider = PersistenceService.getProvider();
-        log.debug("PersistenceService available for multi-backend mode");
-      } catch (error) {
-        log.warn(
-          "PersistenceService not available - persistence-dependent backends will be unavailable",
-          {
-            error: getErrorMessage(error),
-          }
-        );
+      if (options.persistenceProvider) {
+        persistenceProvider = options.persistenceProvider;
+        log.debug("Using injected persistence provider for multi-backend mode");
+      } else {
+        try {
+          const { PersistenceService } = await import("../persistence/service");
+          persistenceProvider = PersistenceService.getProvider();
+          log.debug("PersistenceService available for multi-backend mode");
+        } catch (error) {
+          log.warn(
+            "PersistenceService not available - persistence-dependent backends will be unavailable",
+            {
+              error: getErrorMessage(error),
+            }
+          );
+        }
       }
 
       // Add GitHub backend (gh# prefix) - requires GitHub configuration

--- a/src/domain/tasks/tasks-importer-service.ts
+++ b/src/domain/tasks/tasks-importer-service.ts
@@ -2,6 +2,7 @@ import { readTextFile } from "../../utils/fs";
 import { getTasksFilePath, getTaskSpecFilePath } from "./taskIO";
 import { parseTasksFromMarkdown } from "./taskFunctions";
 import { elementAt } from "../../utils/array-safety";
+import type { PersistenceProvider } from "../persistence/types";
 
 export interface ImportOptions {
   dryRun?: boolean;
@@ -52,7 +53,10 @@ function deriveBackendAndSource(id: string): { backend: string; sourceTaskId: st
 }
 
 export class TasksImporterService {
-  constructor(private readonly workspacePath: string) {}
+  constructor(
+    private readonly workspacePath: string,
+    private readonly persistenceProvider?: PersistenceProvider
+  ) {}
 
   async importMarkdownToDb(options: ImportOptions = {}): Promise<ImportResult> {
     const { dryRun = true, limit, filterStatus } = options;
@@ -73,11 +77,14 @@ export class TasksImporterService {
       taskList = taskList.slice(0, limit);
     }
 
-    // Get connection from PersistenceService
-    const { PersistenceService } = await import("../persistence/service");
-
-    // PersistenceService should already be initialized at application startup
-    const provider = PersistenceService.getProvider();
+    // Use injected provider or fall back to PersistenceService singleton
+    let provider: PersistenceProvider;
+    if (this.persistenceProvider) {
+      provider = this.persistenceProvider;
+    } else {
+      const { PersistenceService } = await import("../persistence/service");
+      provider = PersistenceService.getProvider();
+    }
 
     if (!provider.capabilities.sql) {
       throw new Error("Current persistence provider does not support SQL operations");


### PR DESCRIPTION
## Summary

Replaces 9 `PersistenceService.getProvider()` calls in domain code with injected `persistenceProvider` parameters. All changes are backward compatible — when no provider is injected, the functions fall back to the existing `PersistenceService.getProvider()` singleton.

### Domain tasks (Group 1 — 4 calls in 3 files)
- `taskService.ts`: Added `persistenceProvider?` to `createConfiguredTaskService()` options, used in both single-backend (MINSKY case) and multi-backend paths
- `tasks-importer-service.ts`: Added `persistenceProvider?` to `TasksImporterService` constructor
- `github-issues-api.ts`: Added `persistenceProvider?` parameter to `deleteIssue()`

### Domain storage + persistence/rules (Group 2 — 5 calls in 4 files)
- `postgres-storage.ts`: Added `persistenceProvider?` to `PostgresStorage` constructor, used in `ensureConnection()`
- `postgres-vector-storage.ts`: Added `persistenceProvider?` to `fromPersistenceProvider()` static method
- `vector-storage-factory.ts`: Added `persistenceProvider?` to `createVectorStorageFromConfig()`, `createRulesVectorStorageFromConfig()`, and `createToolsVectorStorageFromConfig()`
- `validation-operations.ts`: Added `persistenceProvider?` to `validatePostgresBackend()`
- `rule-similarity-service.ts`: Added `persistenceProvider?` to `createRuleSimilarityService()`

## Coherence Verification

**Files re-read**: taskService.ts, tasks-importer-service.ts, github-issues-api.ts, postgres-storage.ts, postgres-vector-storage.ts, vector-storage-factory.ts, validation-operations.ts, rule-similarity-service.ts

**Q1 single purpose**: pass
**Q2 comment honesty**: issue fixed — updated stale "Initialize connections using PersistenceService" comment in postgres-storage.ts
**Q3 naming honesty**: pass
**Q4 redundant siblings**: pass
**Q5 dead exports**: pass — old `import { PersistenceService }` in vector-storage-factory.ts replaced with `import type { PersistenceProvider }`; no dead exports remain
**Q6 orphan code**: pass — no concepts removed, only parameters added
**Q7 stray artifacts**: pass — no .backup/.bak/.old/.tmp files

**Items fixed in this PR (beyond original scope)**: stale comment in postgres-storage.ts
**Items deferred (with justification)**: none

## Test plan
- [ ] `bun run validate-all` passes (pre-commit hooks verify tsc/lint/test)
- [ ] All 9 target callsites now have optional `persistenceProvider` parameter
- [ ] All existing callers continue to work without changes (backward compatible)
- [ ] Remaining `PersistenceService.getProvider()` calls in domain code are only fallbacks inside else-branches, plus the 2 legitimate internal calls in `service.ts`