### PR TITLE
fix(mt#721): add sessionId parameter alias to session_pr_create MCP tool

### DIFF
--- a/src/adapters/shared/commands/session/pr-create-command.ts
+++ b/src/adapters/shared/commands/session/pr-create-command.ts
@@ -24,6 +24,7 @@ import { composeConventionalTitle } from "./pr-conventional-title";
  */
 export interface SessionPrCreateParams {
   name?: string;
+  sessionId?: string;
   task?: string;
   repo?: string;
   json?: boolean;
@@ -178,6 +179,11 @@ export async function executeSessionPrCreate(
   params: SessionPrCreateParams,
   context: CommandExecutionContext
 ): Promise<Record<string, unknown>> {
+  // Normalize sessionId to name for callers that use sessionId (e.g., MCP tools)
+  if (params.sessionId && !params.name) {
+    params.name = params.sessionId;
+  }
+
   if (!params.title) {
     throw new ValidationError(
       'Title is required for pull request creation.\nPlease provide:\n  --title <text>       PR title (description only; do not include "feat:")\n\nExample:\n  minsky session pr create --type feat --title "Add new feature"'

--- a/src/adapters/shared/commands/session/session-parameters.ts
+++ b/src/adapters/shared/commands/session/session-parameters.ts
@@ -351,6 +351,11 @@ export const sessionPrCreateCommandParams = {
     description: "Path to file containing PR body",
     required: false,
   },
+  sessionId: {
+    schema: z.string(),
+    description: "Session identifier (ID or task ID)",
+    required: false,
+  },
   name: commonSessionParams.name,
   task: commonSessionParams.task,
   repo: commonSessionParams.repo,


### PR DESCRIPTION
## Summary

Fixes `session_pr_create` MCP tool failing with "No session detected" when using `sessionId` parameter. The tool now accepts both `sessionId` and `name` for session identification, consistent with other session MCP tools.

### Root cause

The PR create command's parameter schema defined `name` for the session ID, but other session MCP tools use `sessionId`. When callers passed `sessionId`, it wasn't recognized.

### Fix

- Added `sessionId` to `SessionPrCreateParams` interface
- Added `sessionId` to `sessionPrCreateCommandParams` schema (exposed in MCP)
- Added normalization in `executeSessionPrCreate`: if `sessionId` is provided but `name` is not, copies `sessionId` to `name`

## Spec verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| sessionId parameter accepted | Met | Added to params interface and schema |
| Normalized to name internally | Met | Early normalization in executeSessionPrCreate |
| Existing name/task params still work | Met | No change to existing paths |

Had Claude look into this.