### PR TITLE
feat(mt#739): Add post-merge hook to auto-install when bun.lock changes

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,4 @@
-if git diff --name-only HEAD@{1} HEAD | grep -q "bun.lock"; then
+if git diff --name-only ORIG_HEAD HEAD | grep -q "bun.lock"; then
   echo "bun.lock changed, running bun install..."
   bun install
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,4 @@
+if git diff --name-only HEAD@{1} HEAD | grep -q "bun.lock"; then
+  echo "bun.lock changed, running bun install..."
+  bun install
+fi


### PR DESCRIPTION
## Summary

- Adds `.husky/post-merge` hook that detects when `bun.lock` changes after a merge
- Automatically runs `bun install` to keep local packages in sync with the lockfile
- Prevents crashes (like the ESLint failure after PR #411 added `minimatch`) caused by missing packages after pulling merges

## Test plan

- [ ] Merge a PR that adds/updates a dependency and verify `bun install` runs automatically
- [ ] Merge a PR with no lockfile changes and verify `bun install` does NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)