### PR TITLE
fix(mt#732): Add minsky: tag validation to edit command and unsupported-backend warning

### DIFF
--- a/src/adapters/shared/commands/tasks/edit-commands.ts
+++ b/src/adapters/shared/commands/tasks/edit-commands.ts
@@ -155,6 +155,14 @@ export class TasksEditCommand extends BaseTaskCommand<TasksEditParams> {
     // Handle tags update
     if (hasTagOperation) {
       const newTags = params.tag ? (Array.isArray(params.tag) ? params.tag : [params.tag]) : [];
+      if (newTags.length > 0) {
+        const invalidTags = newTags.filter((t) => t.startsWith("minsky:"));
+        if (invalidTags.length > 0) {
+          throw new ValidationError(
+            `Tags cannot use the reserved "minsky:" prefix: ${invalidTags.join(", ")}`
+          );
+        }
+      }
       updates.tags = newTags;
       this.debug(`Tags update: ${JSON.stringify(newTags)}`);
     }

--- a/src/domain/tasks/multi-backend-service.ts
+++ b/src/domain/tasks/multi-backend-service.ts
@@ -212,12 +212,14 @@ export class TaskServiceImpl implements TaskService {
     }
 
     // Handle tags update if backend supports it
-    if (
-      updates.tags !== undefined &&
-      backend.getCapabilities().supportsTags &&
-      backend.updateTags
-    ) {
-      await backend.updateTags(taskId, updates.tags);
+    if (updates.tags !== undefined) {
+      if (backend.getCapabilities().supportsTags && backend.updateTags) {
+        await backend.updateTags(taskId, updates.tags);
+      } else {
+        log.warn(
+          `Backend "${backend.name}" does not support tags; tag update skipped for ${taskId}`
+        );
+      }
     }
 
     const final = await this.getTask(taskId);


### PR DESCRIPTION
## Summary

- **Tag validation in edit command**: `tasks edit --tag` now throws a `ValidationError` if any supplied tag uses the reserved `minsky:` prefix, before any update is applied
- **Unsupported-backend warning**: `multi-backend-service.ts` now logs a `warn` instead of silently skipping when a backend doesn't support tags

## Changes

- `src/adapters/shared/commands/tasks/edit-commands.ts`: Added `minsky:` prefix check after tag normalization; reuses the already-imported `ValidationError`
- `src/domain/tasks/multi-backend-service.ts`: Restructured the tags update block to emit `log.warn(...)` when `supportsTags` is false or `updateTags` is missing; reuses the already-imported `log`

## Test plan

- [ ] `bun run validate-all` passes (1514 tests, 0 errors) ✅
- [ ] Manual: `minsky tasks edit <id> --tag minsky:foo --execute` → throws validation error with message about reserved prefix
- [ ] Manual: update tags on a backend that doesn't support tags → warning logged, no crash