### PR TITLE
test(mt#712): replace spy anti-patterns with DI-based assertions in git tests

### DIFF
--- a/src/domain/git-service.test.ts
+++ b/src/domain/git-service.test.ts
@@ -3,32 +3,28 @@
  * @migrated Extracted from git.test.ts as part of modularization
  * @enhanced Enhanced with comprehensive method coverage and DI patterns
  */
-import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import { GitService } from "./git";
-import { setupTestMocks } from "../utils/test-utils/mocking";
+import { FakeGitService } from "./git/fake-git-service";
 import { GIT_COMMANDS } from "../utils/test-utils/test-constants";
-
-// Set up automatic mock cleanup
-setupTestMocks();
 
 describe("GitService", () => {
   let gitService: GitService;
+  let fakeGit: FakeGitService;
 
   beforeEach(() => {
-    // Create a fresh GitService instance for each test
+    // Create a fresh GitService instance for real-method tests
     gitService = new GitService("/mock/base/dir");
 
-    // Mock getStatus method to return canned data
-    spyOn(GitService.prototype, "getStatus").mockImplementation(async () => {
-      return {
-        modified: ["file1.ts", "file2.ts"],
-        untracked: ["newfile1.ts", "newfile2.ts"],
-        deleted: ["deletedfile1.ts"],
-      };
+    // Use FakeGitService as the DI-based test double for behavior verification
+    fakeGit = new FakeGitService();
+    fakeGit.getStatus = async () => ({
+      modified: ["file1.ts", "file2.ts"],
+      untracked: ["newfile1.ts", "newfile2.ts"],
+      deleted: ["deletedfile1.ts"],
     });
-
-    // Mock execInRepository to avoid actual git commands
-    spyOn(GitService.prototype, "execInRepository").mockImplementation(async (workdir, command) => {
+    fakeGit.execInRepository = async (_workdir: string, command: string) => {
+      fakeGit.recordedCommands.push({ workdir: _workdir, command });
       if (command === GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD) {
         return "main";
       }
@@ -36,12 +32,7 @@ describe("GitService", () => {
         return "/mock/repo/path";
       }
       return "";
-    });
-  });
-
-  afterEach(() => {
-    // Restore all mocks
-    mock.restore();
+    };
   });
 
   // ========== Basic API Tests ==========
@@ -50,8 +41,8 @@ describe("GitService", () => {
     expect(gitService instanceof GitService).toBe(true);
   });
 
-  test("should get repository status", async () => {
-    const _status = await gitService.getStatus("/mock/repo/path");
+  test("should get repository status via fake", async () => {
+    const _status = await fakeGit.getStatus("/mock/repo/path");
 
     // Verify the returned status object has the expected structure and content
     expect(_status).toEqual({
@@ -62,6 +53,7 @@ describe("GitService", () => {
   });
 
   test("getSessionWorkdir should return the correct path", () => {
+    // Tests real GitService.getSessionWorkdir (not mocked — this tests actual behavior)
     const workdir = gitService.getSessionWorkdir("test-session");
 
     // NEW: Session-ID-based storage - expect session ID in path, not repo name
@@ -70,24 +62,24 @@ describe("GitService", () => {
     // Repository identity no longer part of filesystem path
   });
 
-  test("execInRepository should execute git commands in the specified repository", async () => {
-    const _branch = await gitService.execInRepository(
+  test("execInRepository should execute git commands in the specified repository via fake", async () => {
+    const _branch = await fakeGit.execInRepository(
       "/mock/repo/path",
       GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD
     );
     expect(_branch).toBe("main");
   });
 
-  test("execInRepository should propagate errors", async () => {
-    // Override the mock implementation to simulate an error
-    const execInRepoMock = spyOn(GitService.prototype, "execInRepository").mockImplementation(
-      async (workdir, command) => {
-        throw new Error("Command execution failed");
-      }
+  test("execInRepository should propagate errors via fake", async () => {
+    // Configure fake to throw an error for git commands
+    const errorFake = new FakeGitService();
+    errorFake.setCommandError(
+      GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD,
+      new Error("Command execution failed")
     );
 
     try {
-      await gitService.execInRepository("/mock/repo/path", GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD);
+      await errorFake.execInRepository("/mock/repo/path", GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD);
       // The test should not reach this line
       expect(true).toBe(false);
     } catch (error: unknown) {
@@ -100,7 +92,7 @@ describe("GitService", () => {
   });
 
   test("should use session-ID-based storage in getSessionWorkdir", () => {
-    // NEW: Session-ID-based storage - repository normalization no longer needed for paths
+    // Tests real GitService.getSessionWorkdir (not mocked — this tests actual behavior)
     const workdir1 = gitService.getSessionWorkdir("test-session");
 
     // Path should contain session ID but NOT repository name

--- a/src/domain/git.pr.test.ts
+++ b/src/domain/git.pr.test.ts
@@ -2,8 +2,9 @@
  * Tests for the PR functionality in the git service
  * @migrated Migrated to native Bun patterns
  */
-import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { GitService } from "./git";
+import { GIT_COMMANDS } from "../utils/test-utils/test-constants";
 
 describe("GitService PR Functionality", () => {
   let gitService: GitService;
@@ -11,19 +12,6 @@ describe("GitService PR Functionality", () => {
   beforeEach(() => {
     // Create a fresh GitService instance for each test
     gitService = new GitService("/tmp/mock-base-dir");
-
-    // Directly mock the PR method to avoid complex dependencies
-    spyOn(GitService.prototype, "pr").mockImplementation(async () => {
-      return {
-        markdown:
-          "# Mock PR Description\n\nThis is a mock PR description generated for testing.\n\n## Changes\n\n- Mock change 1\n- Mock change 2\n\n## Testing\n\nTested with mock tests.",
-      };
-    });
-  });
-
-  afterEach(() => {
-    // Restore all mocks
-    mock.restore();
   });
 
   test("isGitHubRepo should identify GitHub URLs correctly", () => {
@@ -31,15 +19,41 @@ describe("GitService PR Functionality", () => {
     expect(gitService instanceof GitService).toBe(true);
   });
 
-  test("should create a PR description", async () => {
-    // Execute the PR functionality with minimum required parameters
-    const result = await gitService.pr({
-      repoPath: "/tmp/mock-repo-path",
-    });
+  test("should create a PR description via prWithDependencies", async () => {
+    // Use prWithDependencies with injected mock deps — no prototype spy needed
+    const mockDeps = {
+      execAsync: mock(async (command: unknown) => {
+        const cmd = command as string;
+        if (cmd.includes("log --oneline")) {
+          return {
+            stdout: "abc123 feat: add new feature\ndef456 fix: bug fix",
+            stderr: "",
+          };
+        }
+        if (cmd.includes(GIT_COMMANDS.DIFF_NAME_ONLY)) {
+          return { stdout: "src/feature.ts\nREADME.md", stderr: "" };
+        }
+        if (cmd.includes("merge-base")) {
+          return { stdout: "base123", stderr: "" };
+        }
+        if (cmd.includes(GIT_COMMANDS.BRANCH_SHOW_CURRENT)) {
+          return { stdout: "feature-branch", stderr: "" };
+        }
+        return { stdout: "", stderr: "" };
+      }),
+      getSession: mock(async () => ({
+        session: "test-session",
+        repoName: "test-repo",
+        repoUrl: "https://github.com/user/repo.git",
+      })),
+      getSessionWorkdir: mock(() => "/tmp/mock-repo-path/sessions/test-session"),
+    };
+
+    const result = await gitService.prWithDependencies({ session: "test-session" }, mockDeps);
 
     // Verify the result contains expected markdown
     expect(typeof result.markdown).toBe("string");
     expect(result.markdown.length).toBeGreaterThan(0);
-    expect(result.markdown).toContain("# Mock PR Description");
+    expect(result.markdown).toContain("feature-branch");
   });
 });

--- a/src/domain/git.test.ts
+++ b/src/domain/git.test.ts
@@ -5,8 +5,9 @@ const TEST_VALUE = 123;
  * @migrated Migrated to native Bun patterns
  * @enhanced Enhanced with comprehensive method coverage and DI patterns
  */
-import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { describe, test, expect, beforeEach, mock } from "bun:test";
 import { GitService } from "./git";
+import { FakeGitService } from "./git/fake-git-service";
 import { setupTestMocks } from "../utils/test-utils/mocking";
 import { GIT_COMMANDS } from "../utils/test-utils/test-constants";
 import { expectToHaveBeenCalled, expectToHaveBeenCalledWith } from "../utils/test-utils/assertions";
@@ -18,22 +19,21 @@ setupTestMocks();
 
 describe("GitService", () => {
   let gitService: GitService;
+  let fakeGit: FakeGitService;
 
   beforeEach(() => {
-    // Create a fresh GitService instance for each test
+    // Create a fresh GitService instance for real-method tests (e.g. getSessionWorkdir)
     gitService = new GitService("/mock/base/dir");
 
-    // Mock getStatus method to return canned data
-    spyOn(GitService.prototype, "getStatus").mockImplementation(async () => {
-      return {
-        modified: ["file1.ts", "file2.ts"],
-        untracked: ["newfile1.ts", "newfile2.ts"],
-        deleted: ["deletedfile1.ts"],
-      };
+    // Use FakeGitService as the DI-based test double for behavior verification
+    fakeGit = new FakeGitService();
+    fakeGit.getStatus = async () => ({
+      modified: ["file1.ts", "file2.ts"],
+      untracked: ["newfile1.ts", "newfile2.ts"],
+      deleted: ["deletedfile1.ts"],
     });
-
-    // Mock execInRepository to avoid actual git commands
-    spyOn(GitService.prototype, "execInRepository").mockImplementation(async (workdir, command) => {
+    fakeGit.execInRepository = async (_workdir: string, command: string) => {
+      fakeGit.recordedCommands.push({ workdir: _workdir, command });
       if (command === GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD) {
         return "main";
       }
@@ -41,12 +41,7 @@ describe("GitService", () => {
         return "/mock/repo/path";
       }
       return "";
-    });
-  });
-
-  afterEach(() => {
-    // Restore all mocks
-    mock.restore();
+    };
   });
 
   // ========== Basic API Tests ==========
@@ -55,8 +50,8 @@ describe("GitService", () => {
     expect(gitService instanceof GitService).toBe(true);
   });
 
-  test("should get repository status", async () => {
-    const _status = await gitService.getStatus("/mock/repo/path");
+  test("should get repository status via fake", async () => {
+    const _status = await fakeGit.getStatus("/mock/repo/path");
 
     // Verify the returned status object has the expected structure and content
     expect(_status).toEqual({
@@ -67,6 +62,7 @@ describe("GitService", () => {
   });
 
   test("getSessionWorkdir should return the correct path", () => {
+    // Tests real GitService.getSessionWorkdir (not mocked — this tests actual behavior)
     const workdir = gitService.getSessionWorkdir("test-session");
 
     // NEW: Session-ID-based storage - expect session ID in path, not repo name
@@ -75,24 +71,24 @@ describe("GitService", () => {
     // Repository identity no longer part of filesystem path
   });
 
-  test("execInRepository should execute git commands in the specified repository", async () => {
-    const _branch = await gitService.execInRepository(
+  test("execInRepository should execute git commands in the specified repository via fake", async () => {
+    const _branch = await fakeGit.execInRepository(
       "/mock/repo/path",
       GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD
     );
     expect(_branch).toBe("main");
   });
 
-  test("execInRepository should propagate errors", async () => {
-    // Override the mock implementation to simulate an error
-    const execInRepoMock = spyOn(GitService.prototype, "execInRepository").mockImplementation(
-      async (workdir, command) => {
-        throw new Error("Command execution failed");
-      }
+  test("execInRepository should propagate errors via fake", async () => {
+    // Configure a fresh fake to throw an error for specific commands
+    const errorFake = new FakeGitService();
+    errorFake.setCommandError(
+      GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD,
+      new Error("Command execution failed")
     );
 
     try {
-      await gitService.execInRepository("/mock/repo/path", GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD);
+      await errorFake.execInRepository("/mock/repo/path", GIT_COMMANDS.REV_PARSE_ABBREV_REF_HEAD);
       // The test should not reach this line
       expect(true).toBe(false);
     } catch (error: unknown) {
@@ -105,7 +101,7 @@ describe("GitService", () => {
   });
 
   test("should use session-ID-based storage in getSessionWorkdir", () => {
-    // NEW: Session-ID-based storage - repository normalization no longer needed for paths
+    // Tests real GitService.getSessionWorkdir (not mocked — this tests actual behavior)
     const workdir1 = gitService.getSessionWorkdir("test-session");
 
     // Path should contain session ID but NOT repository name
@@ -362,10 +358,6 @@ describe("GitService - Core Methods with Dependency Injection", () => {
 
     beforeEach(() => {
       gitService = new GitService("/test/base/dir");
-      // Prevent ensureBaseDir from hitting real filesystem
-      spyOn(gitService as any, "ensureBaseDir").mockImplementation(() =>
-        Promise.resolve(undefined)
-      );
     });
 
     test("should handle commit operations with proper hash extraction", async () => {
@@ -701,6 +693,7 @@ describe("GitService - Core Methods with Dependency Injection", () => {
         mkdir: mock(),
         readdir: mock(),
         access: mock(),
+        ensureBaseDir: mock(async () => {}),
       };
 
       await expect(
@@ -738,6 +731,7 @@ describe("GitService - Core Methods with Dependency Injection", () => {
           throw new Error("ENOENT");
         }),
         access: mock(),
+        ensureBaseDir: mock(async () => {}),
       };
 
       await expect(

--- a/src/domain/git.ts
+++ b/src/domain/git.ts
@@ -138,7 +138,7 @@ export class GitService implements GitServiceInterface {
     options: CloneOptions,
     deps: CloneDependencies
   ): Promise<CloneResult> {
-    await this.ensureBaseDir();
+    await (deps.ensureBaseDir ?? (() => this.ensureBaseDir()))();
     return cloneImpl(options, deps);
   }
 

--- a/src/domain/git/clone-operations.ts
+++ b/src/domain/git/clone-operations.ts
@@ -33,6 +33,8 @@ export interface CloneDependencies {
   access: (path: string) => Promise<void>;
   rm: (path: string, options?: { recursive?: boolean; force?: boolean }) => Promise<void>;
   generateSessionId: () => string;
+  /** Optional override for base directory initialization (injected in tests to avoid filesystem access). */
+  ensureBaseDir?: () => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces spyOn anti-patterns in git test files with proper DI injection. Module-level spies that intercepted clone operations are replaced with injected mock deps including ensureBaseDir.

Note: this is a partial audit — covers the git test area. Full audit of remaining spyOn calls across the codebase can continue in follow-up waves.

## Test plan
- [x] All 48 git tests pass (0 failures)
- [x] Pre-commit hooks pass
- [ ] CI passes

(Had Claude prepare this PR.)