### PR TITLE
chore(mt#740): fix unjustified eslint-disable comments and bare ts-ignore

### DIFF
--- a/eslint-rules/no-real-fs-in-tests.js
+++ b/eslint-rules/no-real-fs-in-tests.js
@@ -58,9 +58,7 @@ export default {
 
   create(context) {
     const options = context.options[0] || {};
-    const allowedModules = options.allowedModules || ["mock"]; // eslint-disable-line @typescript-eslint/no-unused-vars
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const strictMode = options.strictMode !== false; // Default to true
+    // allowedModules and strictMode are accepted in the schema for future use but not yet implemented
     const allowTimestamps = options.allowTimestamps === true; // Default to false
     const allowGlobalCounters = options.allowGlobalCounters === true; // Default to false
     const allowDynamicImports = options.allowDynamicImports === true; // Default to false

--- a/eslint-rules/no-unsafe-git-network-operations.js
+++ b/eslint-rules/no-unsafe-git-network-operations.js
@@ -192,11 +192,3 @@ function generateAutoFix(fixer, node, gitCommand, originalCommand) {
     return fixer.replaceText(node, replacementText);
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getTemplateLiteralValue(node) {
-  if (node.quasis.length === 1 && node.expressions.length === 0) {
-    return node.quasis[0].value.cooked;
-  }
-  return null;
-}

--- a/src/domain/ai/embedding-service-openai.test.ts
+++ b/src/domain/ai/embedding-service-openai.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { OpenAIEmbeddingService } from "./embedding-service-openai";
 
 function mockFetchOnce(status: number, statusText: string, body: any) {
-  // @ts-ignore
+  // @ts-expect-error -- assigning a partial Response mock to globalThis.fetch for test isolation
   globalThis.fetch = async () => {
     return {
       ok: status >= 200 && status < 300,

--- a/src/domain/configuration/testing.ts
+++ b/src/domain/configuration/testing.ts
@@ -179,7 +179,7 @@ export class MockConfigurationLoader {
     });
 
     // Override the loadAllSources method
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ConfigurationLoader has no public interface for overriding loadAllSources; test-only monkey-patch
     (mockLoader as any).loadAllSources = async () => {
       if (this.loadError) {
         throw this.loadError;

--- a/src/domain/session/commands/pr-get-subcommand.ts
+++ b/src/domain/session/commands/pr-get-subcommand.ts
@@ -153,7 +153,7 @@ export async function sessionPrGet(
 
         if (pulls.length > 0) {
           // Found a PR! Repair the session record with essential workflow state only
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Octokit REST response type for pulls.list is untyped in our codebase
           const githubPr: any = first(pulls, "GitHub PRs for branch");
           const repairedPrData: PullRequestInfo = {
             number: githubPr.number,


### PR DESCRIPTION
## Summary

Fixes 6 suppression shortcuts identified in the post-mt#672 audit:

- Add justification to 2 bare `eslint-disable` comments (`testing.ts:182`, `pr-get-subcommand.ts:156`)
- Replace `@ts-ignore` with `@ts-expect-error` + justification (`embedding-service-openai.test.ts:5`)
- Remove dead `getTemplateLiteralValue` function from `no-unsafe-git-network-operations.js`
- Remove unused `allowedModules`/`strictMode` option variables from `no-real-fs-in-tests.js` (schema accepts them for future use but rule logic never reads them)

All 21 remaining `eslint-disable` comments now have `--` justification.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `eslint .` — zero errors, zero warnings
- [x] `bun test` — 1512 pass, 0 fail

(Had Claude look into this — AI-assisted cleanup)