### PR TITLE
fix(mt#758): Preserve tags during backend migration

### DIFF
--- a/src/adapters/shared/commands/tasks/migrate-backend-command.ts
+++ b/src/adapters/shared/commands/tasks/migrate-backend-command.ts
@@ -316,6 +316,7 @@ export class TasksMigrateBackendCommand extends BaseTaskCommand<MigrateBackendPa
             force: true,
             id: newTaskId,
             status: fullTask.status,
+            tags: fullTask.tags,
           });
 
           // Update session task associations if task ID changed


### PR DESCRIPTION
## Summary

- Adds `tags: fullTask.tags` to the `createTaskFromTitleAndSpec` options call in the migrate-backend command
- Previously, tags were not passed during migration, causing them to be silently dropped when moving tasks between backends

## Test plan

- [x] `bun run validate-all` passes (1474 tests, 0 failures, typecheck clean)
- [ ] Manual: migrate a tagged task between backends and verify tags are preserved in the target backend