### PR TITLE
test(mt#639): Fix non-hermetic tests

### DIFF
--- a/codemods/fix-indentation.test.ts
+++ b/codemods/fix-indentation.test.ts
@@ -10,13 +10,14 @@
  */
 
 import { test, expect } from "bun:test";
-import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 
 // Read the actual codemod content to validate its behavior
-const codemodContent = readFileSync(
-  "/Users/edobry/.local/state/minsky/sessions/task#178/codemods/fix-indentation.ts",
-  "utf8"
-);
+// Use import.meta.url to resolve the path relative to this test file (hermetic)
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const codemodPath = join(__dirname, "fix-indentation.ts");
+const codemodContent = await Bun.file(codemodPath).text();
 
 test("ESLint auto-fix codemod runs ONLY the correct ESLint command", () => {
   // Should contain exactly the right command

--- a/src/adapters/shared/commands/session-context-resolution.test.ts
+++ b/src/adapters/shared/commands/session-context-resolution.test.ts
@@ -7,24 +7,13 @@
  * - MCP interface cannot reliably resolve session context
  */
 
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
 import { CommandExecutionContext } from "../../../schemas/command-registry";
 import { TEST_PATHS, ERROR_MESSAGES } from "../../../utils/test-utils/test-constants";
 
 describe("Session Context Resolution Architecture Issues", () => {
-  let originalCwd: () => string;
+  // mockCwd is assigned per-test — each test creates its own mock before using it
   let mockCwd: ReturnType<typeof mock>;
-
-  beforeEach(() => {
-    originalCwd = process.cwd;
-    mockCwd;
-    process.cwd = mockCwd;
-  });
-
-  afterEach(() => {
-    process.cwd = originalCwd;
-    mockCwd.mockRestore();
-  });
 
   describe("🚩 PROBLEM: Mixed Concerns in Domain Layer", () => {
     it("should NOT require different validation logic based on working directory", async () => {

--- a/src/domain/workspace.test.ts
+++ b/src/domain/workspace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from "bun:test";
 import { resolveWorkspacePath } from "./workspace";
 import type { WorkspaceResolutionOptions, TestDependencies } from "./workspace";
 import { createMockFilesystem } from "../utils/test-utils/filesystem/mock-filesystem";
+import { mockCurrentWorkingDirectory } from "../utils/process";
 
 describe("resolveWorkspacePath", () => {
   let mockFs: ReturnType<typeof createMockFilesystem>;
@@ -32,16 +33,14 @@ describe("resolveWorkspacePath", () => {
   });
 
   it("returns current directory when no workspace option is provided", async () => {
-    // Mock process.cwd()
-    const originalCwd = process.cwd;
-    process.cwd = () => "/current/directory";
-
-    const _result = await resolveWorkspacePath();
-
-    expect(_result).toBe("/current/directory");
-
-    // Restore process.cwd
-    process.cwd = originalCwd;
+    // Use mockCurrentWorkingDirectory for hermetic cwd injection
+    const restore = mockCurrentWorkingDirectory(() => "/current/directory");
+    try {
+      const _result = await resolveWorkspacePath();
+      expect(_result).toBe("/current/directory");
+    } finally {
+      restore();
+    }
   });
 
   it("returns sessionRepo when provided", async () => {

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -5,6 +5,7 @@ import { type SessionProviderInterface } from "./session";
 import { log } from "../utils/logger";
 import { getErrorMessage, getErrorStack } from "../errors/index";
 import { getSessionsDir } from "../utils/paths";
+import { getCurrentWorkingDirectory } from "../utils/process";
 
 /**
  * Options for resolving workspace paths
@@ -38,7 +39,7 @@ export function resolveMainWorkspaceFromRepoUrl(repoUrl: string): string {
     return repoUrl.replace("file://", "");
   }
   // For other URLs, assume they refer to the current directory
-  return process.cwd();
+  return getCurrentWorkingDirectory();
 }
 
 /**
@@ -135,7 +136,7 @@ export async function resolveMainWorkspacePath(
   sessionDB: SessionProviderInterface,
   deps: TestDependencies = {}
 ): Promise<string> {
-  const currentDir = process.cwd();
+  const currentDir = getCurrentWorkingDirectory();
   const { execAsync: execAsyncDep = execAsync } = deps;
 
   try {
@@ -189,7 +190,7 @@ export async function resolveWorkspacePath(
 
   // For task operations, always use the main workspace.
   if (options?.forTaskOperations && deps.getSessionFromRepo) {
-    const sessionInfo = await deps.getSessionFromRepo(process.cwd());
+    const sessionInfo = await deps.getSessionFromRepo(getCurrentWorkingDirectory());
     if (sessionInfo && sessionInfo.upstreamRepository) {
       return resolveMainWorkspaceFromRepoUrl(sessionInfo.upstreamRepository);
     }
@@ -220,7 +221,7 @@ export async function resolveWorkspacePath(
   }
 
   // 4. Use current directory as workspace
-  return process.cwd();
+  return getCurrentWorkingDirectory();
 }
 
 /**
@@ -228,7 +229,7 @@ export async function resolveWorkspacePath(
  * Uses getSessionFromWorkspace to extract the session context from the current working directory.
  */
 export async function getCurrentSession(
-  cwd: string = process.cwd(),
+  cwd: string = getCurrentWorkingDirectory(),
   execAsyncFn: typeof execAsync = execAsync,
   sessionDbOverride: SessionProviderInterface
 ): Promise<string | undefined> {
@@ -242,7 +243,7 @@ export async function getCurrentSession(
  * and then queries the SessionDB for the taskId.
  */
 export async function getCurrentSessionContext(
-  cwd: string = process.cwd(),
+  cwd: string = getCurrentWorkingDirectory(),
   // Added getCurrentSessionFn dependency for better testability
   dependencies: {
     execAsyncFn?: typeof execAsync;


### PR DESCRIPTION
## Summary

Audited all test files for non-hermetic patterns and fixed the identified issues:

- **`codemods/fix-indentation.test.ts`**: Was completely broken — imported `readFileSync` from `"fs"` and read from a hardcoded absolute path to a different session (`task#178`) that doesn't exist in any environment. Fixed by using `import.meta.url` + `Bun.file()` to resolve the path relative to the test file itself.

- **`src/domain/workspace.ts`**: All 6 direct `process.cwd()` calls replaced with `getCurrentWorkingDirectory()` from `src/utils/process.ts` (which already has a `mockCurrentWorkingDirectory()` utility specifically for this purpose).

- **`src/domain/workspace.test.ts`**: Replaced fragile `process.cwd` monkey-patching (`process.cwd = () => "..."` + restore) with `mockCurrentWorkingDirectory()` wrapped in try/finally to guarantee cleanup even on test failure.

- **`src/adapters/shared/commands/session-context-resolution.test.ts`**: Fixed broken `beforeEach`/`afterEach` that set `process.cwd = mockCwd` when `mockCwd` was still `undefined` — corrupting `process.cwd` for the entire test module. The hooks were no-ops (tests create local `mockCwd = mock(...)` per-test and don't call production code through `process.cwd`), so they were removed. The `let mockCwd` declaration remains at describe scope.

## Files NOT touched

- `src/domain/tasks/configuration-integration.test.ts` — Explicitly marked integration test with per-line `eslint-disable custom/no-real-fs-in-tests` comments. Intentionally uses real filesystem.
- `tests/adapters/cli/session-test-utilities.ts` — User-specific paths in mock data are just test strings, not real filesystem access.
- All `.integration.test.ts` files — Expected to use real resources.

## Coherence Verification

**Files re-read**: `codemods/fix-indentation.test.ts`, `src/domain/workspace.ts`, `src/domain/workspace.test.ts`, `src/adapters/shared/commands/session-context-resolution.test.ts`, `src/utils/process.ts`

**Q1 single purpose**: pass — each file still has a clear, coherent purpose
**Q2 comment honesty**: pass — comments updated to reflect new mock approach
**Q3 naming honesty**: pass — no names changed
**Q4 redundant siblings**: pass — no duplicates created
**Q5 dead exports**: pass — `mockCurrentWorkingDirectory` was already exported, now it's actively used
**Q6 orphan code**: pass — `process.cwd` was the orphan, now cleaned up
**Q7 stray artifacts**: pass — no backup files created

**Items fixed in this PR (beyond original scope)**: None
**Items deferred (with justification)**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)