### PR TITLE
feat(mt#727): reference clone optimization for fast session creation

### DIFF
--- a/src/domain/git/clone-operations.ts
+++ b/src/domain/git/clone-operations.ts
@@ -10,6 +10,8 @@ export interface CloneOptions {
   workdir: string; // Explicit path where to clone, provided by caller
   session?: string;
   branch?: string;
+  /** Local repo path to use as git --reference source for faster cloning */
+  referenceRepo?: string;
 }
 
 /**
@@ -61,8 +63,9 @@ export async function cloneImpl(
     }
 
     // Clone the repository with verbose logging FIRST
-    log.debug(`Executing: git clone ${options.repoUrl} ${workdir}`);
-    const cloneCmd = `git clone ${options.repoUrl} ${workdir}`;
+    const refFlag = options.referenceRepo ? `--reference "${options.referenceRepo}" ` : "";
+    const cloneCmd = `git clone ${refFlag}${options.repoUrl} ${workdir}`;
+    log.debug(`Executing: ${cloneCmd}`);
 
     // Ensure parent directory exists (handle undefined workdir)
     if (!workdir) {

--- a/src/domain/git/types.ts
+++ b/src/domain/git/types.ts
@@ -209,6 +209,8 @@ export interface CloneOptions {
   workdir: string; // Explicit path where to clone, provided by caller
   session?: string;
   branch?: string;
+  /** Local repo path to use as git --reference source for faster cloning */
+  referenceRepo?: string;
 }
 
 export interface CloneResult {

--- a/src/domain/init.ts
+++ b/src/domain/init.ts
@@ -4,7 +4,11 @@ import { enumSchemas } from "./configuration/schemas/base";
 import { createDirectoryIfNotExists, createFileIfNotExists } from "./init/file-system";
 import type { FsLike } from "./interfaces/fs-like";
 import { createRealFs } from "./interfaces/real-fs";
-import { getMinskyConfigContentYaml, getMCPConfigContent } from "./init/config-content";
+import {
+  getMinskyConfigContentYaml,
+  getLocalConfigContentYaml,
+  getMCPConfigContent,
+} from "./init/config-content";
 import {
   generateRulesWithTemplateSystem,
   generateMcpRuleWithTemplateSystem,
@@ -28,6 +32,7 @@ export function detectRepositoryBackend(repoPath: string): ResolvedRepositoryCon
 export {
   getMinskyConfigContent,
   getMinskyConfigContentYaml,
+  getLocalConfigContentYaml,
   getMCPConfigContent,
 } from "./init/config-content";
 export {
@@ -159,6 +164,12 @@ export async function initializeProject(
   const configPath = path.join(minskyDir, "config.yaml");
   const configContent = getMinskyConfigContentYaml(backend, repository);
   await createFileIfNotExists(configPath, configContent, overwrite, fileSystem);
+
+  // Write machine-specific local config (gitignored) with workspace.mainPath
+  // so session_start can use --reference cloning for fast session creation.
+  const localConfigPath = path.join(minskyDir, "config.local.yaml");
+  const localConfigContent = getLocalConfigContentYaml(repoPath);
+  await createFileIfNotExists(localConfigPath, localConfigContent, overwrite, fileSystem);
 
   // Setup MCP if enabled (default to enabled if not explicitly disabled)
   if (mcp?.enabled !== false) {

--- a/src/domain/init/config-content.ts
+++ b/src/domain/init/config-content.ts
@@ -84,6 +84,14 @@ export function getMinskyConfigContentYaml(
 }
 
 /**
+ * Returns the content for the local (machine-specific, gitignored) Minsky config file.
+ * Currently stores workspace.mainPath so session_start can use --reference cloning.
+ */
+export function getLocalConfigContentYaml(repoPath: string): string {
+  return yamlStringify({ workspace: { mainPath: repoPath } });
+}
+
+/**
  * Returns the content for the MCP config file
  */
 export function getMCPConfigContent(mcpOptions?: McpOptions): string {

--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -123,6 +123,36 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
     // for local clones) while keeping the canonical repoUrl / backendType from config.
     const cloneSource = repo || repoUrl;
 
+    // Auto-detect local workspace for --reference clone optimization.
+    // Only when user didn't pass --repo (which already provides a fast local source).
+    // Checks config workspace.mainPath first, falls back to cwd heuristic.
+    // Gracefully skips if: not a git repo, no remote, different repo, or any error.
+    let referenceRepo: string | undefined;
+    if (!repo) {
+      try {
+        let candidatePath: string | undefined;
+        const { getConfiguration } = await import("../configuration/index");
+        const cfg = getConfiguration() as { workspace?: { mainPath?: string } };
+        candidatePath = cfg.workspace?.mainPath || currentDir;
+
+        const localRemote = (
+          await deps.gitService.execInRepository(candidatePath, "remote get-url origin")
+        ).trim();
+        if (localRemote) {
+          const { normalizeRepositoryUri } = await import("../uri-utils");
+          const opts = { validateLocalExists: false };
+          const localName = normalizeRepositoryUri(localRemote, opts).name;
+          const configName = normalizeRepositoryUri(repoUrl, opts).name;
+          if (localName === configName) {
+            referenceRepo = candidatePath;
+            log.debug("Using local workspace as reference clone source", { referenceRepo });
+          }
+        }
+      } catch {
+        // Config not available or detection failed — skip optimization
+      }
+    }
+
     // Determine the session ID using task ID if provided
     let sessionId = name;
     let taskId: string | undefined = task;
@@ -260,6 +290,7 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
         repoUrl: cloneSource,
         session: sessionId,
         workdir: sessionDir, // Explicit workdir path computed by SessionDB
+        referenceRepo,
       });
 
       // Create a branch based on the session ID - use branchWithoutSession


### PR DESCRIPTION
## Summary

Adds `git clone --reference` support to session creation, using a local workspace's git objects to avoid re-downloading from the remote. This reduces the clone phase from ~4s to ~0.75s (5x faster on local network; much more on slower connections).

### Environment-aware detection

The MCP server can run in different environments (dev machine, remote server for Claude AI, CI). Detection is layered:

1. **Config-driven** (primary): reads `workspace.mainPath` from `.minsky/config.local.yaml` (gitignored, per-machine)
2. **Heuristic fallback**: tries `process.cwd()` if config not set
3. **Validates**: compares normalized repo names via `normalizeRepositoryUri` (handles SSH vs HTTPS, `.git` suffix)
4. **Graceful degradation**: silently falls back to full clone if no local workspace found or validation fails

### Changes

- **`CloneOptions`** (`types.ts` + `clone-operations.ts`): added `referenceRepo?: string` field; clone command uses `--reference` flag when set
- **`start-session-operations.ts`**: auto-detects local workspace from config or cwd, validates repo identity, passes `referenceRepo` to clone
- **`init.ts` + `config-content.ts`**: `minsky init` now writes `workspace.mainPath` to `.minsky/config.local.yaml` so the optimization works automatically

### Benchmarks

| Method | Time |
|--------|------|
| Full clone (current) | 4.0s |
| Reference clone | 0.75s |
| bun install (warm cache) | 3.4s |
| **Total current** | ~7.4s |
| **Total with reference** | ~4.1s |

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] 309 git/session domain tests pass, 0 failures
- [x] Lint: 0 errors (21 pre-existing warnings)
- [ ] Manual test: `minsky session start` with `workspace.mainPath` set - verify `--reference` in clone command (visible in debug logs)
- [ ] Manual test: `minsky session start` without config - verify cwd fallback works
- [ ] Manual test: remote environment without local repo - verify graceful fallback to full clone