### PR TITLE
feat(mt#734): add post-merge MCP server restart warning hook

### DIFF
--- a/.claude/hooks/post-merge-pull.sh
+++ b/.claude/hooks/post-merge-pull.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Post-merge hook: pull latest main and warn if MCP server code changed
+# Called by PostToolUse hook on session_pr_merge
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+cd "$PROJECT_DIR"
+
+# Record current HEAD before pull
+BEFORE=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+# Pull latest main
+git pull --ff-only origin main 2>/dev/null || true
+
+# Record HEAD after pull
+AFTER=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+# If HEAD changed, check if src/ files were modified
+if [ "$BEFORE" != "$AFTER" ] && [ "$BEFORE" != "unknown" ]; then
+  CHANGED_SRC=$(git diff --name-only "$BEFORE" "$AFTER" -- src/ 2>/dev/null || true)
+  if [ -n "$CHANGED_SRC" ]; then
+    echo ""
+    echo "⚠️  Minsky source code updated by this merge."
+    echo "   The running MCP server is using stale code."
+    echo "   Run: /mcp then reconnect minsky"
+    echo ""
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,12 +60,12 @@
         ]
       },
       {
-        "matcher": "mcp__minsky__session_pr_merge",
+        "matcher": "mcp__minsky__session_pr_merge|mcp__github__merge_pull_request",
         "hooks": [
           {
             "type": "command",
-            "command": "git -C $CLAUDE_PROJECT_DIR pull --ff-only origin main 2>/dev/null || true",
-            "timeout": 15,
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-merge-pull.sh",
+            "timeout": 20,
             "statusMessage": "Pulling latest main..."
           }
         ]


### PR DESCRIPTION
## Summary

After merging Minsky PRs that change source code, the running MCP server uses stale code. This adds a hook that detects when src/ files changed and warns the user to reconnect.

### Changes

- **`.claude/hooks/post-merge-pull.sh`**: New script that pulls latest main, compares HEAD before/after, checks if src/ changed, prints reconnect warning if so
- **`.claude/settings.json`**: Updated PostToolUse hook to use script instead of inline command, added `mcp__github__merge_pull_request` to matcher (covers both Minsky and GitHub MCP merge paths)

### How it works

1. PostToolUse fires after `session_pr_merge` or `github merge_pull_request`
2. Script records HEAD, pulls main, compares
3. If src/ files changed, prints: "Run /mcp then reconnect minsky"

### What it doesn't cover (documented for follow-up)

- Merges via Bash `gh pr merge` (no hook fires)
- Merges on GitHub web UI (external to Claude Code)
- Auto-merges (no hook fires)

Future work: investigate `claude mcp restart` from hooks (Option B) or minimal proxy (Option C).

## Spec verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Pull latest on merge | Met | Script does git pull --ff-only |
| Detect src/ changes | Met | git diff --name-only BEFORE AFTER -- src/ |
| Warn about stale MCP | Met | Prints reconnect instructions |
| Cover GitHub MCP merge | Met | Matcher includes mcp__github__merge_pull_request |

Had Claude look into this.