### PR TITLE
fix(mt#748): Use real source tracking for credential display in config show

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "supabase-postgres-best-practices": {
       "source": "supabase/agent-skills",
       "sourceType": "github",
-      "computedHash": "f4cd7570115d97af6bcb2946eb891a958c8d04a43b479871c9ccadbc670ad058"
+      "computedHash": "d606a1146be6d54fb9e73f718b5320b9acac5ff2ba2d7230a555df4b5a923b4a"
     }
   }
 }

--- a/src/adapters/shared/commands/config.ts
+++ b/src/adapters/shared/commands/config.ts
@@ -215,7 +215,7 @@ const configShowRegistration = defineCommand({
 
       // Gather credential information safely
       const credentialResolver = new DefaultCredentialResolver();
-      const credentials = await gatherCredentialInfo(credentialResolver, config);
+      const credentials = await gatherCredentialInfo(credentialResolver, config, effectiveValues);
 
       // Show ALL configuration properties dynamically instead of hardcoding subset
       const resolved = {
@@ -256,7 +256,8 @@ const configShowRegistration = defineCommand({
  */
 async function gatherCredentialInfo(
   credentialResolver: DefaultCredentialResolver,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  effectiveValues: Record<string, { value: unknown; source: string; path: string }>
 ) {
   const credentials: Record<string, unknown> = {};
 
@@ -266,7 +267,7 @@ async function gatherCredentialInfo(
     if (githubToken) {
       credentials.github = {
         token: `${"*".repeat(20)} (configured)`,
-        source: "environment", // Simplified for display
+        source: effectiveValues["github.token"]?.source ?? "unknown",
       };
     }
   } catch (error) {
@@ -288,9 +289,10 @@ async function gatherCredentialInfo(
       ) {
         const providerCfg = providerConfig as Record<string, unknown>;
         if (providerCfg.apiKey) {
+          const keyPath = `ai.providers.${provider}.apiKey`;
           (credentials.ai as Record<string, unknown>)[provider] = {
             apiKey: `${"*".repeat(20)} (configured)`,
-            source: "environment",
+            source: effectiveValues[keyPath]?.source ?? "unknown",
           };
         }
       }


### PR DESCRIPTION
## Summary

`gatherCredentialInfo()` was hardcoding `source: "environment"` for all API keys in `config show` output, regardless of where the key actually came from. This caused a misleading investigation during the mt#724/mt#730 similarity search quality work — we chased a phantom environment variable override that didn't exist.

Now uses `effectiveValues` (already computed by the config provider) to display the actual source: `"user"` (config file), `"environment"` (env var), `"defaults"`, etc.

## Test plan

- [x] 1489 tests pass
- [x] TypeScript clean, ESLint 0 warnings
- [x] Verified: `config show` now displays correct source for credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and fix this)