### PR TITLE
perf(mt#750): defer persistence init and convert session commands to lazy deps

### DIFF
--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -4,7 +4,7 @@
  * Constructs and registers all session commands (and changeset aliases)
  * in the shared command registry.
  */
-import { type SessionCommandDependencies } from "./session/types";
+import { type SessionCommandDependencies, type LazySessionDeps } from "./session/types";
 import {
   createSessionListCommand,
   createSessionGetCommand,
@@ -42,47 +42,54 @@ import { sharedCommandRegistry, type CommandDefinition } from "../command-regist
 export async function registerSessionCommands(
   partialDeps?: Partial<SessionCommandDependencies>
 ): Promise<void> {
-  const { getSharedSessionProvider } = await import(
-    "../../../domain/session/session-provider-cache"
-  );
-  const { createSessionDeps } = await import("../../../domain/session/session-service");
-  const sessionProvider = partialDeps?.sessionProvider ?? (await getSharedSessionProvider());
-  const deps: SessionCommandDependencies = await createSessionDeps(sessionProvider);
+  // Lazy resolver: defers persistence initialization and domain module loading
+  // to first command execution. CLI bootstrap only registers metadata.
+  let cachedDeps: SessionCommandDependencies | null = null;
+  const getDeps: LazySessionDeps = async () => {
+    if (cachedDeps) return cachedDeps;
+    const { getSharedSessionProvider } = await import(
+      "../../../domain/session/session-provider-cache"
+    );
+    const { createSessionDeps } = await import("../../../domain/session/session-service");
+    const sessionProvider = partialDeps?.sessionProvider ?? (await getSharedSessionProvider());
+    cachedDeps = await createSessionDeps(sessionProvider);
+    return cachedDeps;
+  };
 
   const commands: CommandDefinition[] = [
     // Basic
-    createSessionListCommand(deps),
-    createSessionGetCommand(deps),
-    createSessionStartCommand(deps),
-    createSessionDirCommand(deps),
-    createSessionSearchCommand(deps),
+    createSessionListCommand(getDeps),
+    createSessionGetCommand(getDeps),
+    createSessionStartCommand(getDeps),
+    createSessionDirCommand(getDeps),
+    createSessionSearchCommand(getDeps),
 
     // Management
-    createSessionDeleteCommand(deps),
-    createSessionUpdateCommand(deps),
-    createSessionMigrateBackendCommand(deps),
+    createSessionDeleteCommand(getDeps),
+    createSessionUpdateCommand(getDeps),
+    createSessionMigrateBackendCommand(getDeps),
 
     // Workflow
-    createSessionCommitCommand(deps),
+    createSessionCommitCommand(getDeps),
     // NOTE: session.approve removed in favor of session.pr.approve (Task #358)
-    createSessionInspectCommand(deps),
-    createSessionReviewCommand(deps),
+    createSessionInspectCommand(getDeps),
+    createSessionReviewCommand(getDeps),
 
     // PR subcommands
-    createSessionPrCreateCommand(deps),
-    createSessionPrEditCommand(deps),
-    createSessionPrListCommand(deps),
-    createSessionPrGetCommand(deps),
-    createSessionPrOpenCommand(deps),
-    createSessionPrApproveCommand(deps),
-    createSessionPrMergeCommand(deps),
+    createSessionPrCreateCommand(getDeps),
+    createSessionPrEditCommand(getDeps),
+    createSessionPrListCommand(getDeps),
+    createSessionPrGetCommand(getDeps),
+    createSessionPrOpenCommand(getDeps),
+    createSessionPrApproveCommand(getDeps),
+    createSessionPrMergeCommand(getDeps),
 
     // Utility
-    createSessionConflictsCommand(deps),
-    createSessionRepairCommand(deps),
+    createSessionConflictsCommand(getDeps),
+    createSessionRepairCommand(getDeps),
 
     // File
-    createSessionEditFileCommand(deps),
+    createSessionEditFileCommand(getDeps),
   ];
 
   for (const cmd of commands) {

--- a/src/adapters/shared/commands/session/basic-commands.ts
+++ b/src/adapters/shared/commands/session/basic-commands.ts
@@ -4,7 +4,7 @@
  * Factories for basic session operations (list, get, start, dir, search).
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import {
   sessionListCommandParams,
   sessionGetCommandParams,
@@ -13,7 +13,7 @@ import {
   sessionSearchCommandParams,
 } from "./session-parameters";
 
-export function createSessionListCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionListCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.list",
     category: CommandCategory.SESSION,
@@ -49,7 +49,7 @@ export function createSessionListCommand(deps: SessionCommandDependencies): Comm
   };
 }
 
-export function createSessionGetCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionGetCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.get",
     category: CommandCategory.SESSION,
@@ -91,7 +91,7 @@ export function createSessionGetCommand(deps: SessionCommandDependencies): Comma
   };
 }
 
-export function createSessionStartCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionStartCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.start",
     category: CommandCategory.SESSION,
@@ -131,7 +131,7 @@ export function createSessionStartCommand(deps: SessionCommandDependencies): Com
   };
 }
 
-export function createSessionDirCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionDirCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.dir",
     category: CommandCategory.SESSION,
@@ -155,7 +155,7 @@ export function createSessionDirCommand(deps: SessionCommandDependencies): Comma
   };
 }
 
-export function createSessionSearchCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionSearchCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.search",
     category: CommandCategory.SESSION,
@@ -167,6 +167,7 @@ export function createSessionSearchCommand(deps: SessionCommandDependencies): Co
       const limit = params.limit as number | undefined;
 
       const { log } = await import("../../../../utils/logger");
+      const deps = await getDeps();
       const sessions = await deps.sessionProvider.listSessions();
 
       const lowerQuery = query.toLowerCase();

--- a/src/adapters/shared/commands/session/conflicts-command.ts
+++ b/src/adapters/shared/commands/session/conflicts-command.ts
@@ -5,7 +5,7 @@
  */
 import { z } from "zod";
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import {
   scanSessionConflicts,
   formatSessionConflictResults,
@@ -44,7 +44,7 @@ export const sessionConflictsCommandParams = {
   },
 };
 
-export function createSessionConflictsCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionConflictsCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.conflicts",
     category: CommandCategory.SESSION,

--- a/src/adapters/shared/commands/session/file-commands.ts
+++ b/src/adapters/shared/commands/session/file-commands.ts
@@ -6,7 +6,7 @@
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
 import { MinskyError, getErrorMessage } from "../../../../errors/index";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type SessionCommandDependencies, type LazySessionDeps, withErrorLogging } from "./types";
 import { sessionEditFileCommandParams } from "./session-parameters";
 import { readTextFile } from "../../../../utils/fs";
 
@@ -236,7 +236,7 @@ function formatResult(
   };
 }
 
-export function createSessionEditFileCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionEditFileCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.edit-file",
     category: CommandCategory.SESSION,
@@ -246,6 +246,7 @@ export function createSessionEditFileCommand(deps: SessionCommandDependencies): 
     execute: withErrorLogging("session.edit-file", async (params: Record<string, unknown>) => {
       const typedParams = params as SessionEditFileParams;
       try {
+        const deps = await getDeps();
         const sessionId = await resolveSessionId(deps, typedParams);
         const content = await getEditPattern(typedParams);
 

--- a/src/adapters/shared/commands/session/management-commands.ts
+++ b/src/adapters/shared/commands/session/management-commands.ts
@@ -4,14 +4,14 @@
  * Factories for session management operations (delete, update, migrate-backend).
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import {
   sessionDeleteCommandParams,
   sessionUpdateCommandParams,
   sessionMigrateBackendCommandParams,
 } from "./session-parameters";
 
-export function createSessionDeleteCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionDeleteCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.delete",
     category: CommandCategory.SESSION,
@@ -38,7 +38,7 @@ export function createSessionDeleteCommand(deps: SessionCommandDependencies): Co
   };
 }
 
-export function createSessionUpdateCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionUpdateCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.update",
     category: CommandCategory.SESSION,
@@ -79,9 +79,7 @@ export function createSessionUpdateCommand(deps: SessionCommandDependencies): Co
  * the upstream origin URL from the session workspace and updating the session
  * DB record.
  */
-export function createSessionMigrateBackendCommand(
-  deps: SessionCommandDependencies
-): CommandDefinition {
+export function createSessionMigrateBackendCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.migrate-backend",
     category: CommandCategory.SESSION,
@@ -91,6 +89,7 @@ export function createSessionMigrateBackendCommand(
     execute: withErrorLogging(
       "session.migrate-backend",
       async (params: Record<string, unknown>) => {
+        const deps = await getDeps();
         const { resolveSessionContextWithFeedback } = await import(
           "../../../../domain/session/session-context-resolver"
         );

--- a/src/adapters/shared/commands/session/pr-create-command.ts
+++ b/src/adapters/shared/commands/session/pr-create-command.ts
@@ -14,7 +14,7 @@ import {
   getErrorMessage,
 } from "../../../../errors/index";
 import { log } from "../../../../utils/logger";
-import { type SessionCommandDependencies } from "./types";
+import { type SessionCommandDependencies, type LazySessionDeps } from "./types";
 import { sessionPrCreateCommandParams } from "./session-parameters";
 import { sessionPrCreate } from "../../../../domain/session/commands/pr-subcommands";
 import { composeConventionalTitle } from "./pr-conventional-title";
@@ -284,7 +284,7 @@ export async function executeSessionPrCreate(
   }
 }
 
-export function createSessionPrCreateCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrCreateCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.create",
     category: CommandCategory.SESSION,
@@ -293,6 +293,7 @@ export function createSessionPrCreateCommand(deps: SessionCommandDependencies): 
     parameters: sessionPrCreateCommandParams,
     execute: async (params, context) => {
       try {
+        const deps = await getDeps();
         return await executeSessionPrCreate(deps, params as SessionPrCreateParams, context);
       } catch (error) {
         log.debug(`Error in session.pr.create`, {

--- a/src/adapters/shared/commands/session/pr-edit-command.ts
+++ b/src/adapters/shared/commands/session/pr-edit-command.ts
@@ -14,7 +14,7 @@ import {
   getErrorMessage,
 } from "../../../../errors/index";
 import { log } from "../../../../utils/logger";
-import { type SessionCommandDependencies } from "./types";
+import { type SessionCommandDependencies, type LazySessionDeps } from "./types";
 import { sessionPrEditCommandParams } from "./session-parameters";
 import { sessionPrEdit } from "../../../../domain/session/commands/pr-subcommands";
 import { composeConventionalTitle } from "./pr-conventional-title";
@@ -176,7 +176,7 @@ export async function executeSessionPrEdit(
   }
 }
 
-export function createSessionPrEditCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrEditCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.edit",
     category: CommandCategory.SESSION,
@@ -185,6 +185,7 @@ export function createSessionPrEditCommand(deps: SessionCommandDependencies): Co
     parameters: sessionPrEditCommandParams,
     execute: async (params, context) => {
       try {
+        const deps = await getDeps();
         return await executeSessionPrEdit(deps, params as SessionPrEditParams, context);
       } catch (error) {
         log.debug(`Error in session.pr.edit`, {

--- a/src/adapters/shared/commands/session/pr-get-command.ts
+++ b/src/adapters/shared/commands/session/pr-get-command.ts
@@ -4,12 +4,12 @@
 
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
 import { MinskyError, getErrorMessage } from "../../../../errors/index";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import { sessionPrGetCommandParams } from "./session-parameters";
 import { sessionPrGet } from "../../../../domain/session/commands/pr-subcommands";
 import { formatPrTitleLine } from "./pr-shared-helpers";
 
-export function createSessionPrGetCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrGetCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.get",
     category: CommandCategory.SESSION,
@@ -18,6 +18,7 @@ export function createSessionPrGetCommand(deps: SessionCommandDependencies): Com
     parameters: sessionPrGetCommandParams,
     execute: withErrorLogging("session.pr.get", async (params: Record<string, unknown>) => {
       try {
+        const deps = await getDeps();
         const result = await sessionPrGet(
           {
             sessionId: params.sessionId as string | undefined,

--- a/src/adapters/shared/commands/session/pr-list-command.ts
+++ b/src/adapters/shared/commands/session/pr-list-command.ts
@@ -4,7 +4,7 @@
 
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
 import { MinskyError, getErrorMessage } from "../../../../errors/index";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import { sessionPrListCommandParams } from "./session-parameters";
 import { sessionPrList } from "../../../../domain/session/commands/pr-subcommands";
 import { formatPrTitleLine } from "./pr-shared-helpers";
@@ -32,7 +32,7 @@ function formatRelativeTime(isoString: string): string {
   }
 }
 
-export function createSessionPrListCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrListCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.list",
     category: CommandCategory.SESSION,
@@ -41,6 +41,7 @@ export function createSessionPrListCommand(deps: SessionCommandDependencies): Co
     parameters: sessionPrListCommandParams,
     execute: withErrorLogging("session.pr.list", async (params: Record<string, unknown>) => {
       try {
+        const deps = await getDeps();
         const result = await sessionPrList(
           {
             session: params.session as string | undefined,

--- a/src/adapters/shared/commands/session/pr-open-command.ts
+++ b/src/adapters/shared/commands/session/pr-open-command.ts
@@ -4,11 +4,11 @@
 
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
 import { MinskyError, getErrorMessage } from "../../../../errors/index";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import { sessionPrOpenCommandParams } from "./session-parameters";
 import { sessionPrOpen } from "../../../../domain/session/commands/pr-subcommands";
 
-export function createSessionPrOpenCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrOpenCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.open",
     category: CommandCategory.SESSION,
@@ -17,6 +17,7 @@ export function createSessionPrOpenCommand(deps: SessionCommandDependencies): Co
     parameters: sessionPrOpenCommandParams,
     execute: withErrorLogging("session.pr.open", async (params: Record<string, unknown>) => {
       try {
+        const deps = await getDeps();
         const result = await sessionPrOpen(
           {
             sessionId: params.sessionId as string | undefined,

--- a/src/adapters/shared/commands/session/repair-command.ts
+++ b/src/adapters/shared/commands/session/repair-command.ts
@@ -2,7 +2,7 @@
  * Session Repair Command
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import { sessionRepairCommandParams } from "./session-parameters";
 import {
   sessionRepair,
@@ -12,7 +12,7 @@ import { log } from "../../../../utils/logger";
 import { toJsonRecord } from "../../../../utils/type-utils";
 import { getErrorMessage } from "../../../../errors/index";
 
-export function createSessionRepairCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionRepairCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.repair",
     category: CommandCategory.SESSION,
@@ -21,6 +21,7 @@ export function createSessionRepairCommand(deps: SessionCommandDependencies): Co
     parameters: sessionRepairCommandParams,
     execute: withErrorLogging("session.repair", async (params: Record<string, unknown>) => {
       try {
+        const deps = await getDeps();
         const repairParams: SessionRepairParameters = {
           name: params.name as string | undefined,
           task: params.task as string | undefined,

--- a/src/adapters/shared/commands/session/types.ts
+++ b/src/adapters/shared/commands/session/types.ts
@@ -18,6 +18,13 @@ import type { SessionDeps } from "../../../../domain/session/session-service";
 export type SessionCommandDependencies = SessionDeps;
 
 /**
+ * Lazy resolver for session command dependencies.
+ * Defers persistence initialization and domain module loading to first command execution,
+ * keeping CLI bootstrap fast (command registration only needs metadata + parameter schemas).
+ */
+export type LazySessionDeps = () => Promise<SessionCommandDependencies>;
+
+/**
  * Minimal parameter shape used by the error-logging helper to extract
  * session/task/repo context from arbitrary command params.
  */

--- a/src/adapters/shared/commands/session/workflow-commands.ts
+++ b/src/adapters/shared/commands/session/workflow-commands.ts
@@ -6,7 +6,7 @@
  * live in their own files and are re-exported here for convenience.
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
-import { type SessionCommandDependencies, withErrorLogging } from "./types";
+import { type LazySessionDeps, withErrorLogging } from "./types";
 import {
   sessionApproveCommandParams,
   sessionInspectCommandParams,
@@ -23,7 +23,7 @@ export { createSessionPrListCommand } from "./pr-list-command";
 export { createSessionPrGetCommand } from "./pr-get-command";
 export { createSessionPrOpenCommand } from "./pr-open-command";
 
-export function createSessionCommitCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionCommitCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.commit",
     category: CommandCategory.SESSION,
@@ -64,7 +64,7 @@ export function createSessionCommitCommand(deps: SessionCommandDependencies): Co
   };
 }
 
-export function createSessionApproveCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionApproveCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.approve",
     category: CommandCategory.SESSION,
@@ -86,7 +86,7 @@ export function createSessionApproveCommand(deps: SessionCommandDependencies): C
   };
 }
 
-export function createSessionInspectCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionInspectCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.inspect",
     category: CommandCategory.SESSION,
@@ -208,7 +208,7 @@ async function handleAutoApprove(
   }
 }
 
-export function createSessionReviewCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionReviewCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.review",
     category: CommandCategory.SESSION,
@@ -216,6 +216,7 @@ export function createSessionReviewCommand(deps: SessionCommandDependencies): Co
     description: "Review a session PR by gathering and displaying relevant information",
     parameters: sessionReviewCommandParams,
     execute: withErrorLogging("session.review", async (params: Record<string, unknown>) => {
+      const deps = await getDeps();
       const { sessionReviewImpl } = await import(
         "../../../../domain/session/session-review-operations"
       );
@@ -303,7 +304,7 @@ export function createSessionReviewCommand(deps: SessionCommandDependencies): Co
   };
 }
 
-export function createSessionPrApproveCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrApproveCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.approve",
     category: CommandCategory.SESSION,
@@ -327,7 +328,7 @@ export function createSessionPrApproveCommand(deps: SessionCommandDependencies):
   };
 }
 
-export function createSessionPrMergeCommand(deps: SessionCommandDependencies): CommandDefinition {
+export function createSessionPrMergeCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {
     id: "session.pr.merge",
     category: CommandCategory.SESSION,
@@ -335,6 +336,7 @@ export function createSessionPrMergeCommand(deps: SessionCommandDependencies): C
     description: "Merge an approved session pull request",
     parameters: sessionApproveCommandParams, // Reuse same params
     execute: withErrorLogging("session.pr.merge", async (params: Record<string, unknown>) => {
+      const deps = await getDeps();
       const { mergeSessionPr } = await import(
         "../../../../domain/session/session-merge-operations"
       );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,9 +48,12 @@ export async function createCli(): Promise<Command> {
   // Setup common command customizations with the CLI instance
   setupCommonCommandCustomizations(cli);
 
-  // Persistence must be initialized before shared command registration because
-  // session commands resolve their provider at registration time.
-  await ensurePersistence();
+  // Initialize persistence lazily via preAction hook — only when a command
+  // actually executes, not during registration or help display. Session commands
+  // use LazySessionDeps to defer provider resolution to execution time.
+  cli.hook("preAction", async () => {
+    await ensurePersistence();
+  });
 
   // Register shared commands (session, tasks, git, rules, config, etc.)
   const { registerAllSharedCommands } = await import("./adapters/shared/commands/index");

--- a/tests/adapters/shared/commands/session/session-edit-file.test.ts
+++ b/tests/adapters/shared/commands/session/session-edit-file.test.ts
@@ -7,9 +7,9 @@ import type { SessionCommandDependencies } from "../../../../../src/adapters/sha
 
 describe("session edit-file command definition", () => {
   // The factory only constructs the command definition; execute is never invoked
-  // in this suite, so an empty deps cast is sufficient.
+  // in this suite, so an empty deps thunk is sufficient.
   const deps = {} as SessionCommandDependencies;
-  const command = createSessionEditFileCommand(deps);
+  const command = createSessionEditFileCommand(() => Promise.resolve(deps));
 
   describe("command properties", () => {
     test("should have correct command id", () => {


### PR DESCRIPTION
## Summary

Completes the CLI bootstrap/service layer separation started in PR #424. Session command factories now accept lazy deps resolvers instead of eagerly-resolved dependencies, allowing `PersistenceService.initialize()` to be deferred from startup to first command execution.

### Before/After

| Command | Before (1.76s baseline) | After PR #424 | After this PR |
|---------|------------------------|---------------|---------------|
| `session --help` | 1.76s | 1.46s | **0.24s** |
| `--help` | 1.76s | 1.78s | **0.62s** |
| `tasks list` (execution) | ~2.1s | ~2.1s | ~2.3s (same) |

**`session --help`: 1.76s to 0.24s = 7.3x faster**

### What changed

1. **`LazySessionDeps` type** (`session/types.ts`): `() => Promise<SessionCommandDependencies>` — lazy resolver that defers provider creation to first command execution

2. **All session command factories** (14 files): Changed from `deps: SessionCommandDependencies` to `getDeps: LazySessionDeps`. Execute handlers call `const deps = await getDeps()` on first use. Commands that don't use deps (like `session.start` which already uses dynamic imports) pay zero cost.

3. **`registerSessionCommands`** (`session.ts`): Creates a cached lazy resolver instead of eagerly resolving the session provider. Provider is only created on first command execution.

4. **`cli.ts`**: `PersistenceService.initialize()` moved from before `createCli()` to a `preAction` hook that fires only when a command actually executes. Help display and command parsing skip persistence entirely.

### Design decisions

- **Exported helper functions** in `pr-create-command.ts` and `pr-edit-command.ts` retain `deps: SessionCommandDependencies` parameter since tests call them directly. Only the top-level factory accepts `LazySessionDeps`.
- The lazy resolver caches after first resolution — subsequent commands in the same process reuse the same deps.

## Test plan

- [x] 1474 tests pass, 0 failures
- [x] TypeScript typecheck passes
- [x] `minsky session --help` works (0.24s, no persistence init)
- [x] `minsky --help` shows all commands (0.62s)
- [x] `minsky tasks list` executes correctly (persistence initialized on demand)
- [x] Formatter applied