### PR TITLE
refactor(mt#708): Eliminate variable-index [i]! assertions (mt#708)

### DIFF
--- a/src/adapters/shared/commands/tasks/deps-rendering.ts
+++ b/src/adapters/shared/commands/tasks/deps-rendering.ts
@@ -6,6 +6,7 @@ import { TaskGraphService } from "../../../../domain/tasks/task-graph-service";
 import { type TaskServiceInterface } from "../../../../domain/tasks/taskService";
 import { type Task } from "../../../../domain/tasks/types";
 import { getErrorMessage } from "../../../../errors/index";
+import { elementAt } from "../../../../utils/array-safety";
 
 export interface LayoutOptions {
   layout?: string;
@@ -168,7 +169,7 @@ export async function renderDependencyChain(
   void isLastChain;
 
   for (let i = 0; i < chain.length; i++) {
-    const task = chain[i]!;
+    const task = elementAt(chain, i, "renderDependencyChain chain");
     const isLast = i === chain.length - 1;
     const isFirst = i === 0;
 
@@ -194,7 +195,7 @@ export async function renderDependencyChain(
       const otherDependents = task.dependents.filter((depId) => !chain.some((t) => t.id === depId));
 
       for (let j = 0; j < Math.min(otherDependents.length, 2); j++) {
-        const depId = otherDependents[j]!;
+        const depId = elementAt(otherDependents, j, "renderDependencyChain otherDependents");
         try {
           const depTask = await taskService.getTask(depId);
           const depTitle = depTask?.title?.substring(0, 40) || "Unknown";
@@ -306,7 +307,7 @@ export async function generateDependencyGraph(
 
     // Render chains
     for (let chainIndex = 0; chainIndex < chains.length; chainIndex++) {
-      const chain = chains[chainIndex]!;
+      const chain = elementAt(chains, chainIndex, "renderDependencyChains chains");
       const isLastChain = chainIndex === chains.length - 1;
 
       await renderDependencyChain(chain, lines, graphService, taskService, isLastChain);

--- a/src/adapters/shared/commands/tasks/index-embeddings-command.ts
+++ b/src/adapters/shared/commands/tasks/index-embeddings-command.ts
@@ -3,6 +3,7 @@ import type { CommandExecutionContext } from "../../command-registry";
 import { createTaskSimilarityService } from "./similarity-commands";
 import { tasksIndexEmbeddingsParams } from "./task-parameters";
 import { listTasksFromParams, getTaskFromParams } from "../../../../domain/tasks/taskCommands";
+import { elementAt } from "../../../../utils/array-safety";
 
 interface TasksIndexEmbeddingsParams extends BaseTaskParams {
   limit?: number;
@@ -66,7 +67,7 @@ export class TasksIndexEmbeddingsCommand extends BaseTaskCommand<TasksIndexEmbed
       while (true) {
         const idx = i++;
         if (idx >= tasks.length) break;
-        const t = tasks[idx]!;
+        const t = elementAt(tasks, idx, "index-embeddings worker tasks");
         const changed = await service.indexTask(t.id);
         if (!(params.json || ctx.format === "json")) {
           log.cli(`- ${t.id}: ${changed ? "indexed" : "up-to-date (skipped)"}`);

--- a/src/domain/configuration/config-writer.ts
+++ b/src/domain/configuration/config-writer.ts
@@ -15,6 +15,7 @@ import { ConfigSchema } from "./config-schemas";
 import { log } from "../../utils/logger";
 import type { FsLike } from "../interfaces/fs-like";
 import { createRealFs } from "../interfaces/real-fs";
+import { elementAt } from "../../utils/array-safety";
 
 /**
  * Configuration writer options
@@ -448,10 +449,17 @@ ${stringify(config, { indent: 2 })}`;
     const pathToCheck = [...keys];
 
     for (let i = 0; i < pathToCheck.length - 1; i++) {
-      current = current[pathToCheck[i]!] as Record<string, unknown>;
+      current = current[elementAt(pathToCheck, i, "config-writer cleanupEmptyObjects")] as Record<
+        string,
+        unknown
+      >;
     }
 
-    const lastKey = pathToCheck[pathToCheck.length - 1]!;
+    const lastKey = elementAt(
+      pathToCheck,
+      pathToCheck.length - 1,
+      "config-writer cleanupEmptyObjects lastKey"
+    );
     if (
       current[lastKey] &&
       typeof current[lastKey] === "object" &&

--- a/src/domain/configuration/sources/environment.ts
+++ b/src/domain/configuration/sources/environment.ts
@@ -217,7 +217,7 @@ function setConfigValue(config: Record<string, unknown>, path: string, value: st
 
   // Navigate to the parent object
   for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i]!;
+    const part = elementAt(parts, i, "environment setConfigValue parts");
     if (!(part in current)) {
       current[part] = {};
     }
@@ -225,7 +225,7 @@ function setConfigValue(config: Record<string, unknown>, path: string, value: st
   }
 
   // Set the final value with type conversion
-  const finalKey = parts[parts.length - 1]!;
+  const finalKey = elementAt(parts, parts.length - 1, "environment setConfigValue finalKey");
   const fieldType = fieldTypes[path] || "string";
   const convertedValue = typeConverters[fieldType](value);
 

--- a/src/domain/git/prepared-merge-commit-uncommitted-changes.test.ts
+++ b/src/domain/git/prepared-merge-commit-uncommitted-changes.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, test, expect, beforeEach } from "bun:test";
 import { GIT_TEST_PATTERNS } from "../../utils/test-utils/test-constants";
+import { elementAt } from "../../utils/array-safety";
 import {
   createPreparedMergeCommitPR,
   type PreparedMergeCommitOptions,
@@ -39,8 +40,11 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         const stashEntries = gitCommands.filter((cmd) => cmd.command.startsWith("stash push -m"));
         if (stashEntries.length > 0) {
           const stashMessage =
-            stashEntries[stashEntries.length - 1]!.command.match(/"([^"]+)"/)?.[1] ||
-            "prepared-merge";
+            elementAt(
+              stashEntries,
+              stashEntries.length - 1,
+              "stash-list stashEntries"
+            ).command.match(/\"([^\"]+)\"/)?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {
           return { stdout: "", stderr: "" };
@@ -149,8 +153,11 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         const stashEntries = gitCommands.filter((cmd) => cmd.command.startsWith("stash push -m"));
         if (stashEntries.length > 0) {
           const stashMessage =
-            stashEntries[stashEntries.length - 1]!.command.match(/"([^"]+)"/)?.[1] ||
-            "prepared-merge";
+            elementAt(
+              stashEntries,
+              stashEntries.length - 1,
+              "stash-list stashEntries"
+            ).command.match(/\"([^\"]+)\"/)?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {
           return { stdout: "", stderr: "" };
@@ -240,8 +247,11 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         const stashEntries = gitCommands.filter((cmd) => cmd.command.startsWith("stash push -m"));
         if (stashEntries.length > 0) {
           const stashMessage =
-            stashEntries[stashEntries.length - 1]!.command.match(/"([^"]+)"/)?.[1] ||
-            "prepared-merge";
+            elementAt(
+              stashEntries,
+              stashEntries.length - 1,
+              "stash-list stashEntries"
+            ).command.match(/\"([^\"]+)\"/)?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {
           return { stdout: "", stderr: "" };

--- a/src/domain/session/migration-command.test.ts
+++ b/src/domain/session/migration-command.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import type { SessionProviderInterface, SessionRecord } from "./types";
 import { SessionMigrationService } from "./migration-command";
 import { isUuidSessionId } from "../tasks/task-id";
-import { first } from "../../utils/array-safety";
+import { first, elementAt } from "../../utils/array-safety";
 
 // Mock session data for testing
 const createMockSessionData = () => {
@@ -84,7 +84,10 @@ function createMockSessionDB(initialSessions: SessionRecord[] = []): SessionProv
       async (sessionId: string, updates: Partial<Omit<SessionRecord, "session">>) => {
         const sessionIndex = sessions.findIndex((s) => s.session === sessionId);
         if (sessionIndex !== -1) {
-          sessions[sessionIndex] = { ...sessions[sessionIndex]!, ...updates };
+          sessions[sessionIndex] = {
+            ...elementAt(sessions, sessionIndex, "migration-command.test updateSession"),
+            ...updates,
+          };
         }
       }
     ),

--- a/src/domain/session/session-db.ts
+++ b/src/domain/session/session-db.ts
@@ -5,6 +5,7 @@
 
 import { join } from "path";
 import { getMinskyStateDir } from "../../utils/paths";
+import { elementAt } from "../../utils/array-safety";
 
 /**
  * PR commit information
@@ -175,7 +176,10 @@ export function updateSessionFn(
     session?: string;
   };
   const updatedSessions = [...state.sessions];
-  updatedSessions[index] = { ...updatedSessions[index]!, ...safeUpdates } as SessionRecord;
+  updatedSessions[index] = {
+    ...elementAt(updatedSessions, index, "session-db updateSession"),
+    ...safeUpdates,
+  } as SessionRecord;
 
   return {
     ...state,

--- a/src/domain/storage/vector/memory-vector-storage.ts
+++ b/src/domain/storage/vector/memory-vector-storage.ts
@@ -1,4 +1,5 @@
 import type { VectorStorage, SearchResult, SearchOptions } from "./types";
+import { elementAt } from "../../../utils/array-safety";
 
 export class MemoryVectorStorage implements VectorStorage {
   private readonly dimension: number;
@@ -64,7 +65,9 @@ export class MemoryVectorStorage implements VectorStorage {
     const n = Math.min(a.length, b.length);
     let s = 0;
     for (let i = 0; i < n; i++) {
-      const d = a[i]! - b[i]!;
+      const d =
+        elementAt(a, i, "memory-vector-storage l2 a") -
+        elementAt(b, i, "memory-vector-storage l2 b");
       s += d * d;
     }
     return Math.sqrt(s);

--- a/src/domain/tasks/github-issues-api.ts
+++ b/src/domain/tasks/github-issues-api.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from "../../errors/index";
 import type { TaskData } from "../../types/tasks/taskData";
 import type { TaskReadOperationResult, TaskWriteOperationResult } from "../../types/tasks/taskData";
 import type { Task } from "../tasks";
+import { elementAt } from "../../utils/array-safety";
 import {
   getLabelsForTaskStatus,
   buildSpecContentFromIssue,
@@ -65,7 +66,7 @@ export async function fetchTaskSpecData(
 ): Promise<TaskReadOperationResult> {
   try {
     const pathParts = specPath.split("/");
-    const fileName = pathParts[pathParts.length - 1]!;
+    const fileName = elementAt(pathParts, pathParts.length - 1, "github-issues-api specPath parts");
 
     // Only match legitimate task files: {1-4 digit ID}-{title}.md
     const taskIdMatch = fileName.match(/^(\d{1,4})-[^0-9]/);

--- a/src/domain/tasks/multi-backend-service.ts
+++ b/src/domain/tasks/multi-backend-service.ts
@@ -11,6 +11,7 @@ import { promises as fs } from "fs";
 import { getTasksFilePath } from "./taskIO";
 import { parseTasksFromMarkdown, formatTasksToMarkdown } from "./taskFunctions";
 import { log } from "../../utils/logger";
+import { elementAt } from "../../utils/array-safety";
 
 // Multi-backend specific interface - different from the main TaskBackend interface
 export interface MultiBackendTaskBackend {
@@ -232,7 +233,10 @@ export class TaskServiceImpl implements TaskService {
         });
 
         if (index !== -1) {
-          tasks[index] = { ...tasks[index]!, title: updates.title };
+          tasks[index] = {
+            ...elementAt(tasks, index, "multi-backend updateTask"),
+            title: updates.title,
+          };
           const updated = formatTasksToMarkdown(tasks);
           await fs.writeFile(tasksFilePath, updated, "utf-8");
         }

--- a/tests/domain/storage/vector/server-side-filtering.test.ts
+++ b/tests/domain/storage/vector/server-side-filtering.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { first } from "../../../../src/utils/array-safety";
+import { first, elementAt } from "../../../../src/utils/array-safety";
 import { MemoryVectorStorage } from "../../../../src/domain/storage/vector/memory-vector-storage";
 import type { SearchOptions } from "../../../../src/domain/storage/vector/types";
 
@@ -117,7 +117,11 @@ describe("VectorStorage Server-Side Filtering", () => {
 
     // Verify scores are in ascending order (lower score = better match)
     for (let i = 1; i < results.length; i++) {
-      expect(results[i]!.score).toBeGreaterThanOrEqual(results[i - 1]!.score);
+      expect(
+        elementAt(results, i, "server-side-filtering results[i]").score
+      ).toBeGreaterThanOrEqual(
+        elementAt(results, i - 1, "server-side-filtering results[i-1]").score
+      );
     }
   });
 });

--- a/tests/domain/tasks/task-routing-service.test.ts
+++ b/tests/domain/tasks/task-routing-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { first } from "../../../src/utils/array-safety";
+import { first, elementAt } from "../../../src/utils/array-safety";
 import { TaskRoutingService } from "../../../src/domain/tasks/task-routing-service";
 import type { TaskGraphService } from "../../../src/domain/tasks/task-graph-service";
 import type { TaskServiceInterface } from "../../../src/domain/tasks/taskService";
@@ -137,8 +137,11 @@ describe("TaskRoutingService", () => {
 
       // Should be sorted by readiness score descending
       for (let i = 1; i < availableTasks.length; i++) {
-        expect(availableTasks[i - 1]!.readinessScore).toBeGreaterThanOrEqual(
-          availableTasks[i]!.readinessScore
+        expect(
+          elementAt(availableTasks, i - 1, "task-routing-service readinessScore[i-1]")
+            .readinessScore
+        ).toBeGreaterThanOrEqual(
+          elementAt(availableTasks, i, "task-routing-service readinessScore[i]").readinessScore
         );
       }
     });

--- a/tests/utils/test-monitor.ts
+++ b/tests/utils/test-monitor.ts
@@ -4,6 +4,7 @@
  * Provides flaky test detection, performance monitoring, and test categorization
  * to maintain high test quality and reliability.
  */
+import { elementAt } from "../../src/utils/array-safety";
 
 export interface TestExecution {
   testName: string;
@@ -94,7 +95,10 @@ export class TestQualityMonitor {
     // Look for alternating patterns of success/failure
     let transitions = 0;
     for (let i = 1; i < history.length; i++) {
-      if (history[i]!.status !== history[i - 1]!.status) {
+      if (
+        elementAt(history, i, "test-monitor flakiness history[i]").status !==
+        elementAt(history, i - 1, "test-monitor flakiness history[i-1]").status
+      ) {
         transitions++;
       }
     }


### PR DESCRIPTION
## Summary

- Replaced all variable-index `]!` non-null assertions (e.g. `chain[i]!`, `arr[idx]!`, `sessions[sessionIndex]!`) with `elementAt()` from `src/utils/array-safety.ts`
- 13 files modified across `src/` and `tests/` — zero `]!` patterns remain in either tree
- Map/object string-key lookups (e.g. `groups["key"]!`) were intentionally left as-is — those are not array index patterns and are a separate concern

## Files changed

- `src/adapters/shared/commands/tasks/deps-rendering.ts` — `chain[i]!`, `otherDependents[j]!`, `chains[chainIndex]!`
- `src/adapters/shared/commands/tasks/index-embeddings-command.ts` — `tasks[idx]!`
- `src/domain/configuration/config-writer.ts` — `pathToCheck[i]!`, `pathToCheck[...length-1]!`
- `src/domain/configuration/sources/environment.ts` — `parts[i]!`, `parts[...length-1]!`
- `src/domain/git/prepared-merge-commit-uncommitted-changes.test.ts` — `stashEntries[...length-1]!` (3 occurrences)
- `src/domain/session/migration-command.test.ts` — `sessions[sessionIndex]!`
- `src/domain/session/session-db.ts` — `updatedSessions[index]!`
- `src/domain/storage/vector/memory-vector-storage.ts` — `a[i]!`, `b[i]!`
- `src/domain/tasks/github-issues-api.ts` — `pathParts[...length-1]!`
- `src/domain/tasks/multi-backend-service.ts` — `tasks[index]!`
- `tests/domain/storage/vector/server-side-filtering.test.ts` — `results[i]!`, `results[i-1]!`
- `tests/domain/tasks/task-routing-service.test.ts` — `availableTasks[i-1]!`, `availableTasks[i]!`
- `tests/utils/test-monitor.ts` — `history[i]!`, `history[i-1]!`

## Test plan

- [ ] `bun run validate-all` passes (build + lint + tests)
- [ ] `grep -rn '\]!' src/ tests/ --include='*.ts' | grep -v '\[[0-9]\+\]!' | grep -v 'array-safety.ts'` returns 0 results