### PR TITLE
feat(mt#744): add staleness detection to MCP server tool responses

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,6 +13,7 @@ import { log } from "../utils/logger";
 import type { ProjectContext } from "../types/project";
 import { createProjectContextFromCwd } from "../types/project";
 import { getErrorMessage } from "../errors/index";
+import { StalenessDetector } from "./staleness-detector";
 import type { Request, Response } from "express";
 import { randomUUID } from "crypto";
 
@@ -107,6 +108,7 @@ export class MinskyMCPServer {
   private tools: Map<string, ToolDefinition> = new Map();
   private resources: Map<string, ResourceDefinition> = new Map();
   private prompts: Map<string, PromptDefinition> = new Map();
+  private stalenessDetector: StalenessDetector;
 
   // For HTTP transport: map sessionId to transport for multiple clients
   private httpTransports: Map<string, StreamableHTTPServerTransport> = new Map();
@@ -126,6 +128,11 @@ export class MinskyMCPServer {
 
     // Set up project context
     this.projectContext = options.projectContext || createProjectContextFromCwd();
+
+    // Initialize staleness detector to warn when server code is outdated
+    this.stalenessDetector = new StalenessDetector(
+      this.projectContext.repositoryPath || process.cwd()
+    );
 
     // Create server instance
     this.server = new Server(
@@ -279,7 +286,7 @@ export class MinskyMCPServer {
           content: [
             {
               type: "text",
-              text: responseText,
+              text: responseText + (this.stalenessDetector.getStaleWarning() ?? ""),
             },
           ],
         };

--- a/src/mcp/staleness-detector.ts
+++ b/src/mcp/staleness-detector.ts
@@ -1,0 +1,109 @@
+/**
+ * MCP Server Staleness Detector
+ *
+ * Detects when the MCP server's loaded code is stale relative to the workspace.
+ * Records git HEAD at startup, periodically checks if it moved and src/ changed.
+ * Returns a warning message to append to tool responses when stale.
+ */
+
+import { execSync } from "child_process";
+import { log } from "../utils/logger";
+
+/** How often to re-check git HEAD (milliseconds) */
+const CHECK_INTERVAL_MS = 60_000; // 60 seconds
+
+export class StalenessDetector {
+  private startupHead: string | null = null;
+  private workspacePath: string;
+  private isStale = false;
+  private staleMessage: string | null = null;
+  private lastCheckTime = 0;
+
+  constructor(workspacePath: string) {
+    this.workspacePath = workspacePath;
+    this.startupHead = this.getGitHead();
+    if (this.startupHead) {
+      log.debug(`StalenessDetector: startup HEAD is ${this.startupHead.slice(0, 8)}`);
+    }
+  }
+
+  /**
+   * Get current git HEAD, or null if not a git repo / git not available
+   */
+  private getGitHead(): string | null {
+    try {
+      return execSync("git rev-parse HEAD", {
+        cwd: this.workspacePath,
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+        .toString()
+        .trim();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Check if src/ files changed between startup HEAD and current HEAD
+   */
+  private checkSrcChanged(currentHead: string): boolean {
+    if (!this.startupHead) return false;
+    try {
+      const diff = execSync(`git diff --name-only ${this.startupHead} ${currentHead} -- src/`, {
+        cwd: this.workspacePath,
+        timeout: 5000,
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+        .toString()
+        .trim();
+      return diff.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check for staleness (debounced). Call on each tool invocation.
+   * Returns a warning string if stale, or null if current.
+   */
+  getStaleWarning(): string | null {
+    // Already detected as stale — return cached message
+    if (this.isStale) {
+      return this.staleMessage;
+    }
+
+    // No startup HEAD — can't detect staleness
+    if (!this.startupHead) {
+      return null;
+    }
+
+    // Debounce: only check every CHECK_INTERVAL_MS
+    const now = Date.now();
+    if (now - this.lastCheckTime < CHECK_INTERVAL_MS) {
+      return null;
+    }
+    this.lastCheckTime = now;
+
+    // Check current HEAD
+    const currentHead = this.getGitHead();
+    if (!currentHead || currentHead === this.startupHead) {
+      return null;
+    }
+
+    // HEAD moved — check if src/ changed
+    if (this.checkSrcChanged(currentHead)) {
+      this.isStale = true;
+      this.staleMessage =
+        `\n\n⚠️ The Minsky MCP server was loaded from commit ${this.startupHead.slice(0, 8)} ` +
+        `but the workspace is now at ${currentHead.slice(0, 8)}. Source files have changed. ` +
+        `Run: /mcp then reconnect minsky`;
+      log.info(
+        `StalenessDetector: server is stale (${this.startupHead.slice(0, 8)} → ${currentHead.slice(0, 8)})`
+      );
+      return this.staleMessage;
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

The MCP server now detects when its loaded code is stale relative to the workspace and appends a warning to tool responses. Non-disruptive — no crash, no disconnect, tools keep working.

### How it works

1. On startup, records git HEAD of the workspace
2. On each tool call (debounced to every 60s), checks if HEAD moved
3. If HEAD moved and src/ files changed, appends a warning to the tool response text
4. Warning tells the AI/user to run /mcp reconnect when convenient

### New files

- **src/mcp/staleness-detector.ts**: Self-contained module that tracks startup HEAD, debounces checks, and caches the stale state once detected

### Integration

- **src/mcp/server.ts**: StalenessDetector initialized in constructor, warning appended in CallToolRequestSchema handler

### Design decisions

- Debounced (60s) to avoid running git on every tool call
- Once stale is detected, cached permanently (no need to re-check)
- Uses git diff on src/ specifically — doc-only changes don't trigger warning
- Warning is appended to tool response text, visible to both AI and user

## Spec verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Record git HEAD at startup | Met | StalenessDetector constructor |
| Debounced check on tool calls | Met | 60s CHECK_INTERVAL_MS |
| Only warn when src/ changed | Met | git diff --name-only -- src/ |
| Append to tool responses | Met | CallToolRequestSchema handler |
| Non-disruptive | Met | No crash, no disconnect |
| 1512 tests pass | Met | validate-all clean |

Had Claude look into this.