### PR TITLE
refactor(mt#733): remove dead exports from test mocking hub

### DIFF
--- a/src/utils/test-utils/mocking.ts
+++ b/src/utils/test-utils/mocking.ts
@@ -1,53 +1,20 @@
 /**
  * Test Mocking Utilities - Import Hub
- * @migrated Converted to import hub after extracting components to focused modules
- * @architecture Follows the established modularization pattern
  *
- * Centralized test mocking utilities for consistent test patterns across the codebase.
- * These utilities encapsulate Bun's testing mocking patterns for easier and consistent mocking.
- *
- * This module provides utilities to:
- * - Create mock functions with proper type safety
- * - Mock entire modules with custom implementations
- * - Set up automatic mock cleanup for tests
- * - Create mock objects with multiple mock methods
- * - Create specialized mocks for common Node.js modules
+ * Re-exports test mocking primitives from focused submodules.
  *
  * @module mocking
  */
 
 // Export core mock functions and types
-export { mockFunction, createMock } from "./core/mock-functions";
-
-// Export types separately
+export { createMock } from "./core/mock-functions";
 export type { MockFunction } from "./core/mock-functions";
 
 // Export cleanup and setup utilities
-export { setupTestMocksWithCleanup, resetTestState } from "./cleanup/test-cleanup";
-
-// Backward compatibility export
 export { setupTestMocksWithCleanup as setupTestMocks } from "./cleanup/test-cleanup";
 
 // Export mock objects and specialized utilities
-export { createMockObject, createMockExecSync, createPartialMock } from "./objects/mock-objects";
+export { createPartialMock } from "./objects/mock-objects";
 
 // Export filesystem mocking utilities
 export { createMockFilesystem } from "./filesystem/mock-filesystem";
-
-// Compatibility export for tests that use uppercase 'S'
-export { createMockFilesystem as createMockFileSystem } from "./filesystem/mock-filesystem";
-
-// Note: This file now serves as an import hub, providing access to all test mocking
-// functionality through focused, modularized components. The original 668-line file
-// has been reduced to a clean interface with each responsibility separated into
-// dedicated modules.
-//
-// File size reduction: 668 → 71 lines (89.4% reduction)
-//
-// Extracted modules:
-// - core/mock-functions.ts: Basic mock creation and function mocking
-// - cleanup/test-cleanup.ts: Test cleanup and setup utilities
-// - objects/mock-objects.ts: Mock objects and specialized utilities
-// - filesystem/mock-filesystem.ts: Mock filesystem utilities
-// - spies/mock-spies.ts: Spy and property mocking utilities
-// - context/test-context.ts: Test context management


### PR DESCRIPTION
## Summary

- Remove 6 dead re-exports from `mocking.ts` with zero test consumers: `mockFunction`, `createMockObject`, `createMockExecSync`, `setupTestMocksWithCleanup` (canonical name — only the `setupTestMocks` alias is used), `resetTestState`, `createMockFileSystem` (uppercase S compat alias)
- Clean up stale comments referencing deleted modules (`spies/mock-spies.ts`, `context/test-context.ts`)
- Net: -33 lines, 1512/1512 tests pass, tsc clean

## Test plan

- [x] `tsc --noEmit` — no errors
- [x] Full suite — 1512/1512 pass
- [x] `grep` for removed export names against test files — zero hits