### PR TITLE
feat(mt#637): Add dependsOn parameter to tasks_create for inline dependency declaration

### DIFF
--- a/src/adapters/shared/commands/tasks-modular.ts
+++ b/src/adapters/shared/commands/tasks-modular.ts
@@ -49,9 +49,10 @@ export class ModularTasksCommandManager {
 
       // Create command instances to get their parameter definitions
       log.debug("[ModularTasksCommandManager] Creating command instances");
+      const getPersistenceProvider = () => PersistenceService.getProvider();
       const listCommand = createTasksListCommand();
       const getCommand = createTasksGetCommand();
-      const createCommand = createTasksCreateCommand();
+      const createCommand = createTasksCreateCommand(getPersistenceProvider);
       const editCommand = createTasksEditCommand();
       const deleteCommand = createTasksDeleteCommand();
       const specCommand = createTasksSpecCommand();
@@ -63,8 +64,6 @@ export class ModularTasksCommandManager {
       const similarCommand = new TasksSimilarCommand();
       const searchCommand = new TasksSearchCommand();
       const indexEmbeddingsCommand = new TasksIndexEmbeddingsCommand();
-
-      const getPersistenceProvider = () => PersistenceService.getProvider();
       const depsAddCommand = createTasksDepsAddCommand(getPersistenceProvider);
       const depsRmCommand = createTasksDepsRmCommand(getPersistenceProvider);
       const depsListCommand = createTasksDepsListCommand(getPersistenceProvider);

--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -20,6 +20,10 @@ import {
   tasksCreateParams,
   tasksDeleteParams,
 } from "./task-parameters";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { PersistenceProvider } from "../../../../domain/persistence/types";
+import { TaskGraphService } from "../../../../domain/tasks/task-graph-service";
+import { log } from "../../../../utils/logger";
 
 /**
  * Parameters for tasks list command
@@ -50,6 +54,7 @@ interface TasksCreateParams extends BaseTaskParams {
   specPath?: string;
   force?: boolean;
   githubRepo?: string;
+  dependsOn?: string | string[];
 }
 
 /**
@@ -172,6 +177,10 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
   readonly description = "Create a new task";
   readonly parameters = tasksCreateParams;
 
+  constructor(private readonly getPersistenceProvider?: () => PersistenceProvider) {
+    super();
+  }
+
   async execute(params: TasksCreateParams, ctx: CommandExecutionContext) {
     this.debug("Starting tasks.create execution");
 
@@ -206,6 +215,37 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
 
       this.debug("Task created successfully");
 
+      // Handle dependsOn: add dependency edges after task creation
+      const depsAdded: string[] = [];
+      const depsWarnings: string[] = [];
+      if (params.dependsOn) {
+        const deps = Array.isArray(params.dependsOn) ? params.dependsOn : [params.dependsOn];
+        if (this.getPersistenceProvider) {
+          try {
+            const persistence = this.getPersistenceProvider();
+            const db: PostgresJsDatabase = await persistence.getDatabaseConnection?.();
+            const service = new TaskGraphService(db);
+            for (const dep of deps) {
+              try {
+                await service.addDependency(result.id, dep);
+                depsAdded.push(dep);
+              } catch (depErr) {
+                const msg = getErrorMessage(depErr);
+                depsWarnings.push(`Failed to add dependency ${dep}: ${msg}`);
+                log.warn(`[tasks.create] Failed to add dependency ${dep}: ${msg}`);
+              }
+            }
+          } catch (providerErr) {
+            const msg = getErrorMessage(providerErr);
+            depsWarnings.push(`Could not connect to persistence for dependencies: ${msg}`);
+            log.warn(`[tasks.create] Could not connect to persistence for dependencies: ${msg}`);
+          }
+        } else {
+          depsWarnings.push("No persistence provider available; dependencies were not recorded");
+          log.warn("[tasks.create] No persistence provider; skipping dependsOn");
+        }
+      }
+
       // Build success message
       let message = `Task ${result.id} created: "${result.title}"`;
       if (!params.json) {
@@ -217,11 +257,19 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
         }
         message += `\n${chalk.gray("  Title: ")}${result.title}`;
         message += `\n${chalk.gray("  ID: ")}${result.id}`;
+        if (depsAdded.length > 0) {
+          message += `\n${chalk.gray("  Depends on: ")}${depsAdded.join(", ")}`;
+        }
+        for (const warning of depsWarnings) {
+          message += `\n${chalk.yellow(`  ⚠️  ${warning}`)}`;
+        }
       }
 
       return this.formatResult(
         this.createSuccessResult(result.id, message, {
           task: result,
+          ...(depsAdded.length > 0 && { depsAdded }),
+          ...(depsWarnings.length > 0 && { depsWarnings }),
         }),
         params.json
       );
@@ -332,6 +380,8 @@ export const createTasksListCommand = (): TasksListCommand => new TasksListComma
 
 export const createTasksGetCommand = (): TasksGetCommand => new TasksGetCommand();
 
-export const createTasksCreateCommand = (): TasksCreateCommand => new TasksCreateCommand();
+export const createTasksCreateCommand = (
+  getPersistenceProvider?: () => PersistenceProvider
+): TasksCreateCommand => new TasksCreateCommand(getPersistenceProvider);
 
 export const createTasksDeleteCommand = (): TasksDeleteCommand => new TasksDeleteCommand();

--- a/src/adapters/shared/commands/tasks/task-parameters.ts
+++ b/src/adapters/shared/commands/tasks/task-parameters.ts
@@ -57,6 +57,11 @@ export const taskCreationParams = {
       "GitHub repository override in 'owner/repo' format (only for github-issues backend)",
     required: false,
   },
+  dependsOn: {
+    schema: z.union([z.string(), z.array(z.string())]).optional(),
+    description: "Task ID(s) this task depends on (e.g., 'mt#123' or ['mt#123', 'mt#456'])",
+    required: false,
+  },
 };
 
 /**

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -119,6 +119,10 @@ export const taskCreateParamsSchema = z
       .string()
       .optional()
       .describe("Specify task backend (available: github-issues, minsky)"),
+    dependsOn: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe("Task ID(s) this task depends on (e.g., 'mt#123' or ['mt#123', 'mt#456'])"),
   })
   .merge(commonCommandOptionsSchema)
   .refine(


### PR DESCRIPTION
## Summary

- Adds optional `dependsOn` parameter to `tasks_create` accepting a single task ID or array of task IDs
- After the task is created, calls `TaskGraphService.addDependency()` for each dependency
- Dependency creation is best-effort: if the persistence provider is unavailable or a dep fails, a warning is included in the output but task creation still succeeds
- `createTasksCreateCommand` now accepts an optional `getPersistenceProvider` factory; `tasks-modular.ts` passes it during registration

## Changes

- `src/adapters/shared/commands/tasks/task-parameters.ts` — added `dependsOn` to `taskCreationParams`
- `src/schemas/tasks.ts` — added `dependsOn` to `taskCreateParamsSchema`
- `src/adapters/shared/commands/tasks/crud-commands.ts` — added `dependsOn` to `TasksCreateParams`, wired dependency creation logic into `TasksCreateCommand.execute()`, updated factory signature
- `src/adapters/shared/commands/tasks-modular.ts` — moved `getPersistenceProvider` declaration before command constructors, passes it to `createTasksCreateCommand`

## Test plan

- [ ] All 1515 existing tests pass (`bun run validate-all` green)
- [ ] `minsky tasks create --title "..." --description "..." --depends-on mt#123` creates task and adds dependency edge
- [ ] `minsky tasks create ... --depends-on mt#123 --depends-on mt#456` (or array form) adds multiple edges
- [ ] If persistence is unavailable, task is still created and a warning is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)