### PR TITLE
perf(mt#760): defer domain imports in tasks-modular and changeset commands

### DIFF
--- a/src/adapters/shared/commands/changeset/changeset-commands.ts
+++ b/src/adapters/shared/commands/changeset/changeset-commands.ts
@@ -7,13 +7,12 @@
  */
 
 import { z } from "zod";
-import { createChangesetService } from "../../../../domain/changeset/index";
+// Domain imports deferred to execute handlers to avoid loading at registration time.
 import type {
   ChangesetListOptions,
   ChangesetSearchOptions,
   ChangesetStatus,
 } from "../../../../domain/changeset/types";
-import { getRepositoryBackendFromConfig } from "../../../../domain/session/repository-backend-detection";
 import {
   sharedCommandRegistry,
   CommandCategory,
@@ -156,10 +155,14 @@ async function executeChangesetList(
   ctx?: CommandExecutionContext
 ): Promise<Record<string, unknown>> {
   try {
-    // Resolve repository
+    // Resolve repository (lazy-imported to defer domain loading)
+    const { getRepositoryBackendFromConfig } = await import(
+      "../../../../domain/session/repository-backend-detection"
+    );
     const { repoUrl } = await getRepositoryBackendFromConfig();
 
-    // Create changeset service
+    // Create changeset service (lazy-imported)
+    const { createChangesetService } = await import("../../../../domain/changeset/index");
     const changesetService = await createChangesetService(repoUrl);
 
     // Build list options
@@ -242,10 +245,14 @@ async function executeChangesetSearch(
   ctx?: CommandExecutionContext
 ): Promise<Record<string, unknown>> {
   try {
-    // Resolve repository
+    // Resolve repository (lazy-imported to defer domain loading)
+    const { getRepositoryBackendFromConfig } = await import(
+      "../../../../domain/session/repository-backend-detection"
+    );
     const { repoUrl } = await getRepositoryBackendFromConfig();
 
-    // Create changeset service
+    // Create changeset service (lazy-imported)
+    const { createChangesetService } = await import("../../../../domain/changeset/index");
     const changesetService = await createChangesetService(repoUrl);
 
     // Build search options
@@ -330,10 +337,14 @@ async function executeChangesetGet(
   ctx?: CommandExecutionContext
 ): Promise<Record<string, unknown>> {
   try {
-    // Resolve repository
+    // Resolve repository (lazy-imported to defer domain loading)
+    const { getRepositoryBackendFromConfig } = await import(
+      "../../../../domain/session/repository-backend-detection"
+    );
     const { repoUrl } = await getRepositoryBackendFromConfig();
 
-    // Create changeset service
+    // Create changeset service (lazy-imported)
+    const { createChangesetService } = await import("../../../../domain/changeset/index");
     const changesetService = await createChangesetService(repoUrl);
 
     // Get changeset
@@ -413,10 +424,14 @@ async function executeChangesetInfo(
   ctx?: CommandExecutionContext
 ): Promise<Record<string, unknown>> {
   try {
-    // Resolve repository
+    // Resolve repository (lazy-imported to defer domain loading)
+    const { getRepositoryBackendFromConfig } = await import(
+      "../../../../domain/session/repository-backend-detection"
+    );
     const { repoUrl } = await getRepositoryBackendFromConfig();
 
-    // Create changeset service
+    // Create changeset service (lazy-imported)
+    const { createChangesetService } = await import("../../../../domain/changeset/index");
     const changesetService = await createChangesetService(repoUrl);
     const platform = await changesetService.getPlatform();
 

--- a/src/adapters/shared/commands/tasks-modular.ts
+++ b/src/adapters/shared/commands/tasks-modular.ts
@@ -7,7 +7,8 @@
 import { sharedCommandRegistry, defineCommand } from "../command-registry";
 import { CommandCategory } from "../command-registry";
 import { log } from "../../../utils/logger";
-import { PersistenceService } from "../../../domain/persistence/service";
+// PersistenceService is lazy-imported inside the closure to avoid loading
+// the persistence module (~95ms) during command registration.
 import {
   createTasksListCommand,
   createTasksGetCommand,
@@ -48,7 +49,18 @@ export class ModularTasksCommandManager {
 
       // Create command instances to get their parameter definitions
       log.debug("[ModularTasksCommandManager] Creating command instances");
-      const getPersistenceProvider = () => PersistenceService.getProvider();
+      // Lazy: PersistenceService is imported on first call, not at registration.
+      // By command execution time, the preAction hook in cli.ts has already
+      // initialized PersistenceService, so getProvider() is safe to call sync.
+      let cachedPersistence: {
+        getProvider: () => import("../../../domain/persistence/types").PersistenceProvider;
+      } | null = null;
+      const getPersistenceProvider = () => {
+        if (!cachedPersistence) {
+          cachedPersistence = require("../../../domain/persistence/service").PersistenceService;
+        }
+        return cachedPersistence!.getProvider();
+      };
       const listCommand = createTasksListCommand();
       const getCommand = createTasksGetCommand();
       const createCommand = createTasksCreateCommand(getPersistenceProvider);


### PR DESCRIPTION
## Summary

Follow-up to mt#750 (CLI startup optimization). Defers eager domain imports in two more command modules:

1. **`tasks-modular.ts`**: `PersistenceService` was imported at module scope (~95ms) but only used inside a closure called at execute time. Changed to a lazy `require()` cached on first call, keeping the sync `() => PersistenceProvider` signature consumers expect.

2. **`changeset-commands.ts`**: `createChangesetService` and `getRepositoryBackendFromConfig` were imported at module scope but only used inside execute handlers. Moved to dynamic `await import()` inside each handler (4 occurrences).

Part of mt#760 (audit remaining command modules for eager domain imports).

## Test plan

- [x] TypeScript typecheck passes
- [x] 1476 tests pass, 0 failures
- [x] Pre-commit hooks pass