### PR TITLE
feat(mt#691): ESLint rule to prevent singleton reach-in

### DIFF
--- a/eslint-rules/no-singleton-reach-in.js
+++ b/eslint-rules/no-singleton-reach-in.js
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview ESLint rule to prevent singleton reach-in from non-composition-root files
+ * @author Task #691
+ *
+ * Prevents PersistenceService.getProvider() and createSessionProvider() from being called
+ * outside of explicitly allowlisted composition root files. This enforces the architectural
+ * boundary that only composition roots should wire up singleton providers.
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/**
+ * Convert a glob-style pattern to a regex.
+ * Supports ** (any path segment), * (within a segment), and ? (single char).
+ */
+function globToRegex(pattern) {
+  // Handle ** before * to avoid double-substitution
+  // Split on **, replace *, then rejoin with .*
+  const parts = pattern.replace(/\./g, "\\.").split("**");
+  const withStarReplaced = parts.map((p) => p.replace(/\*/g, "[^/]*").replace(/\?/g, "[^/]"));
+  return new RegExp(withStarReplaced.join(".*"));
+}
+
+export default {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "prevent PersistenceService.getProvider() and createSessionProvider() calls outside composition root files",
+      category: "Architecture",
+      recommended: false,
+    },
+    fixable: null,
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedFiles: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Glob patterns for composition root files where singleton access is permitted",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      singletonReachIn:
+        "'{{call}}' is a singleton reach-in and may only be called from composition root files. " +
+        "Pass the provider via dependency injection instead, or add this file to the allowedFiles list if it is a legitimate composition root.",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const allowedFiles = options.allowedFiles || [];
+
+    const filename = context.getFilename();
+
+    // Normalize path separators for cross-platform compatibility
+    const normalizedFilename = filename.replace(/\\/g, "/");
+
+    // Always skip test files — tests may call singletons to test them directly
+    const isTestFile =
+      /\.(test|spec)\.(js|ts|jsx|tsx)$/.test(normalizedFilename) ||
+      /\/(tests?|__tests__|spec)\//i.test(normalizedFilename);
+
+    if (isTestFile) {
+      return {};
+    }
+
+    // Skip ESLint rule files — they reference these names as string identifiers
+    if (normalizedFilename.includes("/eslint-rules/")) {
+      return {};
+    }
+
+    // Check if the current file matches any of the allowlist patterns
+    const isAllowed = allowedFiles.some((pattern) => {
+      const regex = globToRegex(pattern);
+      return regex.test(normalizedFilename);
+    });
+
+    if (isAllowed) {
+      return {}; // File is a composition root — allow all calls
+    }
+
+    return {
+      CallExpression(node) {
+        // Detect PersistenceService.getProvider()
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.type === "Identifier" &&
+          node.callee.object.name === "PersistenceService" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "getProvider"
+        ) {
+          context.report({
+            node,
+            messageId: "singletonReachIn",
+            data: { call: "PersistenceService.getProvider()" },
+          });
+        }
+
+        // Detect createSessionProvider()
+        if (node.callee.type === "Identifier" && node.callee.name === "createSessionProvider") {
+          context.report({
+            node,
+            messageId: "singletonReachIn",
+            data: { call: "createSessionProvider()" },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ import noUnreliableFactoryMocks from "./eslint-rules/no-unreliable-factory-mocks
 import noCliExecutionInTests from "./eslint-rules/no-cli-execution-in-tests.js";
 import noMagicStringDuplication from "./eslint-rules/no-magic-string-duplication.js";
 import noUnwaitedAsyncFactory from "./eslint-rules/no-unwaited-async-factory.js";
+import noSingletonReachIn from "./eslint-rules/no-singleton-reach-in.js";
 
 export default [
   js.configs.recommended,
@@ -108,6 +109,7 @@ export default [
           "no-cli-execution-in-tests": noCliExecutionInTests,
           "no-magic-string-duplication": noMagicStringDuplication,
           "no-unwaited-async-factory": noUnwaitedAsyncFactory,
+          "no-singleton-reach-in": noSingletonReachIn,
         },
       },
     },
@@ -165,6 +167,50 @@ export default [
           asyncFactoryFunctions: ["createSessionProvider"],
         },
       ], // Prevent unwaited async factory calls that silently assign Promises
+
+      // === SINGLETON ARCHITECTURE ===
+      "custom/no-singleton-reach-in": [
+        "warn",
+        {
+          allowedFiles: [
+            // PersistenceService composition roots
+            "**/src/domain/persistence/service.ts",
+            "**/src/domain/persistence/validation-operations.ts",
+            // Session provider composition roots
+            "**/src/domain/session/session-service.ts",
+            "**/src/domain/session/session-provider-cache.ts",
+            "**/src/domain/session/session-db-adapter.ts",
+            // Domain-level facade files that re-export/wire providers
+            "**/src/domain/session.ts",
+            "**/src/domain/git.ts",
+            // Storage backends that need direct provider access
+            "**/src/domain/storage/backends/postgres-storage.ts",
+            "**/src/domain/storage/vector/vector-storage-factory.ts",
+            "**/src/domain/storage/vector/postgres-vector-storage.ts",
+            // Task domain composition roots
+            "**/src/domain/tasks/tasks-importer-service.ts",
+            "**/src/domain/tasks/taskService.ts",
+            "**/src/domain/tasks/github-issues-api.ts",
+            // Rules domain
+            "**/src/domain/rules/rule-similarity-service.ts",
+            // Adapter-layer composition roots
+            "**/src/adapters/shared/commands/session.ts",
+            "**/src/adapters/shared/commands/tasks-modular.ts",
+            "**/src/adapters/shared/commands/tasks/registry-setup.ts",
+            // CLI task command composition roots
+            "**/src/adapters/cli/tasks/*.ts",
+            // Git subcommand composition roots
+            "**/subcommands/*.ts",
+            // Scripts and one-off tools (composition roots by nature)
+            "**/scripts/*.ts",
+            "**/debug-*.ts",
+            "**/test-*.ts",
+            "**/dependency-backfill-tool.ts",
+            // ESLint rule files (the rules themselves reference these identifiers as strings)
+            "**/eslint-rules/**",
+          ],
+        },
+      ], // Prevent singleton reach-in from non-composition-root files
 
       // === TEST ORGANIZATION ===
       "custom/no-tests-directories": "warn", // Encourage co-located test files over __tests__ directories


### PR DESCRIPTION
## Summary

- Adds new `custom/no-singleton-reach-in` ESLint rule (at warn level) in `eslint-rules/no-singleton-reach-in.js`
- Registers the rule in `eslint.config.js` with a comprehensive allowlist of all legitimate composition root files
- Flags `PersistenceService.getProvider()` and `createSessionProvider()` calls outside allowlisted files
- Test files are unconditionally exempt from the rule
- `bun run lint` shows 0 violations from the new rule

## Allowlisted composition roots

- `src/domain/persistence/service.ts` — PersistenceService internals
- `src/domain/persistence/validation-operations.ts`
- `src/domain/session/session-service.ts` — session composition root
- `src/domain/session/session-provider-cache.ts` — canonical provider cache
- `src/domain/session/session-db-adapter.ts` — DB adapter definition
- `src/domain/session.ts` — domain facade
- `src/domain/git.ts` — git domain
- `src/domain/storage/backends/postgres-storage.ts`
- `src/domain/storage/vector/vector-storage-factory.ts`
- `src/domain/storage/vector/postgres-vector-storage.ts`
- `src/domain/tasks/tasks-importer-service.ts`
- `src/domain/tasks/taskService.ts`
- `src/domain/tasks/github-issues-api.ts`
- `src/domain/rules/rule-similarity-service.ts`
- `src/adapters/shared/commands/session.ts`
- `src/adapters/shared/commands/tasks-modular.ts`
- `src/adapters/shared/commands/tasks/registry-setup.ts`
- `src/adapters/cli/tasks/*.ts` — CLI task command composition roots
- `**/subcommands/*.ts` — git subcommand composition roots
- Scripts, debug scripts, and test utility scripts at root level

## Test plan

- [x] `bun run lint` passes with 0 errors, 0 singleton violations
- [ ] Add a singleton call in a non-allowlisted file and confirm lint warns
- [ ] Promote to "error" level in a follow-up once the pattern is established