### PR TITLE
feat(mt#715): make SQLite the default persistence backend

### DIFF
--- a/docs/architecture/sessiondb-multi-backend-architecture.md
+++ b/docs/architecture/sessiondb-multi-backend-architecture.md
@@ -258,7 +258,7 @@ minsky sessiondb migrate to postgres --dry-run
 ### Error Recovery
 
 - **Automatic Retry**: Transient network errors
-- **Graceful Degradation**: Fall back to JSON backend on database failures
+- **Graceful Degradation**: Fall back to SQLite backend on database failures
 - **Data Recovery**: Restore from backups, repair corrupted data
 - **User Guidance**: Clear error messages with resolution steps
 

--- a/src/domain/configuration/sources/defaults.ts
+++ b/src/domain/configuration/sources/defaults.ts
@@ -7,6 +7,7 @@
  */
 
 import type { PartialConfiguration } from "../schemas";
+import { getDefaultSqliteDbPath } from "../../../utils/paths";
 
 /**
  * Application default configuration
@@ -26,7 +27,7 @@ export const defaultConfiguration: PartialConfiguration = {
   persistence: {
     backend: "sqlite",
     sqlite: {
-      dbPath: "~/.local/state/minsky/minsky.db",
+      dbPath: getDefaultSqliteDbPath(),
     },
     postgres: undefined,
   },

--- a/src/domain/persistence/providers/sqlite-provider.ts
+++ b/src/domain/persistence/providers/sqlite-provider.ts
@@ -16,7 +16,8 @@ import { SqliteStorage } from "../../storage/backends/sqlite-storage";
 import type { SqliteStorageConfig } from "../../storage/backends/sqlite-storage";
 import { log } from "../../../utils/logger";
 import { mkdirSync, existsSync } from "fs";
-import { dirname } from "path";
+import { dirname, join } from "path";
+import { homedir } from "os";
 
 /**
  * SQLite persistence provider implementation
@@ -60,7 +61,9 @@ export class SqlitePersistenceProvider extends PersistenceProvider {
         throw new Error("SQLite configuration required for sqlite backend");
       }
 
-      const dbPath = this.config.sqlite.dbPath;
+      const dbPath = this.config.sqlite.dbPath.startsWith("~/")
+        ? join(homedir(), this.config.sqlite.dbPath.slice(2))
+        : this.config.sqlite.dbPath;
       log.debug(`Initializing SQLite persistence provider at ${dbPath}`);
 
       // Ensure directory exists


### PR DESCRIPTION
Makes SQLite the transitional default persistence backend. Fixes path resolution for default SQLite dbPath.