### PR TITLE
feat(mt#730): Add structured degradation metadata and embedding health check

### DIFF
--- a/src/adapters/shared/commands/config.ts
+++ b/src/adapters/shared/commands/config.ts
@@ -657,6 +657,50 @@ const configDoctorRegistration = defineCommand({
       });
     }
 
+    // Embedding provider health probe
+    try {
+      const provider = getConfigurationProvider();
+      const config = provider.getConfig();
+      const embProvider = config.embeddings?.provider || config.ai?.defaultProvider || "openai";
+      const embModel = config.embeddings?.model || "text-embedding-3-small";
+      const providerCfg = config.ai?.providers?.[embProvider];
+      const hasKey = Boolean(providerCfg?.apiKey || providerCfg?.api_key);
+
+      if (!hasKey) {
+        diagnostics.push({
+          check: "Embedding Provider",
+          status: "warning",
+          message: `Embedding provider "${embProvider}" has no API key configured`,
+        });
+      } else {
+        const { createEmbeddingServiceFromConfig } = await import(
+          "../../../domain/ai/embedding-service-factory"
+        );
+        const embeddingService = await createEmbeddingServiceFromConfig();
+        await embeddingService.generateEmbedding("test");
+        diagnostics.push({
+          check: "Embedding Provider",
+          status: "pass",
+          message: `Embedding provider "${embProvider}" (${embModel}) is working`,
+        });
+      }
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      const isQuota = /quota|429|insufficient/i.test(msg);
+      const isAuth = /401|unauthorized|api.key/i.test(msg);
+      diagnostics.push({
+        check: "Embedding Provider",
+        status: "error",
+        message: `Embedding provider check failed: ${msg}`,
+        ...(isQuota && {
+          suggestion: "Check your OpenAI billing at https://platform.openai.com/account/billing",
+        }),
+        ...(isAuth && {
+          suggestion: "API key may be invalid or expired — https://platform.openai.com/api-keys",
+        }),
+      });
+    }
+
     const errors = diagnostics.filter((d) => d.status === "error");
     const warnings = diagnostics.filter((d) => d.status === "warning");
 

--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -110,21 +110,42 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
     const threshold = params.threshold;
 
     const service = await this.createService();
-    const searchResults = await service.similarToTask(taskId, limit, threshold);
+    const response = await service.similarToTask(taskId, limit, threshold);
 
     // Enhance results with task details for better usability
     const includeSpecPath = params.backend !== "minsky";
     const enhancedResults = await this.enhanceSearchResults(
-      searchResults,
+      response.results,
       params.details,
       includeSpecPath
     );
+
+    // Show degraded warning to stderr unless JSON/quiet
+    if (response.degraded) {
+      try {
+        const { log } = await import("../../../../utils/logger");
+        const quiet = Boolean(params.quiet);
+        const json = Boolean(params.json) || ctx.format === "json";
+        if (!quiet && !json) {
+          log.cliWarn(
+            `Warning: similarity search degraded — using lexical fallback: ` +
+              `${response.degradedReason ?? "unknown"}. ` +
+              `Run 'minsky config doctor' to diagnose.`
+          );
+        }
+      } catch {
+        // ignore logging failures
+      }
+    }
 
     return this.formatResult(
       {
         success: true,
         count: enhancedResults.length,
         results: enhancedResults,
+        backend: response.backend,
+        degraded: response.degraded,
+        degradedReason: response.degradedReason,
         details: params.details, // Pass through details flag for CLI formatter
       },
       params.json || ctx.format === "json"
@@ -264,12 +285,7 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       filters.statusExclude = [TaskStatus.DONE, TaskStatus.CLOSED];
     }
 
-    const { results: searchResults, searchBackend } = await service.searchByText(
-      query,
-      limit,
-      threshold,
-      filters
-    );
+    const response = await service.searchByText(query, limit, threshold, filters);
 
     // Show backend info to stderr unless JSON/quiet
     try {
@@ -277,13 +293,17 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       const quiet = Boolean(params.quiet);
       const json = Boolean(params.json) || ctx.format === "json";
       if (!quiet && !json) {
-        const backendLabel =
-          searchBackend === "embeddings"
-            ? "embeddings"
-            : searchBackend
-              ? searchBackend
-              : "lexical (embedding unavailable)";
-        log.cliWarn(`Search backend: ${backendLabel}`);
+        if (response.degraded) {
+          log.cliWarn(
+            `Warning: similarity search degraded — using lexical fallback: ` +
+              `${response.degradedReason ?? "unknown"}. ` +
+              `Run 'minsky config doctor' to diagnose.`
+          );
+        } else {
+          const backendLabel =
+            response.backend === "embeddings" ? "embeddings" : response.backend || "lexical";
+          log.cliWarn(`Search backend: ${backendLabel}`);
+        }
       }
     } catch {
       // ignore logging failures
@@ -291,8 +311,8 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
 
     // Enhance results with task details for better usability
     const includeSpecPath = params.backend !== "minsky";
-    let enhancedResults = await this.enhanceSearchResults(
-      searchResults,
+    const enhancedResults = await this.enhanceSearchResults(
+      response.results,
       params.details,
       includeSpecPath
     );
@@ -305,7 +325,9 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
         success: true,
         count: enhancedResults.length,
         results: enhancedResults,
-        searchBackend: searchBackend ?? "lexical",
+        backend: response.backend,
+        degraded: response.degraded,
+        degradedReason: response.degradedReason,
         details: params.details, // Pass through details flag for CLI formatter
       },
       params.json || ctx.format === "json"

--- a/src/commands/config/doctor.ts
+++ b/src/commands/config/doctor.ts
@@ -35,6 +35,7 @@ export async function executeConfigDoctor(options: DoctorOptions): Promise<void>
     await runValidationCheck(diagnostics);
     await runFileSystemCheck(diagnostics);
     await runConnectivityCheck(diagnostics);
+    await runEmbeddingProviderCheck(diagnostics);
     await runPermissionsCheck(diagnostics);
 
     // Count results
@@ -292,6 +293,63 @@ async function runConnectivityCheck(diagnostics: DiagnosticResult[]): Promise<vo
       status: "error",
       message: `Connectivity check failed: ${error instanceof Error ? error.message : String(error)}`,
       suggestion: "Check configuration format and connectivity settings",
+    });
+  }
+}
+
+/**
+ * Check embedding provider health by making a tiny test request
+ */
+async function runEmbeddingProviderCheck(diagnostics: DiagnosticResult[]): Promise<void> {
+  try {
+    const provider = getConfigurationProvider();
+    const config = provider.getConfig();
+
+    const embeddingProvider = config.embeddings?.provider || config.ai?.defaultProvider || "openai";
+    const embeddingModel = config.embeddings?.model || "text-embedding-3-small";
+
+    // Check if the provider has an API key configured
+    const providerConfig = config.ai?.providers?.[embeddingProvider];
+    if (!providerConfig?.apiKey && !providerConfig?.api_key) {
+      diagnostics.push({
+        check: "Embedding Provider",
+        status: "warning",
+        message: `Embedding provider "${embeddingProvider}" has no API key configured`,
+        suggestion: `Set the API key with 'minsky config set ai.providers.${embeddingProvider}.apiKey <key>'`,
+      });
+      return;
+    }
+
+    // Make a tiny test embedding request
+    const { createEmbeddingServiceFromConfig } = await import(
+      "../../domain/ai/embedding-service-factory"
+    );
+    const embeddingService = await createEmbeddingServiceFromConfig();
+    await embeddingService.generateEmbedding("test");
+
+    diagnostics.push({
+      check: "Embedding Provider",
+      status: "pass",
+      message: `Embedding provider "${embeddingProvider}" (${embeddingModel}) is working`,
+    });
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const isQuota = /quota|429|insufficient/i.test(errorMsg);
+    const isAuth = /401|unauthorized|api.key/i.test(errorMsg);
+
+    let suggestion = "Check your embedding provider configuration";
+    if (isQuota) {
+      suggestion = "Check your OpenAI billing at https://platform.openai.com/account/billing";
+    } else if (isAuth) {
+      suggestion =
+        "Your API key may be invalid or expired. Generate a new one at https://platform.openai.com/api-keys";
+    }
+
+    diagnostics.push({
+      check: "Embedding Provider",
+      status: "error",
+      message: `Embedding provider check failed: ${errorMsg}`,
+      suggestion,
     });
   }
 }

--- a/src/domain/rules/rule-similarity-service.ts
+++ b/src/domain/rules/rule-similarity-service.ts
@@ -59,9 +59,9 @@ export class RuleSimilarityService {
    */
   async searchByText(query: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
     const core = await createRuleSimilarityCore(this.workspacePath);
-    const items = await core.search({ queryText: query, limit });
+    const response = await core.search({ queryText: query, limit });
     // Map to SearchResult shape (id/score compatible)
-    return items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
+    return response.items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
 
   /**

--- a/src/domain/similarity/similarity-search-service.test.ts
+++ b/src/domain/similarity/similarity-search-service.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "bun:test";
+import { SimilaritySearchService } from "./similarity-search-service";
+import type { SimilarityBackend, SimilarityItem, SimilarityQuery } from "./types";
+
+function createBackend(
+  name: string,
+  options: {
+    available?: boolean;
+    results?: SimilarityItem[];
+    error?: Error;
+  } = {}
+): SimilarityBackend {
+  const { available = true, results = [], error } = options;
+  return {
+    name,
+    isAvailable: async () => available,
+    search: async () => {
+      if (error) throw error;
+      return results;
+    },
+  };
+}
+
+describe("SimilaritySearchService", () => {
+  const query: SimilarityQuery = { queryText: "test query", limit: 5 };
+
+  it("returns results from the first available backend", async () => {
+    const items: SimilarityItem[] = [{ id: "a", score: 0.5 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { results: items }),
+      createBackend("lexical", { results: [{ id: "b", score: 0.1 }] }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("embeddings");
+    expect(response.degraded).toBe(false);
+    expect(response.degradedReason).toBeUndefined();
+    expect(response.items).toEqual(items);
+  });
+
+  it("sets degraded=true with reason when a backend throws and falls back", async () => {
+    const fallbackItems: SimilarityItem[] = [{ id: "b", score: 0.2 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", {
+        error: new Error("429 insufficient_quota"),
+      }),
+      createBackend("lexical", { results: fallbackItems }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("lexical");
+    expect(response.degraded).toBe(true);
+    expect(response.degradedReason).toContain("429 insufficient_quota");
+    expect(response.items).toEqual(fallbackItems);
+  });
+
+  it("skips unavailable backends without setting degraded", async () => {
+    const items: SimilarityItem[] = [{ id: "c", score: 0.3 }];
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { available: false }),
+      createBackend("lexical", { results: items }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("lexical");
+    expect(response.degraded).toBe(false);
+    expect(response.degradedReason).toBeUndefined();
+  });
+
+  it("returns empty with backend='none' when all backends fail", async () => {
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { error: new Error("quota exceeded") }),
+      createBackend("lexical", { error: new Error("lexical also broken") }),
+    ]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("none");
+    expect(response.degraded).toBe(true);
+    expect(response.degradedReason).toContain("lexical also broken");
+    expect(response.items).toEqual([]);
+  });
+
+  it("returns empty with degraded=false when no backends configured", async () => {
+    const svc = new SimilaritySearchService([]);
+
+    const response = await svc.search(query);
+
+    expect(response.backend).toBe("none");
+    expect(response.degraded).toBe(false);
+    expect(response.items).toEqual([]);
+  });
+
+  it("tracks lastUsedBackend correctly", async () => {
+    const svc = new SimilaritySearchService([
+      createBackend("embeddings", { error: new Error("fail") }),
+      createBackend("lexical", { results: [{ id: "x", score: 0.1 }] }),
+    ]);
+
+    expect(svc.getLastUsedBackend()).toBeNull();
+    await svc.search(query);
+    expect(svc.getLastUsedBackend()).toBe("lexical");
+  });
+});

--- a/src/domain/similarity/similarity-search-service.ts
+++ b/src/domain/similarity/similarity-search-service.ts
@@ -1,4 +1,4 @@
-import type { SimilarityBackend, SimilarityItem, SimilarityQuery } from "./types";
+import type { SimilarityBackend, SimilarityQuery, SimilaritySearchResponse } from "./types";
 import { log } from "../../utils/logger";
 
 export class SimilaritySearchService {
@@ -17,23 +17,41 @@ export class SimilaritySearchService {
     return this.backends.find((b) => b.name === name);
   }
 
-  async search(query: SimilarityQuery): Promise<SimilarityItem[]> {
+  async search(query: SimilarityQuery): Promise<SimilaritySearchResponse> {
+    let degraded = false;
+    let degradedReason: string | undefined;
+
     for (const backend of this.backends) {
       try {
         const available = await backend.isAvailable();
         if (!available) continue;
         const items = await backend.search(query);
         this.lastUsedBackend = backend.name;
-        return Array.isArray(items) ? items : [];
+        return {
+          items: Array.isArray(items) ? items : [],
+          backend: backend.name,
+          degraded,
+          degradedReason,
+        };
       } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
         log.warn(`Similarity search backend "${backend.name}" failed, trying next`, {
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMsg,
         });
+        // A backend was available but threw — mark degraded for whoever
+        // eventually succeeds (the fallback).
+        degraded = true;
+        degradedReason = `${backend.name} failed: ${errorMsg}`;
         continue;
       }
     }
     this.lastUsedBackend = null;
     log.warn("All similarity search backends failed; returning empty results");
-    return [];
+    return {
+      items: [],
+      backend: "none",
+      degraded,
+      degradedReason: degraded ? degradedReason : undefined,
+    };
   }
 }

--- a/src/domain/similarity/task-similarity-service.core.test.ts
+++ b/src/domain/similarity/task-similarity-service.core.test.ts
@@ -57,19 +57,18 @@ describe("TaskSimilarityService → SimilaritySearchService (lexical fallback)",
   });
 
   it("searchByText returns top-k ordered by lexical similarity", async () => {
-    const { results, searchBackend } = await service.searchByText(
-      "refactor modules and organization",
-      2
-    );
-    expect(results.length).toBe(2);
-    expect(first(results).id).toBe("md#102"); // best lexical match
-    expect(searchBackend).toBe("lexical"); // embeddings disabled, falls back to lexical
+    const response = await service.searchByText("refactor modules and organization", 2);
+    expect(response.results.length).toBe(2);
+    expect(first(response.results).id).toBe("md#102"); // best lexical match
+    expect(response.backend).toBe("lexical"); // embeddings disabled, falls back to lexical
+    expect(response.degraded).toBe(false); // not degraded, just unavailable
   });
 
   it("similarToTask finds similar tasks by content using lexical backend", async () => {
-    const results = await service.similarToTask("md#101", 2);
-    expect(results.length).toBeGreaterThan(0);
+    const response = await service.similarToTask("md#101", 2);
+    expect(response.results.length).toBeGreaterThan(0);
     // md#103 mentions auth/tests; md#102 is refactor; either may appear, just ensure ids exist
-    results.forEach((r) => expect(["md#102", "md#103", "md#101"]).toContain(r.id));
+    response.results.forEach((r) => expect(["md#102", "md#103", "md#101"]).toContain(r.id));
+    expect(response.backend).toBe("lexical");
   });
 });

--- a/src/domain/similarity/types.ts
+++ b/src/domain/similarity/types.ts
@@ -16,3 +16,10 @@ export interface SimilarityBackend {
   isAvailable(): Promise<boolean>;
   search(query: SimilarityQuery): Promise<SimilarityItem[]>;
 }
+
+export interface SimilaritySearchResponse {
+  items: SimilarityItem[];
+  backend: string;
+  degraded: boolean;
+  degradedReason?: string;
+}

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -13,6 +13,13 @@ export interface TaskSimilarityServiceConfig {
   dimension?: number;
 }
 
+export interface TaskSearchResponse {
+  results: SearchResult[];
+  backend: string;
+  degraded: boolean;
+  degradedReason?: string;
+}
+
 export class TaskSimilarityService {
   constructor(
     private readonly embeddingService: EmbeddingService,
@@ -30,7 +37,7 @@ export class TaskSimilarityService {
     return this.config;
   }
 
-  async similarToTask(taskId: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
+  async similarToTask(taskId: string, limit = 10, threshold?: number): Promise<TaskSearchResponse> {
     // Delegate to generic core; embeddings backend will be first if available
     const core = await createTaskSimilarityCore({
       getById: this.findTaskById,
@@ -38,10 +45,21 @@ export class TaskSimilarityService {
       getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
     });
     const task = await this.findTaskById(taskId);
-    if (!task) return [];
+    if (!task) {
+      return { results: [], backend: "none", degraded: false };
+    }
     const content = await this.extractTaskContent(task);
-    const items = await core.search({ queryText: content, limit });
-    return items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata }));
+    const response = await core.search({ queryText: content, limit });
+    return {
+      results: response.items.map((i) => ({
+        id: i.id,
+        score: i.score,
+        metadata: i.metadata,
+      })),
+      backend: response.backend,
+      degraded: response.degraded,
+      degradedReason: response.degradedReason,
+    };
   }
 
   async searchByText(
@@ -49,17 +67,22 @@ export class TaskSimilarityService {
     limit = 10,
     threshold?: number,
     filters?: Record<string, unknown>
-  ): Promise<{ results: SearchResult[]; searchBackend: string | null }> {
+  ): Promise<TaskSearchResponse> {
     const core = await createTaskSimilarityCore({
       getById: this.findTaskById,
       listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
       getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
     });
-    const items = await core.search({ queryText: query, limit, filters });
-    const searchBackend = core.getLastUsedBackend();
+    const response = await core.search({ queryText: query, limit, filters });
     return {
-      results: items.map((i) => ({ id: i.id, score: i.score, metadata: i.metadata })),
-      searchBackend,
+      results: response.items.map((i) => ({
+        id: i.id,
+        score: i.score,
+        metadata: i.metadata,
+      })),
+      backend: response.backend,
+      degraded: response.degraded,
+      degradedReason: response.degradedReason,
     };
   }
 
@@ -68,15 +91,26 @@ export class TaskSimilarityService {
     excludeTaskIds: string[] = [],
     limit = 10,
     threshold?: number
-  ): Promise<SearchResult[]> {
-    if (searchTerms.length === 0) return [];
+  ): Promise<TaskSearchResponse> {
+    if (searchTerms.length === 0) {
+      return { results: [], backend: "none", degraded: false };
+    }
 
     // Create a natural language query from the search terms
     const query = this.constructSearchQuery(searchTerms);
-    const { results } = await this.searchByText(query, limit * 2, threshold); // Get more to filter
+    const response = await this.searchByText(query, limit * 2, threshold);
 
     // Filter out excluded task IDs
-    return results.filter((result) => !excludeTaskIds.includes(result.id)).slice(0, limit);
+    const filtered = response.results
+      .filter((result) => !excludeTaskIds.includes(result.id))
+      .slice(0, limit);
+
+    return {
+      results: filtered,
+      backend: response.backend,
+      degraded: response.degraded,
+      degradedReason: response.degradedReason,
+    };
   }
 
   /**

--- a/src/domain/tools/similarity/tool-similarity-service.ts
+++ b/src/domain/tools/similarity/tool-similarity-service.ts
@@ -4,7 +4,6 @@ import {
   type SharedCommand,
 } from "../../../adapters/shared/command-registry";
 import { createLogger } from "../../../utils/logger";
-import type { SimilarityItem } from "../../similarity/types";
 
 const log = createLogger();
 
@@ -63,10 +62,10 @@ export class ToolSimilarityService {
       .join(" ");
 
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({ queryText: toolContent, limit });
+    const response = await core.search({ queryText: toolContent, limit });
 
     // Filter out the original tool from results
-    return items
+    return response.items
       .filter((i) => i.id !== toolId)
       .map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
@@ -76,9 +75,9 @@ export class ToolSimilarityService {
    */
   async searchByText(query: string, limit = 10, threshold?: number): Promise<SearchResult[]> {
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({ queryText: query, limit });
+    const response = await core.search({ queryText: query, limit });
 
-    return items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
+    return response.items.map((i) => ({ id: i.id, score: i.score }) as SearchResult);
   }
 
   /**
@@ -87,10 +86,11 @@ export class ToolSimilarityService {
    */
   async findRelevantTools(request: ToolSearchRequest): Promise<RelevantTool[]> {
     const core = await createToolSimilarityCore();
-    const items: SimilarityItem[] = await core.search({
+    const response = await core.search({
       queryText: request.query,
       limit: request.limit || 20,
     });
+    const items = response.items;
 
     const results: RelevantTool[] = [];
     for (const item of items) {


### PR DESCRIPTION
## Summary

Builds on mt#735's logging fix with structured observability for similarity search degradation:

- **`SimilaritySearchResponse` type** with `backend`, `degraded`, `degradedReason` — distinguishes "backend unavailable" (intentional, not degraded) from "backend errored" (degraded with reason)
- **All task similarity methods** (`searchByText`, `similarToTask`, `searchSimilarTasks`) now return `TaskSearchResponse` with metadata (mt#735 only updated `searchByText`)
- **MCP responses** for both `tasks search` and `tasks similar` include `backend`, `degraded`, `degradedReason`
- **CLI warning** with actionable guidance: points users to `minsky config doctor`
- **`config doctor` embedding health probe** (both CLI and MCP): makes a tiny test embedding request, reports success/failure with contextual hints for quota and auth errors
- **6 new unit tests** for `SimilaritySearchService` fallback scenarios

### Background

Investigation in mt#724 found that the OpenAI API key had exceeded its quota, causing all similarity searches to silently fall back to lexical (Jaccard) matching for months. mt#735 added logging. This PR closes the loop with structured metadata for programmatic consumers and an actionable diagnostic path.

## Test plan

- [x] 6 new `SimilaritySearchService` unit tests (success, degraded fallback, unavailable, all-fail, no backends, lastUsedBackend)
- [x] Existing tests updated for new return types (1518 total, 0 failures)
- [x] TypeScript compilation clean
- [x] ESLint: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and implement this)