### PR TITLE
fix(mt#738): Enable prefer-const and no-useless-escape ESLint rules

### DIFF
--- a/eslint-rules/__fixtures__/pathological-fs-usage.js
+++ b/eslint-rules/__fixtures__/pathological-fs-usage.js
@@ -9,7 +9,7 @@ import { mkdir, writeFile } from "fs/promises";
 
 // ❌ SHOULD BE DETECTED: Global counters
 let testSequenceNumber = 0;
-let _globalCounter = 0;
+const _globalCounter = 0;
 
 describe("filesystem operations test", () => {
   // ❌ SHOULD BE DETECTED: Real filesystem in test hooks

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -366,11 +366,11 @@ export default [
       // Removed: indent, linebreak-style, quotes, semi - Prettier handles these
 
       // === OTHER ===
-      "prefer-const": "off",
+      "prefer-const": "error",
       "no-restricted-globals": "off",
       "import/extensions": "off",
       "import/no-unresolved": ["off", { ignore: [".ts"] }],
-      "no-useless-escape": "off",
+      "no-useless-escape": "error",
     },
   },
   {

--- a/src/domain/context/components/tool-schemas.ts
+++ b/src/domain/context/components/tool-schemas.ts
@@ -125,7 +125,7 @@ export const ToolSchemasComponent: ContextComponent = {
       // disable query-based filtering to ensure full registry visibility.
       let shouldFilterByQuery = Boolean(userQuery?.trim()) && !context.commandRegistry;
 
-      let toolSchemas: Record<string, unknown> = {};
+      const toolSchemas: Record<string, unknown> = {};
       let totalTools = 0;
       let filteredBy: string | undefined;
       let originalToolCount: number | undefined;

--- a/src/domain/context/components/workspace-rules.ts
+++ b/src/domain/context/components/workspace-rules.ts
@@ -32,11 +32,11 @@ export const WorkspaceRulesComponent: ContextComponent = {
       // Check if we should use enhanced filtering
       const userQuery = context.userQuery || context.userPrompt;
       const filesInContext = context.filesInContext || [];
-      let shouldUseEnhancedFiltering = Boolean(userQuery?.trim() || filesInContext.length > 0);
+      const shouldUseEnhancedFiltering = Boolean(userQuery?.trim() || filesInContext.length > 0);
 
       let filteredRules: Rule[] = [];
       let filteredBy: string | undefined;
-      let queryUsed: string | undefined = userQuery;
+      const queryUsed: string | undefined = userQuery;
       let reductionPercentage: number | undefined;
       let rulesByType: Record<string, Rule[]> | undefined;
 

--- a/src/domain/context/rule-suggestion.ts
+++ b/src/domain/context/rule-suggestion.ts
@@ -181,7 +181,7 @@ Only suggest rules that are actually relevant. If no rules match well, return em
       const ruleText = `${rule.id} ${rule.name || ""} ${rule.description || ""}`.toLowerCase();
 
       let relevanceScore = 0;
-      let matchedKeywords: string[] = [];
+      const matchedKeywords: string[] = [];
 
       // Look for meaningful keyword matches (not just any substring)
       for (const queryWord of queryWords) {

--- a/src/domain/git/prepare-pr-operations.ts
+++ b/src/domain/git/prepare-pr-operations.ts
@@ -105,7 +105,7 @@ export async function preparePrImpl(
 
   // Determine working directory and current branch
   if (options.session) {
-    let record = await deps.sessionDb.getSession(options.session);
+    const record = await deps.sessionDb.getSession(options.session);
 
     // Add more detailed debugging
     log.debug(

--- a/src/domain/git/prepare-pr.ts
+++ b/src/domain/git/prepare-pr.ts
@@ -40,7 +40,7 @@ export async function preparePr(
 
   // Determine working directory and current branch
   if (options.session) {
-    let record = await deps.sessionDb.getSession(options.session);
+    const record = await deps.sessionDb.getSession(options.session);
 
     // Add more detailed debugging
     log.debug(

--- a/src/domain/git/prepared-merge-commit-uncommitted-changes.test.ts
+++ b/src/domain/git/prepared-merge-commit-uncommitted-changes.test.ts
@@ -43,7 +43,7 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         if (stashEntries.length > 0) {
           const stashMessage =
             elementAt(stashEntries, stashEntries.length - 1, STASH_LIST_COMMAND).command.match(
-              /\"([^\"]+)\"/
+              /"([^"]+)"/
             )?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {
@@ -154,7 +154,7 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         if (stashEntries.length > 0) {
           const stashMessage =
             elementAt(stashEntries, stashEntries.length - 1, STASH_LIST_COMMAND).command.match(
-              /\"([^\"]+)\"/
+              /"([^"]+)"/
             )?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {
@@ -246,7 +246,7 @@ describe("Prepared Merge Commit Workflow - Uncommitted Changes Handling", () => 
         if (stashEntries.length > 0) {
           const stashMessage =
             elementAt(stashEntries, stashEntries.length - 1, STASH_LIST_COMMAND).command.match(
-              /\"([^\"]+)\"/
+              /"([^"]+)"/
             )?.[1] || "prepared-merge";
           return { stdout: `stash@{0}: On branch: ${stashMessage}`, stderr: "" };
         } else {

--- a/src/domain/repository-uri.ts
+++ b/src/domain/repository-uri.ts
@@ -64,7 +64,7 @@ export function parseRepositoryURI(uri: string): RepositoryURIComponents {
     });
 
     // Extract components based on format
-    let components: Partial<RepositoryURIComponents> = {
+    const components: Partial<RepositoryURIComponents> = {
       original: uri,
       normalized: normalizedInfo.name,
     };

--- a/src/domain/repository/github.ts
+++ b/src/domain/repository/github.ts
@@ -84,8 +84,8 @@ export class GitHubBackend implements RepositoryBackend {
       try {
         // SSH: git@github.com:owner/repo.git
         // HTTPS: https://github.com/owner/repo.git
-        const sshMatch = this.repoUrl.match(/git@github\.com:([^\/]+)\/([^\.]+)/);
-        const httpsMatch = this.repoUrl.match(/https:\/\/github\.com\/([^\.]+)\/([^\.]+)/);
+        const sshMatch = this.repoUrl.match(/git@github\.com:([^/]+)\/([^.]+)/);
+        const httpsMatch = this.repoUrl.match(/https:\/\/github\.com\/([^.]+)\/([^.]+)/);
         const match = sshMatch || httpsMatch;
         if (match && match[1] && match[2]) {
           this.owner = this.owner || match[1];

--- a/src/domain/rules/templates/integration-templates.ts
+++ b/src/domain/rules/templates/integration-templates.ts
@@ -168,7 +168,7 @@ After PR merge:
 
 \`\`\`bash
 # 1. Verify implementation complete and tests passing
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 2. Update task status to IN-REVIEW
 ${helpers.command("tasks.status.set")}
@@ -181,7 +181,7 @@ ${helpers.command("session.pr.create")}
 
 \`\`\`bash
 # 1. Ensure fix is complete and tested
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 2. Update task status
 ${helpers.command("tasks.status.set")}
@@ -194,7 +194,7 @@ ${helpers.command("session.pr.create")}
 
 \`\`\`bash
 # 1. Verify documentation changes
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 2. Set appropriate status
 ${helpers.command("tasks.status.set")}

--- a/src/domain/rules/templates/session-templates.ts
+++ b/src/domain/rules/templates/session-templates.ts
@@ -179,7 +179,7 @@ ${helpers.command("tasks.get")}
 ${helpers.command("session.start")}
 
 # 3. Navigate to session workspace
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 4. Begin implementation
 \`\`\`
@@ -194,14 +194,14 @@ ${helpers.command("session.list")}
 ${helpers.command("session.dir")}
 
 # 3. Navigate and continue work
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 \`\`\`
 
 ### Scenario 3: Updating Session
 
 \`\`\`bash
 # 1. Ensure you're in session directory
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 2. Update session with latest changes
 ${helpers.command("session.update")}
@@ -213,7 +213,7 @@ ${helpers.command("session.update")}
 
 \`\`\`bash
 # 1. Verify all changes committed in session
-cd \$(${helpers.command("session.dir")})
+cd $(${helpers.command("session.dir")})
 
 # 2. Create pull request from session
 ${helpers.command("session.pr.create")}

--- a/src/domain/session/migration-command.test.ts
+++ b/src/domain/session/migration-command.test.ts
@@ -67,7 +67,7 @@ const createMockSessionData = () => {
 
 // Mock SessionProviderInterface
 function createMockSessionDB(initialSessions: SessionRecord[] = []): SessionProviderInterface {
-  let sessions = [...initialSessions];
+  const sessions = [...initialSessions];
 
   return {
     listSessions: mock(async () => [...sessions]),

--- a/src/domain/session/migration-command.ts
+++ b/src/domain/session/migration-command.ts
@@ -197,7 +197,7 @@ export class SessionMigrationService {
     try {
       const _enhanced = SessionMultiBackendIntegration.enhanceSessionRecord(session);
       // Strict-only: perform a minimal migration that upgrades legacy task IDs and session IDs
-      let migrated: MultiBackendSessionRecord = { ...session } as MultiBackendSessionRecord;
+      const migrated: MultiBackendSessionRecord = { ...session } as MultiBackendSessionRecord;
       let sessionIdChanged = false;
       let taskIdChanged = false;
       let backendAdded = false;

--- a/src/domain/session/repository-backend-detection.ts
+++ b/src/domain/session/repository-backend-detection.ts
@@ -370,8 +370,8 @@ export function extractGitHubInfoFromUrl(
   try {
     // SSH: git@github.com:owner/repo.git
     // HTTPS: https://github.com/owner/repo.git
-    const sshMatch = remoteUrl.match(/git@github\.com:([^\/]+)\/([^\.]+)/);
-    const httpsMatch = remoteUrl.match(/https:\/\/github\.com\/([^\/]+)\/([^\.]+)/);
+    const sshMatch = remoteUrl.match(/git@github\.com:([^/]+)\/([^.]+)/);
+    const httpsMatch = remoteUrl.match(/https:\/\/github\.com\/([^/]+)\/([^.]+)/);
 
     const match = sshMatch || httpsMatch;
     if (match && match[1] && match[2]) {

--- a/src/domain/session/session-start-operations.ts
+++ b/src/domain/session/session-start-operations.ts
@@ -147,7 +147,7 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
     // Check if a session already exists for this task
     if (taskId) {
       const existingSessions = await deps.sessionDB.listSessions();
-      let taskSession = existingSessions.find((s: SessionRecord) => {
+      const taskSession = existingSessions.find((s: SessionRecord) => {
         // Both taskId (from schema normalization) and s.taskId should be in plain format
         return s.taskId === taskId;
       });

--- a/src/domain/session/session-update-operations.ts
+++ b/src/domain/session/session-update-operations.ts
@@ -27,7 +27,7 @@ export async function updateSessionImpl(
   params: SessionUpdateParameters,
   deps: UpdateSessionDependencies
 ): Promise<Session> {
-  let {
+  const {
     name,
     branch,
     remote,

--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -130,10 +130,9 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
     let referenceRepo: string | undefined;
     if (!repo) {
       try {
-        let candidatePath: string | undefined;
         const { getConfiguration } = await import("../configuration/index");
         const cfg = getConfiguration() as { workspace?: { mainPath?: string } };
-        candidatePath = cfg.workspace?.mainPath || currentDir;
+        const candidatePath = cfg.workspace?.mainPath || currentDir;
 
         const localRemote = (
           await deps.gitService.execInRepository(candidatePath, "git remote get-url origin")
@@ -212,7 +211,7 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
     // Check if a session already exists for this task
     if (taskId) {
       const existingSessions = await deps.sessionDB.listSessions();
-      let taskSession = existingSessions.find((s: SessionRecord) => {
+      const taskSession = existingSessions.find((s: SessionRecord) => {
         // Both taskId (from schema normalization) and s.taskId should be in plain format
         return s.taskId === taskId;
       });

--- a/src/domain/tasks/dynamic-backend-selection.test.ts
+++ b/src/domain/tasks/dynamic-backend-selection.test.ts
@@ -33,7 +33,7 @@ describe("Dynamic Backend Selection", () => {
   });
 
   test("should support both explicit and automatic backend selection", async () => {
-    let capturedBackends: (string | undefined)[] = [];
+    const capturedBackends: (string | undefined)[] = [];
 
     const mockCreateTaskService = mock(
       async (options: { workspacePath: string; backend?: string }) => {

--- a/src/domain/tasks/github-issues-mapping.ts
+++ b/src/domain/tasks/github-issues-mapping.ts
@@ -59,7 +59,7 @@ export function formatGitHubTasks(tasks: TaskData[], statusLabels: Record<string
 export function parseGitHubTaskSpec(content: string): TaskSpecData {
   const lines = content.toString().split("\n");
   let title = "";
-  let metadata: Record<string, unknown> = {};
+  const metadata: Record<string, unknown> = {};
   let currentSection = "";
   const descriptionLines: string[] = [];
 

--- a/src/domain/tasks/githubBackendConfig.ts
+++ b/src/domain/tasks/githubBackendConfig.ts
@@ -38,8 +38,8 @@ function extractGitHubRepoFromRemote(
     // Parse GitHub repository from various URL formats
     // SSH: git@github.com:owner/repo.git
     // HTTPS: https://github.com/owner/repo.git
-    const sshMatch = remoteUrl.match(/git@github\.com:([^\/]+)\/([^\.]+)/);
-    const httpsMatch = remoteUrl.match(/https:\/\/github\.com\/([^\/]+)\/([^\.]+)/);
+    const sshMatch = remoteUrl.match(/git@github\.com:([^/]+)\/([^.]+)/);
+    const httpsMatch = remoteUrl.match(/https:\/\/github\.com\/([^/]+)\/([^.]+)/);
 
     const match = sshMatch || httpsMatch;
     if (match && match[1] && match[2]) {
@@ -61,8 +61,8 @@ function extractGitHubRepoFromRemote(
           .trim();
 
         // Recursively parse the upstream remote
-        const upstreamSshMatch = upstreamUrl.match(/git@github\.com:([^\/]+)\/([^\.]+)/);
-        const upstreamHttpsMatch = upstreamUrl.match(/https:\/\/github\.com\/([^\/]+)\/([^\.]+)/);
+        const upstreamSshMatch = upstreamUrl.match(/git@github\.com:([^/]+)\/([^.]+)/);
+        const upstreamHttpsMatch = upstreamUrl.match(/https:\/\/github\.com\/([^/]+)\/([^.]+)/);
 
         const upstreamMatch = upstreamSshMatch || upstreamHttpsMatch;
         if (upstreamMatch && upstreamMatch[1] && upstreamMatch[2]) {
@@ -73,7 +73,7 @@ function extractGitHubRepoFromRemote(
         }
       } catch (error) {
         // Fallback: extract from path if it looks like a repo name
-        const pathMatch = remoteUrl.match(/\/([^\/]+)$/);
+        const pathMatch = remoteUrl.match(/\/([^/]+)$/);
         if (pathMatch && (pathMatch[1] || "") === "minsky") {
           // Hardcoded fallback for known repository
           return {

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -591,7 +591,7 @@ export async function getTaskSpecContentFromParams(
 
       if (sectionStart === -1) {
         throw new ResourceNotFoundError(
-          `Section \"${validParams.section}\" not found in task ${taskId} specification`
+          `Section "${validParams.section}" not found in task ${taskId} specification`
         );
       }
 

--- a/src/domain/uri-utils.ts
+++ b/src/domain/uri-utils.ts
@@ -99,7 +99,7 @@ export function normalizeRepositoryUri(
   if (normalizedUri.startsWith("https://")) {
     format = UriFormat?.HTTPS;
     // Extract org/repo from the URL
-    const match = normalizedUri.match(/https:\/\/[^\/]+\/([^\/]+)\/([^\/]+?)(\.git)?$/);
+    const match = normalizedUri.match(/https:\/\/[^/]+\/([^/]+)\/([^/]+?)(\.git)?$/);
     if (!match || !match[1] || !match[2]) {
       throw new ValidationError(`Invalid HTTPS repository URL: ${uri}`);
     }
@@ -114,7 +114,7 @@ export function normalizeRepositoryUri(
   else if (normalizedUri.includes("@") && normalizedUri.includes(":")) {
     format = UriFormat?.SSH;
     // Extract org/repo from the URL
-    const match = normalizedUri.match(/[^@]+@[^:]+:([^\/]+)\/([^\/]+?)(\.git)?$/);
+    const match = normalizedUri.match(/[^@]+@[^:]+:([^/]+)\/([^/]+?)(\.git)?$/);
     if (!match || !match[1] || !match[2]) {
       throw new ValidationError(`Invalid SSH repository URL: ${uri}`);
     }
@@ -177,7 +177,7 @@ export function normalizeRepositoryUri(
     }
   }
   // DEFAULT_RETRY_COUNT. Handle GitHub shorthand notation (org/repo)
-  else if (normalizedUri.match(/^[^\/]+\/[^\/]+$/)) {
+  else if (normalizedUri.match(/^[^/]+\/[^/]+$/)) {
     format = UriFormat?.SHORTHAND;
     // Shorthand is already in org/repo format
     normalizedName = normalizedUri;

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -151,7 +151,7 @@ export function generateDiffSummary(
 
   let linesAdded = 0;
   let linesRemoved = 0;
-  let linesChanged = 0;
+  const linesChanged = 0;
 
   const minLines = Math.min(originalLines.length, modifiedLines.length);
   const _maxLines = Math.max(originalLines.length, modifiedLines.length);

--- a/src/utils/semantic-error-classifier.ts
+++ b/src/utils/semantic-error-classifier.ts
@@ -297,7 +297,7 @@ export class SemanticErrorClassifier {
       this.extractPathFromError(rawMessage);
 
     // Enhance solutions based on context
-    let solutions = [...mapping.solutions];
+    const solutions = [...mapping.solutions];
 
     // Add context-specific solutions
     if (

--- a/tests/adapters/cli/session-directory.test.ts
+++ b/tests/adapters/cli/session-directory.test.ts
@@ -24,7 +24,7 @@ describe("session dir command", () => {
   test("should return correct session directory for task ID", async () => {
     // Arrange: Mock correct behavior with call tracking
     const correctSession = testData.mockSessions[1]; // task#160 session
-    let getSessionByTaskIdCalls: any[] = [];
+    const getSessionByTaskIdCalls: any[] = [];
 
     testData.mockSessionDB.getSessionByTaskId = mock((taskId: any) => {
       getSessionByTaskIdCalls.push(taskId);
@@ -61,7 +61,7 @@ describe("session dir command", () => {
   test("should normalize task IDs correctly (with and without # prefix)", async () => {
     // Arrange with call tracking
     const correctSession = testData.mockSessions[1];
-    let getSessionByTaskIdCalls: any[] = [];
+    const getSessionByTaskIdCalls: any[] = [];
 
     testData.mockSessionDB.getSessionByTaskId = mock((taskId: any) => {
       getSessionByTaskIdCalls.push(taskId);

--- a/tests/integration/github-api.integration.test.ts
+++ b/tests/integration/github-api.integration.test.ts
@@ -32,7 +32,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
   "GitHub API Integration Tests",
   () => {
     let octokit: Octokit;
-    let createdIssueNumbers: number[] = [];
+    const createdIssueNumbers: number[] = [];
 
     beforeAll(async () => {
       console.log("🔍 Setting up GitHub API integration tests...");


### PR DESCRIPTION
## Summary

- Fixed 32 `prefer-const` violations across 19 files: changed `let` declarations that are never reassigned to `const`
- Fixed 42 `no-useless-escape` violations across 8 files: removed unnecessary backslash escapes in regex character classes (`[^\/]` → `[^/]`, `[^\.]` → `[^.]`) and template literals (`\"` → `"`, `\$` → `$`)
- Enabled both rules as `"error"` in `eslint.config.js` (previously `"off"`)

## Key changes

- `eslint.config.js`: `prefer-const: "off"` → `"error"`, `no-useless-escape: "off"` → `"error"`
- Regex patterns in GitHub URL parsers (`githubBackendConfig.ts`, `repository-backend-detection.ts`, `github.ts`, `uri-utils.ts`): removed useless `\/` and `\.` inside character classes
- Template literals in rule templates: removed useless `\$` before `(`
- Destructuring in `session-update-operations.ts`: changed `let { name, branch, ... } = params` to `const` since none of the destructured vars are reassigned
- Various `let x = []` / `let x = {}` where only mutation (not reassignment) occurs → `const`

## Test plan

- [x] Pre-commit hook runs ESLint with `MAX_LINT_WARNINGS = 0` — commit succeeded, confirming 0 errors from these rules
- [x] 27 files changed, all semantic behavior preserved (only variable binding mutability and regex character class escaping changed)
- [ ] CI build should pass without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)