### PR TITLE
refactor(mt#757): remove unused createFormattedValidationError export

### DIFF
--- a/src/utils/zod-error-formatter.ts
+++ b/src/utils/zod-error-formatter.ts
@@ -181,14 +181,3 @@ function isTaskStatusEnum(options: string[]): boolean {
     options.every((option) => (TASK_STATUS_VALUES as string[]).includes(option))
   );
 }
-
-/**
- * Create a formatted error message for common validation scenarios
- * @param operation The operation being performed (e.g., "setting task status")
- * @param error The Zod validation error
- * @returns Formatted error message
- */
-export function createFormattedValidationError(operation: string, error: ZodError): string {
-  const formattedError = formatZodError(error, operation);
-  return `Invalid parameters for ${operation}:\n${formattedError}`;
-}


### PR DESCRIPTION
## Summary

Final item from the dead code audit. Remove `createFormattedValidationError` from `zod-error-formatter.ts` — a 4-line wrapper around `formatZodError` with zero consumers. `formatZodError` (the live export) is unchanged.

## Test plan

- [x] `tsc --noEmit` — no errors
- [x] Full suite — 1474/1474 pass