### PR TITLE
feat(mt#730): Surface degraded similarity search state to users

### DIFF
--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -1,8 +1,19 @@
 import { BaseTaskCommand, type BaseTaskParams } from "./base-task-command";
 import type { CommandExecutionContext } from "../../command-registry";
 import { TaskStatus } from "../../../../domain/tasks/taskConstants";
-import { TaskSimilarityService } from "../../../../domain/tasks/task-similarity-service";
+import {
+  TaskSimilarityService,
+  type TaskSearchResponse,
+} from "../../../../domain/tasks/task-similarity-service";
 import { tasksSimilarParams, tasksSearchParams } from "./task-parameters";
+import { log } from "../../../../utils/logger";
+
+/** Emit a CLI warning when similarity search falls back to a degraded backend */
+function warnIfDegraded(response: TaskSearchResponse, json: boolean): void {
+  if (!response.degraded || json) return;
+  const reason = response.degradedReason ? `: ${response.degradedReason}` : "";
+  log.cliWarn(`Warning: similarity search degraded — using ${response.backend} fallback${reason}`);
+}
 
 interface TasksSimilarParams extends BaseTaskParams {
   taskId: string;
@@ -120,6 +131,9 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
       includeSpecPath
     );
 
+    const isJson = Boolean(params.json) || ctx.format === "json";
+    warnIfDegraded(searchResponse, isJson);
+
     return this.formatResult(
       {
         success: true,
@@ -132,7 +146,7 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
         results: enhancedResults,
         details: params.details, // Pass through details flag for CLI formatter
       },
-      params.json || ctx.format === "json"
+      isJson
     );
   }
 }
@@ -282,6 +296,9 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
     // Server-side filtering handles all filtering - no client-side filtering needed
     // This eliminates redundant filtering and improves performance
 
+    const isJson = Boolean(params.json) || ctx.format === "json";
+    warnIfDegraded(searchResponse, isJson);
+
     return this.formatResult(
       {
         success: true,
@@ -294,7 +311,7 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
         results: enhancedResults,
         details: params.details, // Pass through details flag for CLI formatter
       },
-      params.json || ctx.format === "json"
+      isJson
     );
   }
 }

--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -110,12 +110,12 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
     const threshold = params.threshold;
 
     const service = await this.createService();
-    const searchResults = await service.similarToTask(taskId, limit, threshold);
+    const searchResponse = await service.similarToTask(taskId, limit, threshold);
 
     // Enhance results with task details for better usability
     const includeSpecPath = params.backend !== "minsky";
     const enhancedResults = await this.enhanceSearchResults(
-      searchResults,
+      searchResponse.results,
       params.details,
       includeSpecPath
     );
@@ -124,6 +124,11 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
       {
         success: true,
         count: enhancedResults.length,
+        backend: searchResponse.backend,
+        degraded: searchResponse.degraded,
+        ...(searchResponse.degradedReason && {
+          degradedReason: searchResponse.degradedReason,
+        }),
         results: enhancedResults,
         details: params.details, // Pass through details flag for CLI formatter
       },
@@ -264,12 +269,12 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       filters.statusExclude = [TaskStatus.DONE, TaskStatus.CLOSED];
     }
 
-    const searchResults = await service.searchByText(query, limit, threshold, filters);
+    const searchResponse = await service.searchByText(query, limit, threshold, filters);
 
     // Enhance results with task details for better usability
     const includeSpecPath = params.backend !== "minsky";
-    let enhancedResults = await this.enhanceSearchResults(
-      searchResults,
+    const enhancedResults = await this.enhanceSearchResults(
+      searchResponse.results,
       params.details,
       includeSpecPath
     );
@@ -281,6 +286,11 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       {
         success: true,
         count: enhancedResults.length,
+        backend: searchResponse.backend,
+        degraded: searchResponse.degraded,
+        ...(searchResponse.degradedReason && {
+          degradedReason: searchResponse.degradedReason,
+        }),
         results: enhancedResults,
         details: params.details, // Pass through details flag for CLI formatter
       },

--- a/src/domain/rules/rule-similarity-service.ts
+++ b/src/domain/rules/rule-similarity-service.ts
@@ -59,9 +59,9 @@ export class RuleSimilarityService {
    */
   async searchByText(query: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
     const core = await createRuleSimilarityCore(this.workspacePath);
-    const items = await core.search({ queryText: query, limit });
+    const response = await core.search({ queryText: query, limit });
     // Map to SearchResult shape (id/score compatible)
-    return items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
+    return response.items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
 
   /**

--- a/src/domain/similarity/similarity-search-service.test.ts
+++ b/src/domain/similarity/similarity-search-service.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "bun:test";
+import { SimilaritySearchService } from "./similarity-search-service";
+import type { SimilarityBackend, SimilarityItem, SimilarityQuery } from "./types";
+
+function createBackend(
+  name: string,
+  options: {
+    available?: boolean;
+    results?: SimilarityItem[];
+    error?: Error;
+  } = {}
+): SimilarityBackend {
+  const { available = true, results = [], error } = options;
+  return {
+    name,
+    isAvailable: async () => available,
+    search: async () => {
+      if (error) throw error;
+      return results;
+    },
+  };
+}
+
+describe("SimilaritySearchService", () => {
+  const query: SimilarityQuery = { queryText: "test query", limit: 5 };
+
+  it("returns results from the first available backend", async () => {
+    const items: SimilarityItem[] = [{ id: "a", score: 0.5 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { results: items }),
+      createBackend("lexical", { results: [{ id: "b", score: 0.1 }] }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("embeddings");
+    expect(response.degraded).toBe(false);
+    expect(response.degradedReason).toBeUndefined();
+    expect(response.items).toEqual(items);
+  });
+
+  it("sets degraded=true with reason when a backend throws and falls back", async () => {
+    const fallbackItems: SimilarityItem[] = [{ id: "b", score: 0.2 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", {
+        error: new Error("429 insufficient_quota"),
+      }),
+      createBackend("lexical", { results: fallbackItems }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("lexical");
+    expect(response.degraded).toBe(true);
+    expect(response.degradedReason).toBe("429 insufficient_quota");
+    expect(response.items).toEqual(fallbackItems);
+  });
+
+  it("skips unavailable backends without setting degraded", async () => {
+    const items: SimilarityItem[] = [{ id: "c", score: 0.3 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { available: false }),
+      createBackend("lexical", { results: items }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("lexical");
+    expect(response.degraded).toBe(false);
+    expect(response.degradedReason).toBeUndefined();
+  });
+
+  it("returns empty with backend='none' when all backends fail", async () => {
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", {
+        error: new Error("quota exceeded"),
+      }),
+      createBackend("lexical", {
+        error: new Error("lexical also broken"),
+      }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("none");
+    expect(response.degraded).toBe(true);
+    expect(response.degradedReason).toBe("lexical also broken");
+    expect(response.items).toEqual([]);
+  });
+
+  it("returns empty with degraded=false when no backends configured", async () => {
+    const svc = new SimilaritySearchService([]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("none");
+    expect(response.degraded).toBe(false);
+    expect(response.items).toEqual([]);
+  });
+
+  it("tracks lastUsedBackend correctly", async () => {
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { error: new Error("fail") }),
+      createBackend("lexical", { results: [{ id: "x", score: 0.1 }] }),
+    ]);
+
+    expect(svc.getLastUsedBackend()).toBeNull();
+    await svc.search(query);
+    expect(svc.getLastUsedBackend()).toBe("lexical");
+  });
+});

--- a/src/domain/similarity/similarity-search-service.ts
+++ b/src/domain/similarity/similarity-search-service.ts
@@ -1,4 +1,5 @@
-import type { SimilarityBackend, SimilarityItem, SimilarityQuery } from "./types";
+import { log } from "../../utils/logger";
+import type { SimilarityBackend, SimilarityQuery, SimilaritySearchResponse } from "./types";
 
 export class SimilaritySearchService {
   private readonly backends: SimilarityBackend[];
@@ -16,19 +17,36 @@ export class SimilaritySearchService {
     return this.backends.find((b) => b.name === name);
   }
 
-  async search(query: SimilarityQuery): Promise<SimilarityItem[]> {
+  async search(query: SimilarityQuery): Promise<SimilaritySearchResponse> {
+    let degraded = false;
+    let degradedReason: string | undefined;
+
     for (const backend of this.backends) {
       try {
         const available = await backend.isAvailable();
         if (!available) continue;
         const items = await backend.search(query);
         this.lastUsedBackend = backend.name;
-        return Array.isArray(items) ? items : [];
-      } catch {
+        return {
+          items: Array.isArray(items) ? items : [],
+          backend: backend.name,
+          degraded,
+          degradedReason,
+        };
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        log.warn(`Similarity backend "${backend.name}" failed, falling back`, { error: reason });
+        degraded = true;
+        degradedReason = reason;
         continue;
       }
     }
     this.lastUsedBackend = null;
-    return [];
+    return {
+      items: [],
+      backend: "none",
+      degraded,
+      degradedReason,
+    };
   }
 }

--- a/src/domain/similarity/task-similarity-service.core.test.ts
+++ b/src/domain/similarity/task-similarity-service.core.test.ts
@@ -57,15 +57,19 @@ describe("TaskSimilarityService → SimilaritySearchService (lexical fallback)",
   });
 
   it("searchByText returns top-k ordered by lexical similarity", async () => {
-    const results = await service.searchByText("refactor modules and organization", 2);
-    expect(results.length).toBe(2);
-    expect(first(results).id).toBe("md#102"); // best lexical match
+    const response = await service.searchByText("refactor modules and organization", 2);
+    expect(response.results.length).toBe(2);
+    expect(first(response.results).id).toBe("md#102"); // best lexical match
+    expect(response.backend).toBeDefined();
+    expect(response.degraded).toBe(false);
   });
 
   it("similarToTask finds similar tasks by content using lexical backend", async () => {
-    const results = await service.similarToTask("md#101", 2);
-    expect(results.length).toBeGreaterThan(0);
+    const response = await service.similarToTask("md#101", 2);
+    expect(response.results.length).toBeGreaterThan(0);
     // md#103 mentions auth/tests; md#102 is refactor; either may appear, just ensure ids exist
-    results.forEach((r) => expect(["md#102", "md#103", "md#101"]).toContain(r.id));
+    response.results.forEach((r) => expect(["md#102", "md#103", "md#101"]).toContain(r.id));
+    expect(response.backend).toBeDefined();
+    expect(response.degraded).toBe(false);
   });
 });

--- a/src/domain/similarity/types.ts
+++ b/src/domain/similarity/types.ts
@@ -16,3 +16,14 @@ export interface SimilarityBackend {
   isAvailable(): Promise<boolean>;
   search(query: SimilarityQuery): Promise<SimilarityItem[]>;
 }
+
+/** Result of a similarity search with backend metadata and degradation info */
+export interface SimilaritySearchResponse {
+  items: SimilarityItem[];
+  /** Which backend produced the results ("embeddings" | "lexical") */
+  backend: string;
+  /** True if a higher-priority backend failed and we fell back */
+  degraded: boolean;
+  /** Human-readable reason for the fallback, if degraded */
+  degradedReason?: string;
+}

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -13,6 +13,14 @@ export interface TaskSimilarityServiceConfig {
   dimension?: number;
 }
 
+/** Task search response wrapping results with backend metadata */
+export interface TaskSearchResponse {
+  results: SearchResult[];
+  backend: string;
+  degraded: boolean;
+  degradedReason?: string;
+}
+
 export class TaskSimilarityService {
   constructor(
     private readonly embeddingService: EmbeddingService,
@@ -30,7 +38,7 @@ export class TaskSimilarityService {
     return this.config;
   }
 
-  async similarToTask(taskId: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
+  async similarToTask(taskId: string, limit = 10, threshold?: number): Promise<TaskSearchResponse> {
     // Delegate to generic core; embeddings backend will be first if available
     const core = await createTaskSimilarityCore({
       getById: this.findTaskById,
@@ -38,10 +46,21 @@ export class TaskSimilarityService {
       getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
     });
     const task = await this.findTaskById(taskId);
-    if (!task) return [];
+    if (!task) {
+      return { results: [], backend: "none", degraded: false };
+    }
     const content = await this.extractTaskContent(task);
-    const items = await core.search({ queryText: content, limit });
-    return items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata }));
+    const response = await core.search({ queryText: content, limit });
+    return {
+      results: response.items.map((i) => ({
+        id: i.id,
+        score: i.score,
+        metadata: i.metadata,
+      })),
+      backend: response.backend,
+      degraded: response.degraded,
+      degradedReason: response.degradedReason,
+    };
   }
 
   async searchByText(
@@ -49,14 +68,23 @@ export class TaskSimilarityService {
     limit = 10,
     threshold?: number,
     filters?: Record<string, unknown>
-  ): Promise<SearchResult[]> {
+  ): Promise<TaskSearchResponse> {
     const core = await createTaskSimilarityCore({
       getById: this.findTaskById,
       listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
       getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
     });
-    const items = await core.search({ queryText: query, limit, filters });
-    return items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata }));
+    const response = await core.search({ queryText: query, limit, filters });
+    return {
+      results: response.items.map((i) => ({
+        id: i.id,
+        score: i.score,
+        metadata: i.metadata,
+      })),
+      backend: response.backend,
+      degraded: response.degraded,
+      degradedReason: response.degradedReason,
+    };
   }
 
   async searchSimilarTasks(
@@ -64,15 +92,22 @@ export class TaskSimilarityService {
     excludeTaskIds: string[] = [],
     limit = 10,
     threshold?: number
-  ): Promise<SearchResult[]> {
-    if (searchTerms.length === 0) return [];
+  ): Promise<TaskSearchResponse> {
+    if (searchTerms.length === 0) {
+      return { results: [], backend: "none", degraded: false };
+    }
 
     // Create a natural language query from the search terms
     const query = this.constructSearchQuery(searchTerms);
-    const results = await this.searchByText(query, limit * 2, threshold); // Get more to filter
+    const response = await this.searchByText(query, limit * 2, threshold);
 
     // Filter out excluded task IDs
-    return results.filter((result) => !excludeTaskIds.includes(result.id)).slice(0, limit);
+    return {
+      ...response,
+      results: response.results
+        .filter((result) => !excludeTaskIds.includes(result.id))
+        .slice(0, limit),
+    };
   }
 
   /**

--- a/src/domain/tools/similarity/tool-similarity-service.ts
+++ b/src/domain/tools/similarity/tool-similarity-service.ts
@@ -4,7 +4,6 @@ import {
   type SharedCommand,
 } from "../../../adapters/shared/command-registry";
 import { createLogger } from "../../../utils/logger";
-import type { SimilarityItem } from "../../similarity/types";
 
 const log = createLogger();
 
@@ -63,10 +62,10 @@ export class ToolSimilarityService {
       .join(" ");
 
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({ queryText: toolContent, limit });
+    const response = await core.search({ queryText: toolContent, limit });
 
     // Filter out the original tool from results
-    return items
+    return response.items
       .filter((i) => i.id !== toolId)
       .map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
@@ -76,9 +75,9 @@ export class ToolSimilarityService {
    */
   async searchByText(query: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({ queryText: query, limit });
+    const response = await core.search({ queryText: query, limit });
 
-    return items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
+    return response.items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
 
   /**
@@ -87,13 +86,13 @@ export class ToolSimilarityService {
    */
   async findRelevantTools(request: ToolSearchRequest): Promise<RelevantTool[]> {
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({
+    const searchResponse = await core.search({
       queryText: request.query,
       limit: request.limit || 20,
     });
 
     const results: RelevantTool[] = [];
-    for (const item of items) {
+    for (const item of searchResponse.items) {
       const tool = sharedCommandRegistry.getCommand(item.id);
       if (!tool) {
         continue; // Skip if tool not found in registry


### PR DESCRIPTION
## Summary

When the embeddings backend fails (API quota exhausted, network error, misconfiguration), the `SimilaritySearchService` was silently falling back to lexical (Jaccard word-overlap) search with no indication to the user. This caused months of undetected quality degradation (see mt#724 investigation).

This PR adds observability to the similarity search fallback:

- **`SimilaritySearchResponse` type** — search results now include `backend`, `degraded`, and `degradedReason` metadata
- **Warning logging** — fallback errors are logged via `log.warn()` instead of silently swallowed
- **MCP response enrichment** — `tasks search` and `tasks similar` responses include backend/degraded fields
- **Propagation through the stack** — `TaskSimilarityService` returns `TaskSearchResponse` with metadata; rule and tool similarity services updated for new core return type

### Example degraded MCP response:
```json
{
  "success": true,
  "count": 5,
  "backend": "lexical",
  "degraded": true,
  "degradedReason": "Embedding provider returned 429 (quota exceeded)",
  "results": [...]
}
```

## Test plan

- [x] 6 new `SimilaritySearchService` unit tests covering: success metadata, degraded fallback, unavailable vs errored backends, all-fail case, empty config, lastUsedBackend tracking
- [x] Existing task/rule/tool similarity tests pass (1520 total, 0 failures)
- [x] TypeScript compilation clean
- [x] ESLint warnings at or below threshold (168)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and implement this)