### PR TITLE
fix(mt#727): add missing git prefix to execInRepository call in reference clone detection

### DIFF
--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -136,7 +136,7 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
         candidatePath = cfg.workspace?.mainPath || currentDir;
 
         const localRemote = (
-          await deps.gitService.execInRepository(candidatePath, "remote get-url origin")
+          await deps.gitService.execInRepository(candidatePath, "git remote get-url origin")
         ).trim();
         if (localRemote) {
           const { normalizeRepositoryUri } = await import("../uri-utils");


### PR DESCRIPTION
## Summary

Fixes the reference clone optimization from #410. The `execInRepository` method runs raw shell commands, so the command needs the `git` prefix. Without it, `remote get-url origin` fails as a shell command (no such binary), gets caught by the try/catch, and the reference clone optimization is silently skipped.

**Before:** `execInRepository(path, "remote get-url origin")` - fails silently
**After:** `execInRepository(path, "git remote get-url origin")` - works correctly

Confirmed by checking production callers which all use the `git` prefix (e.g., `"git log -1 ..."`, `"git rev-parse HEAD"`, `"git fetch origin"`).

## Test plan

- [x] 309 git/session tests pass
- [ ] Manual test: start a session and verify `.git/objects/info/alternates` exists (proof of --reference clone)