### PR TITLE
fix(mt#735): Surface similarity search backend in output and fix silent error swallowing

### DIFF
--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -264,7 +264,30 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       filters.statusExclude = [TaskStatus.DONE, TaskStatus.CLOSED];
     }
 
-    const searchResults = await service.searchByText(query, limit, threshold, filters);
+    const { results: searchResults, searchBackend } = await service.searchByText(
+      query,
+      limit,
+      threshold,
+      filters
+    );
+
+    // Show backend info to stderr unless JSON/quiet
+    try {
+      const { log } = await import("../../../../utils/logger");
+      const quiet = Boolean(params.quiet);
+      const json = Boolean(params.json) || ctx.format === "json";
+      if (!quiet && !json) {
+        const backendLabel =
+          searchBackend === "embeddings"
+            ? "embeddings"
+            : searchBackend
+              ? searchBackend
+              : "lexical (embedding unavailable)";
+        log.cliWarn(`Search backend: ${backendLabel}`);
+      }
+    } catch {
+      // ignore logging failures
+    }
 
     // Enhance results with task details for better usability
     const includeSpecPath = params.backend !== "minsky";
@@ -282,6 +305,7 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
         success: true,
         count: enhancedResults.length,
         results: enhancedResults,
+        searchBackend: searchBackend ?? "lexical",
         details: params.details, // Pass through details flag for CLI formatter
       },
       params.json || ctx.format === "json"

--- a/src/domain/similarity/similarity-search-service.ts
+++ b/src/domain/similarity/similarity-search-service.ts
@@ -1,4 +1,5 @@
 import type { SimilarityBackend, SimilarityItem, SimilarityQuery } from "./types";
+import { log } from "../../utils/logger";
 
 export class SimilaritySearchService {
   private readonly backends: SimilarityBackend[];
@@ -24,11 +25,15 @@ export class SimilaritySearchService {
         const items = await backend.search(query);
         this.lastUsedBackend = backend.name;
         return Array.isArray(items) ? items : [];
-      } catch {
+      } catch (error) {
+        log.warn(`Similarity search backend "${backend.name}" failed, trying next`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
         continue;
       }
     }
     this.lastUsedBackend = null;
+    log.warn("All similarity search backends failed; returning empty results");
     return [];
   }
 }

--- a/src/domain/similarity/task-similarity-service.core.test.ts
+++ b/src/domain/similarity/task-similarity-service.core.test.ts
@@ -57,9 +57,13 @@ describe("TaskSimilarityService → SimilaritySearchService (lexical fallback)",
   });
 
   it("searchByText returns top-k ordered by lexical similarity", async () => {
-    const results = await service.searchByText("refactor modules and organization", 2);
+    const { results, searchBackend } = await service.searchByText(
+      "refactor modules and organization",
+      2
+    );
     expect(results.length).toBe(2);
     expect(first(results).id).toBe("md#102"); // best lexical match
+    expect(searchBackend).toBe("lexical"); // embeddings disabled, falls back to lexical
   });
 
   it("similarToTask finds similar tasks by content using lexical backend", async () => {

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -49,14 +49,18 @@ export class TaskSimilarityService {
     limit = 10,
     threshold?: number,
     filters?: Record<string, unknown>
-  ): Promise<SearchResult[]> {
+  ): Promise<{ results: SearchResult[]; searchBackend: string | null }> {
     const core = await createTaskSimilarityCore({
       getById: this.findTaskById,
       listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
       getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
     });
     const items = await core.search({ queryText: query, limit, filters });
-    return items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata }));
+    const searchBackend = core.getLastUsedBackend();
+    return {
+      results: items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata })),
+      searchBackend,
+    };
   }
 
   async searchSimilarTasks(
@@ -69,7 +73,7 @@ export class TaskSimilarityService {
 
     // Create a natural language query from the search terms
     const query = this.constructSearchQuery(searchTerms);
-    const results = await this.searchByText(query, limit * 2, threshold); // Get more to filter
+    const { results } = await this.searchByText(query, limit * 2, threshold); // Get more to filter
 
     // Filter out excluded task IDs
     return results.filter((result) => !excludeTaskIds.includes(result.id)).slice(0, limit);


### PR DESCRIPTION
## Summary

- Replace bare catch in SimilaritySearchService.search() with log.warn() calls reporting which backend failed and why
- Log a warning when all backends fail and empty results are returned
- Change TaskSimilarityService.searchByText() return type to include searchBackend name
- TasksSearchCommand prints "Search backend: lexical (embedding unavailable)" or "Search backend: embeddings" to stderr in text mode, and includes searchBackend in JSON output
- Update searchSimilarTasks() to destructure the new return type
- Update test to use new return shape and assert searchBackend value

## Test plan

- [ ] Run bun test — all 1512 tests pass
- [ ] Run bun run validate-all — typecheck and lint pass
- [ ] Manual: run minsky tasks search without OpenAI key — shows "Search backend: lexical (embedding unavailable)"
- [ ] Manual: run with --json — output includes searchBackend field

🤖 Generated with [Claude Code](https://claude.com/claude-code)