### PR TITLE
feat(mt#713): Add git.log and git.search MCP tools

### DIFF
--- a/src/adapters/shared/commands/git.ts
+++ b/src/adapters/shared/commands/git.ts
@@ -594,36 +594,13 @@ export function registerGitCommands(): void {
         let command: string;
 
         if (type === "content") {
-          // Use git grep to search working tree / specific ref
           const args: string[] = ["git", "-C", repoPath, "grep"];
           if (ignoreCase) args.push("-i");
-          args.push("-n"); // show line numbers
-          args.push("--", pattern);
-          if (params!.ref) {
-            // git grep searches working tree by default; to search at a ref, pass ref before --
-            // Rebuild: git grep [opts] <pattern> <ref> -- [path]
-            const grepArgs: string[] = ["git", "-C", repoPath, "grep"];
-            if (ignoreCase) grepArgs.push("-i");
-            grepArgs.push("-n");
-            grepArgs.push(pattern);
-            grepArgs.push(params!.ref);
-            if (params!.path) {
-              grepArgs.push("--", params!.path);
-            }
-            command = grepArgs.join(" ");
-          } else {
-            if (params!.path) args.push("--", params!.path);
-            // Remove the duplicate '--' already added before pattern
-            // Rebuild cleanly for working tree search
-            const cleanArgs: string[] = ["git", "-C", repoPath, "grep"];
-            if (ignoreCase) cleanArgs.push("-i");
-            cleanArgs.push("-n");
-            cleanArgs.push(pattern);
-            if (params!.path) {
-              cleanArgs.push("--", params!.path);
-            }
-            command = cleanArgs.join(" ");
-          }
+          args.push("-n");
+          args.push(pattern);
+          if (params!.ref) args.push(params!.ref);
+          if (params!.path) args.push("--", params!.path);
+          command = args.join(" ");
         } else if (type === "commits") {
           // Pickaxe search: find commits that added/removed the pattern
           const args: string[] = ["git", "-C", repoPath, "log"];
@@ -641,7 +618,7 @@ export function registerGitCommands(): void {
           args.push("--oneline");
           args.push("-p");
           if (ignoreCase) args.push("-i");
-          args.push(`--grep=${pattern}`);
+          args.push(`-G${pattern}`);
           if (params!.ref) args.push(params!.ref);
           if (params!.path) args.push("--", params!.path);
           command = args.join(" ");

--- a/src/adapters/shared/commands/git.ts
+++ b/src/adapters/shared/commands/git.ts
@@ -28,6 +28,7 @@ import {
 import { log } from "../../../utils/logger";
 import { SESSION_DESCRIPTION } from "../../../utils/option-descriptions";
 import { CommonParameters, GitParameters, composeParams } from "../common-parameters";
+import { execAsync } from "../../../utils/exec";
 
 /**
  * Parameters for the commit command
@@ -192,6 +193,105 @@ const rebaseCommandParams = composeParams(
       schema: z.enum(["automatic", "guided", "manual"]),
       description: "Choose conflict resolution strategy",
       required: false,
+    },
+  }
+) satisfies CommandParameterMap;
+
+/**
+ * Parameters for the git log command
+ */
+const logCommandParams = composeParams(
+  {
+    repo: CommonParameters.repo,
+  },
+  {
+    limit: {
+      schema: z.number(),
+      description: "Maximum number of commits to show",
+      required: false,
+      defaultValue: 20,
+    },
+    author: {
+      schema: z.string(),
+      description: "Filter commits by author name or email",
+      required: false,
+    },
+    since: {
+      schema: z.string(),
+      description:
+        "Show commits more recent than a specific date (e.g. '2024-01-01', '1 week ago')",
+      required: false,
+    },
+    until: {
+      schema: z.string(),
+      description: "Show commits older than a specific date",
+      required: false,
+    },
+    path: {
+      schema: z.string(),
+      description: "Filter commits that affect the specified file path",
+      required: false,
+    },
+    grep: {
+      schema: z.string(),
+      description: "Filter commits by message text",
+      required: false,
+    },
+    format: {
+      schema: z.enum(["oneline", "short", "medium", "full"]),
+      description: "Output format: oneline, short, medium, or full",
+      required: false,
+      defaultValue: "oneline",
+    },
+    ref: {
+      schema: z.string(),
+      description: "Branch, tag, or ref to start log from",
+      required: false,
+    },
+  }
+) satisfies CommandParameterMap;
+
+/**
+ * Parameters for the git search command
+ */
+const searchCommandParams = composeParams(
+  {
+    repo: CommonParameters.repo,
+  },
+  {
+    pattern: {
+      schema: z.string().min(1),
+      description: "Search pattern",
+      required: true,
+    },
+    type: {
+      schema: z.enum(["content", "commits", "diff"]),
+      description:
+        "Search type: content (git grep), commits (git log -S pickaxe), or diff (git log -p with grep)",
+      required: false,
+      defaultValue: "content",
+    },
+    path: {
+      schema: z.string(),
+      description: "Restrict search to a specific file path or directory",
+      required: false,
+    },
+    ref: {
+      schema: z.string(),
+      description: "Search at a specific ref (default HEAD for content search)",
+      required: false,
+    },
+    limit: {
+      schema: z.number(),
+      description: "Maximum number of results to return",
+      required: false,
+      defaultValue: 20,
+    },
+    ignoreCase: {
+      schema: z.boolean(),
+      description: "Perform case-insensitive search",
+      required: false,
+      defaultValue: false,
     },
   }
 ) satisfies CommandParameterMap;
@@ -410,6 +510,158 @@ export function registerGitCommands(): void {
         success: true,
         data: result.data,
       };
+    },
+  });
+
+  // Register git log command
+  sharedCommandRegistry.registerCommand({
+    id: "git.log",
+    category: CommandCategory.GIT,
+    name: "log",
+    description: "View commit history with optional filtering",
+    parameters: logCommandParams,
+    execute: async (params, _context) => {
+      log.debug("Executing git.log command", { params });
+
+      const repoPath = params!.repo || process.cwd();
+      const limit = params!.limit ?? 20;
+      const format = params!.format ?? "oneline";
+
+      const args: string[] = ["git", "-C", repoPath, "log"];
+
+      // Format flag
+      if (format === "oneline") {
+        args.push("--oneline");
+      } else {
+        args.push(`--format=${format}`);
+      }
+
+      // Limit
+      args.push(`-n`, String(limit));
+
+      // Optional filters
+      if (params!.author) {
+        args.push(`--author=${params!.author}`);
+      }
+      if (params!.since) {
+        args.push(`--since=${params!.since}`);
+      }
+      if (params!.until) {
+        args.push(`--until=${params!.until}`);
+      }
+      if (params!.grep) {
+        args.push(`--grep=${params!.grep}`);
+      }
+      if (params!.ref) {
+        args.push(params!.ref);
+      }
+      if (params!.path) {
+        args.push("--", params!.path);
+      }
+
+      try {
+        const { stdout } = await execAsync(args.join(" "));
+        return {
+          success: true,
+          output: stdout.trim(),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+
+  // Register git search command
+  sharedCommandRegistry.registerCommand({
+    id: "git.search",
+    category: CommandCategory.GIT,
+    name: "search",
+    description: "Search repository content, commits, or diffs",
+    parameters: searchCommandParams,
+    execute: async (params, _context) => {
+      log.debug("Executing git.search command", { params });
+
+      const repoPath = params!.repo || process.cwd();
+      const pattern = params!.pattern;
+      const type = params!.type ?? "content";
+      const limit = params!.limit ?? 20;
+      const ignoreCase = params!.ignoreCase ?? false;
+
+      try {
+        let command: string;
+
+        if (type === "content") {
+          // Use git grep to search working tree / specific ref
+          const args: string[] = ["git", "-C", repoPath, "grep"];
+          if (ignoreCase) args.push("-i");
+          args.push("-n"); // show line numbers
+          args.push("--", pattern);
+          if (params!.ref) {
+            // git grep searches working tree by default; to search at a ref, pass ref before --
+            // Rebuild: git grep [opts] <pattern> <ref> -- [path]
+            const grepArgs: string[] = ["git", "-C", repoPath, "grep"];
+            if (ignoreCase) grepArgs.push("-i");
+            grepArgs.push("-n");
+            grepArgs.push(pattern);
+            grepArgs.push(params!.ref);
+            if (params!.path) {
+              grepArgs.push("--", params!.path);
+            }
+            command = grepArgs.join(" ");
+          } else {
+            if (params!.path) args.push("--", params!.path);
+            // Remove the duplicate '--' already added before pattern
+            // Rebuild cleanly for working tree search
+            const cleanArgs: string[] = ["git", "-C", repoPath, "grep"];
+            if (ignoreCase) cleanArgs.push("-i");
+            cleanArgs.push("-n");
+            cleanArgs.push(pattern);
+            if (params!.path) {
+              cleanArgs.push("--", params!.path);
+            }
+            command = cleanArgs.join(" ");
+          }
+        } else if (type === "commits") {
+          // Pickaxe search: find commits that added/removed the pattern
+          const args: string[] = ["git", "-C", repoPath, "log"];
+          args.push(`-n`, String(limit));
+          args.push("--oneline");
+          if (ignoreCase) args.push("-i");
+          args.push(`-S${pattern}`);
+          if (params!.ref) args.push(params!.ref);
+          if (params!.path) args.push("--", params!.path);
+          command = args.join(" ");
+        } else {
+          // type === "diff": search in diffs
+          const args: string[] = ["git", "-C", repoPath, "log"];
+          args.push(`-n`, String(limit));
+          args.push("--oneline");
+          args.push("-p");
+          if (ignoreCase) args.push("-i");
+          args.push(`--grep=${pattern}`);
+          if (params!.ref) args.push(params!.ref);
+          if (params!.path) args.push("--", params!.path);
+          command = args.join(" ");
+        }
+
+        const { stdout } = await execAsync(command);
+        return {
+          success: true,
+          output: stdout.trim(),
+        };
+      } catch (error) {
+        // git grep exits with code 1 when no matches found — treat as success with empty output
+        if (error instanceof Error && error.message.includes("exit code 1")) {
+          return { success: true, output: "" };
+        }
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     },
   });
 }


### PR DESCRIPTION
## Summary

- Adds `git.log` command: view commit history with filters for author, date range, file path, message grep, output format (oneline/short/medium/full), and starting ref
- Adds `git.search` command: search repository by content (`git grep`), commit pickaxe (`git log -S`), or diff text (`git log -p --grep`); supports case-insensitive flag and result limit
- Both commands follow the existing pattern in `src/adapters/shared/commands/git.ts` using `composeParams`, `execAsync`, `CommandCategory.GIT`, and are auto-registered in both MCP and CLI adapters

## Test plan

- [x] `bun run validate-all` passes (1515 tests, 0 failures, 0 lint errors)
- [ ] Verify `git.log` and `git.search` MCP tools appear in tool listing
- [ ] Test `git.log` with no params returns last 20 commits in oneline format
- [ ] Test `git.log` with `author`, `since`, `path`, `grep` filters
- [ ] Test `git.search` with `type: "content"` finds pattern in working tree
- [ ] Test `git.search` with `type: "commits"` returns commits touching pattern
- [ ] Test `git.search` with `ignoreCase: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)