### PR TITLE
feat(mt#761): implement typed DI container (Phase 1)

### DIFF
--- a/src/composition/container.test.ts
+++ b/src/composition/container.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for AppContainer
+ *
+ * Tests cover every public API method and the key behavioral contracts
+ * documented in the mt#761 spec:
+ * - register() + initialize() + get() basic flow
+ * - set() directly sets instances (test pattern)
+ * - get() throws for unresolved services
+ * - initialize() resolves in registration order
+ * - Factories can access previously resolved services via get()
+ * - close() calls disposers in reverse order
+ * - set() takes precedence over register()
+ * - has() returns correct boolean
+ * - Async factories are properly awaited
+ */
+
+import { describe, test, expect } from "bun:test";
+import { AppContainer } from "./container";
+import type { AppServices } from "./types";
+
+// Minimal fakes that satisfy the type constraints
+const fakePersistence = {
+  initialize: async () => {},
+  close: async () => {},
+  getStorage: () => ({}) as any,
+  isInitialized: () => true,
+} as unknown as AppServices["persistence"];
+
+const fakeSessionProvider = {
+  getSession: async () => null,
+  listSessions: async () => [],
+  addSession: async () => {},
+  deleteSession: async () => {},
+} as unknown as AppServices["sessionProvider"];
+
+const SERVICE_NOT_AVAILABLE = 'Service "persistence" is not available';
+
+const fakeGitService = {
+  clone: async () => ({ workdir: "", session: "" }),
+  execInRepository: async () => "",
+} as unknown as AppServices["gitService"];
+
+describe("AppContainer", () => {
+  // --- register() + initialize() + get() ---
+
+  test("register + initialize + get: basic sync factory", async () => {
+    const container = new AppContainer();
+    container.register("persistence", () => fakePersistence);
+    await container.initialize();
+    expect(container.get("persistence")).toBe(fakePersistence);
+  });
+
+  test("register + initialize + get: async factory", async () => {
+    const container = new AppContainer();
+    container.register("persistence", async () => {
+      // Simulate async work (DB connection)
+      await new Promise((r) => setTimeout(r, 1));
+      return fakePersistence;
+    });
+    await container.initialize();
+    expect(container.get("persistence")).toBe(fakePersistence);
+  });
+
+  // --- set() ---
+
+  test("set: directly provides instance without factory", () => {
+    const container = new AppContainer();
+    container.set("persistence", fakePersistence);
+    expect(container.get("persistence")).toBe(fakePersistence);
+  });
+
+  test("set: takes precedence over register (factory not called)", async () => {
+    let factoryCalled = false;
+    const container = new AppContainer();
+    container.register("persistence", () => {
+      factoryCalled = true;
+      return fakePersistence;
+    });
+    container.set("persistence", fakePersistence);
+    await container.initialize();
+    expect(factoryCalled).toBe(false);
+    expect(container.get("persistence")).toBe(fakePersistence);
+  });
+
+  // --- get() throws ---
+
+  test("get: throws for unregistered service", () => {
+    const container = new AppContainer();
+    expect(() => container.get("persistence")).toThrow(SERVICE_NOT_AVAILABLE);
+  });
+
+  test("get: throws for registered but not initialized service", () => {
+    const container = new AppContainer();
+    container.register("persistence", () => fakePersistence);
+    // initialize() not called
+    expect(() => container.get("persistence")).toThrow(SERVICE_NOT_AVAILABLE);
+  });
+
+  // --- has() ---
+
+  test("has: returns false for unregistered service", () => {
+    const container = new AppContainer();
+    expect(container.has("persistence")).toBe(false);
+  });
+
+  test("has: returns true after set()", () => {
+    const container = new AppContainer();
+    container.set("persistence", fakePersistence);
+    expect(container.has("persistence")).toBe(true);
+  });
+
+  test("has: returns true after initialize()", async () => {
+    const container = new AppContainer();
+    container.register("persistence", () => fakePersistence);
+    expect(container.has("persistence")).toBe(false);
+    await container.initialize();
+    expect(container.has("persistence")).toBe(true);
+  });
+
+  // --- Registration order ---
+
+  test("initialize: resolves factories in registration order", async () => {
+    const order: string[] = [];
+    const container = new AppContainer();
+
+    container.register("persistence", () => {
+      order.push("persistence");
+      return fakePersistence;
+    });
+    container.register("sessionProvider", () => {
+      order.push("sessionProvider");
+      return fakeSessionProvider;
+    });
+    container.register("gitService", () => {
+      order.push("gitService");
+      return fakeGitService;
+    });
+
+    await container.initialize();
+    expect(order).toEqual(["persistence", "sessionProvider", "gitService"]);
+  });
+
+  // --- Dependency resolution via get() ---
+
+  test("factories can access previously resolved services", async () => {
+    const container = new AppContainer();
+
+    container.register("persistence", () => fakePersistence);
+    container.register("sessionProvider", (c) => {
+      // This factory depends on persistence being resolved first
+      const p = c.get("persistence");
+      expect(p).toBe(fakePersistence);
+      return fakeSessionProvider;
+    });
+
+    await container.initialize();
+    expect(container.get("sessionProvider")).toBe(fakeSessionProvider);
+  });
+
+  test("factory throws if dependency not yet resolved (wrong registration order)", async () => {
+    const container = new AppContainer();
+
+    // Register sessionProvider BEFORE persistence — wrong order
+    container.register("sessionProvider", (c) => {
+      c.get("persistence"); // This should throw
+      return fakeSessionProvider;
+    });
+    container.register("persistence", () => fakePersistence);
+
+    await expect(container.initialize()).rejects.toThrow(SERVICE_NOT_AVAILABLE);
+  });
+
+  // --- close() ---
+
+  test("close: calls registered disposers", async () => {
+    let disposed = false;
+    const container = new AppContainer();
+
+    container.register("persistence", () => fakePersistence, {
+      dispose: async () => {
+        disposed = true;
+      },
+    });
+
+    await container.initialize();
+    expect(disposed).toBe(false);
+    await container.close();
+    expect(disposed).toBe(true);
+  });
+
+  test("close: disposes in reverse registration order", async () => {
+    const order: string[] = [];
+    const container = new AppContainer();
+
+    container.register("persistence", () => fakePersistence, {
+      dispose: async () => {
+        order.push("persistence");
+      },
+    });
+    container.register("sessionProvider", () => fakeSessionProvider, {
+      dispose: async () => {
+        order.push("sessionProvider");
+      },
+    });
+    container.register("gitService", () => fakeGitService, {
+      dispose: async () => {
+        order.push("gitService");
+      },
+    });
+
+    await container.initialize();
+    await container.close();
+    // Reverse of registration order: leaves before roots
+    expect(order).toEqual(["gitService", "sessionProvider", "persistence"]);
+  });
+
+  test("close: clears all instances", async () => {
+    const container = new AppContainer();
+    container.set("persistence", fakePersistence);
+    expect(container.has("persistence")).toBe(true);
+    await container.close();
+    expect(container.has("persistence")).toBe(false);
+  });
+
+  // --- Chaining ---
+
+  test("register and set return this for chaining", () => {
+    const container = new AppContainer();
+    const result = container
+      .register("persistence", () => fakePersistence)
+      .set("gitService", fakeGitService);
+    expect(result).toBe(container);
+  });
+
+  // --- Re-registration ---
+
+  test("re-registering a key updates the factory and moves to end of init order", async () => {
+    const order: string[] = [];
+    const container = new AppContainer();
+
+    container.register("persistence", () => {
+      order.push("persistence-v1");
+      return fakePersistence;
+    });
+    container.register("sessionProvider", () => {
+      order.push("sessionProvider");
+      return fakeSessionProvider;
+    });
+    // Re-register persistence — should now resolve AFTER sessionProvider
+    container.register("persistence", () => {
+      order.push("persistence-v2");
+      return fakePersistence;
+    });
+
+    await container.initialize();
+    expect(order).toEqual(["sessionProvider", "persistence-v2"]);
+  });
+});

--- a/src/composition/container.ts
+++ b/src/composition/container.ts
@@ -1,0 +1,97 @@
+/**
+ * Typed DI Container
+ *
+ * A lightweight (~80 lines) container that maps service keys to factory functions,
+ * caches resolved instances as singletons, and manages async lifecycle.
+ *
+ * Design decisions (see mt#761 spec):
+ * - DIY rather than a library: the codebase is function-oriented with 18+ DI interfaces
+ *   already in place. A 80-line container fits better than decorator-based frameworks.
+ * - Async initialization is first-class: JS constructors can't be async, so TypeScript
+ *   DI libraries punt on this. We make initialize() a core lifecycle method.
+ * - Registration order = dependency order: factories are resolved sequentially during
+ *   initialize(). Each factory can call container.get() to access earlier services.
+ *   This is explicit and debuggable — no topological sort needed for ~20 services.
+ * - Domain code never sees this container. It receives typed deps interfaces
+ *   (SessionDeps, StartSessionDependencies, etc.) assembled by composition roots.
+ */
+
+import type {
+  AppServices,
+  ServiceKey,
+  ServiceFactory,
+  RegisterOptions,
+  AppContainerInterface,
+} from "./types";
+
+interface Registration<T> {
+  factory: ServiceFactory<T>;
+  dispose?: (instance: T) => Promise<void>;
+}
+
+export class AppContainer implements AppContainerInterface {
+  private instances = new Map<string, unknown>();
+  private registrations = new Map<string, Registration<unknown>>();
+  /** Tracks registration order for sequential initialization and reverse-order disposal. */
+  private registrationOrder: string[] = [];
+
+  register<K extends ServiceKey>(
+    key: K,
+    factory: ServiceFactory<AppServices[K]>,
+    options?: RegisterOptions<AppServices[K]>
+  ): this {
+    this.registrations.set(key, {
+      factory: factory as ServiceFactory<unknown>,
+      dispose: options?.dispose as ((instance: unknown) => Promise<void>) | undefined,
+    });
+    // Track order — remove if re-registered to maintain last-registration position
+    const idx = this.registrationOrder.indexOf(key);
+    if (idx !== -1) this.registrationOrder.splice(idx, 1);
+    this.registrationOrder.push(key);
+    return this;
+  }
+
+  set<K extends ServiceKey>(key: K, instance: AppServices[K]): this {
+    this.instances.set(key, instance);
+    return this;
+  }
+
+  get<K extends ServiceKey>(key: K): AppServices[K] {
+    const instance = this.instances.get(key);
+    if (instance !== undefined) return instance as AppServices[K];
+    throw new Error(
+      `Service "${String(key)}" is not available. ` +
+        `Call initialize() first or use set() to provide an instance.`
+    );
+  }
+
+  has<K extends ServiceKey>(key: K): boolean {
+    return this.instances.has(key);
+  }
+
+  async initialize(): Promise<void> {
+    for (const key of this.registrationOrder) {
+      // Skip services already provided via set()
+      if (this.instances.has(key)) continue;
+
+      const registration = this.registrations.get(key);
+      if (!registration) continue;
+
+      const instance = await Promise.resolve(registration.factory(this));
+      this.instances.set(key, instance);
+    }
+  }
+
+  async close(): Promise<void> {
+    // Dispose in reverse registration order (tear down leaves before roots)
+    const keys = [...this.registrationOrder].reverse();
+    for (const key of keys) {
+      const registration = this.registrations.get(key);
+      const instance = this.instances.get(key);
+      if (registration?.dispose && instance !== undefined) {
+        await registration.dispose(instance);
+      }
+    }
+    this.instances.clear();
+  }
+}

--- a/src/composition/index.ts
+++ b/src/composition/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Composition Root Module
+ *
+ * Exports the DI container and types. Composition roots (CLI, MCP, test)
+ * import from here to build service graphs.
+ *
+ * Domain code should NEVER import from this module.
+ */
+
+export { AppContainer } from "./container";
+export type {
+  AppServices,
+  ServiceKey,
+  ServiceFactory,
+  RegisterOptions,
+  AppContainerInterface,
+} from "./types";

--- a/src/composition/types.ts
+++ b/src/composition/types.ts
@@ -1,0 +1,109 @@
+/**
+ * DI Container Types
+ *
+ * Defines the service map (AppServices) and factory types for the typed
+ * DI container. All imports are type-only — this module has zero runtime cost.
+ *
+ * Design decision: AppServices uses an interface with keyof for compile-time
+ * type safety on container.get()/register(). Domain code never sees this
+ * interface — it only sees the individual service interfaces via typed deps.
+ *
+ * @see mt#761 spec, "Container design" section
+ */
+
+import type { BasePersistenceProvider } from "../domain/persistence/types";
+import type { SessionProviderInterface } from "../domain/session/types";
+import type { SessionDeps } from "../domain/session/session-service";
+import type { GitServiceInterface } from "../domain/git/types";
+import type { TaskServiceInterface } from "../domain/tasks/taskService";
+import type { WorkspaceUtilsInterface } from "../domain/workspace";
+import type { RepositoryBackendType } from "../domain/repository";
+
+/**
+ * The complete set of services managed by the DI container.
+ *
+ * Each key maps to a typed service interface. Composition roots register
+ * factories for these services; domain code receives them via typed deps
+ * interfaces (SessionDeps, StartSessionDependencies, etc.) — never via
+ * the container directly.
+ */
+export interface AppServices {
+  /** Persistence provider — async init (DB connection). Resolved first. */
+  persistence: BasePersistenceProvider;
+
+  /** Session provider — depends on persistence. */
+  sessionProvider: SessionProviderInterface;
+
+  /** Pre-wired session deps bundle — depends on sessionProvider + other services. */
+  sessionDeps: SessionDeps;
+
+  /** Git operations service. */
+  gitService: GitServiceInterface;
+
+  /** Task CRUD and query service. */
+  taskService: TaskServiceInterface;
+
+  /** Workspace detection and path utilities. */
+  workspaceUtils: WorkspaceUtilsInterface;
+
+  /** Repository backend configuration (from project config). */
+  repositoryBackend: {
+    repoUrl: string;
+    backendType: RepositoryBackendType;
+    github?: { owner: string; repo: string };
+  };
+}
+
+/** A service key — one of the keys of AppServices. */
+export type ServiceKey = keyof AppServices;
+
+/**
+ * Factory function that creates a service instance.
+ * May be sync or async — the container handles both uniformly via Promise.resolve().
+ * The factory receives the container so it can resolve dependencies.
+ */
+export type ServiceFactory<T> = (container: AppContainerInterface) => T | Promise<T>;
+
+/**
+ * Options for service registration.
+ */
+export interface RegisterOptions<T> {
+  /** Called during container.close() to clean up resources (e.g., close DB connections). */
+  dispose?: (instance: T) => Promise<void>;
+}
+
+/**
+ * The public container interface.
+ * Used in composition roots — domain code never sees this.
+ */
+export interface AppContainerInterface {
+  /** Register a factory for a service key. Returns `this` for chaining. */
+  register<K extends ServiceKey>(
+    key: K,
+    factory: ServiceFactory<AppServices[K]>,
+    options?: RegisterOptions<AppServices[K]>
+  ): this;
+
+  /** Directly set a service instance (for tests or pre-resolved values). Returns `this` for chaining. */
+  set<K extends ServiceKey>(key: K, instance: AppServices[K]): this;
+
+  /** Get a resolved service instance. Throws if not available. */
+  get<K extends ServiceKey>(key: K): AppServices[K];
+
+  /** Check if a service has been resolved (set or initialized). */
+  has<K extends ServiceKey>(key: K): boolean;
+
+  /**
+   * Initialize all registered factories in registration order.
+   * Each factory may call container.get() to access previously resolved services.
+   * Skips services already set via set().
+   * Async factories are awaited.
+   */
+  initialize(): Promise<void>;
+
+  /**
+   * Dispose all services with registered disposers, then clear all instances.
+   * Called during application shutdown (e.g., CLI exit, MCP server stop).
+   */
+  close(): Promise<void>;
+}


### PR DESCRIPTION
## Summary

Phase 1 of mt#761: Build the typed DI container. No changes to existing code — only new files in `src/composition/`.

### What was built

**`src/composition/types.ts`** — The `AppServices` interface (service map) and container interface. All imports are `import type` — zero runtime cost. Defines 7 service keys mapping to existing domain interfaces (`BasePersistenceProvider`, `SessionProviderInterface`, `GitServiceInterface`, etc.).

**`src/composition/container.ts`** — `AppContainer` class (~80 lines):
- `register(key, factory, options?)` — stores a factory (sync or async) for a service key
- `set(key, instance)` — directly injects an instance (for tests)
- `get(key)` — returns cached instance, throws if not resolved
- `has(key)` — checks if a service is available
- `initialize()` — resolves all registered factories in registration order; factories can call `get()` for previously resolved deps; `set()` values take precedence (factories skipped)
- `close()` — calls registered disposers in reverse order, then clears all instances

**`src/composition/container.test.ts`** — 17 unit tests covering all public methods and behavioral contracts.

**`src/composition/index.ts`** — Barrel export.

### Key design decisions (from mt#761 spec)

1. **DIY not a library**: The codebase has 18+ DI interfaces and is function-oriented. A lightweight container fits better than decorator-based frameworks (tsyringe) or paradigm shifts (Effect).
2. **Async init is first-class**: `initialize()` wraps all factories in `Promise.resolve()` — both sync and async factories work uniformly. This addresses the gap in TypeScript DI libraries where JS constructors can't be async.
3. **Registration order = dependency order**: Explicit, debuggable, no topological sort needed for ~20 services.
4. **Reverse-order disposal**: `close()` tears down leaves before roots (sessionProvider before persistence).
5. **Domain code unchanged**: The container is only used in composition roots. Domain code receives typed deps interfaces.

## Test plan

- [x] 17 container unit tests pass
- [x] 1506 existing tests still pass (verified by pre-push hook)
- [x] TypeScript typecheck passes
- [x] ESLint: 0 errors, 0 warnings
- [x] No changes to existing files