### PR TITLE
feat(mt#432): Add write-time embedding hooks for automatic indexing

### DIFF
--- a/src/adapters/mcp/task-edit-tools.ts
+++ b/src/adapters/mcp/task-edit-tools.ts
@@ -11,6 +11,7 @@ import { getTaskSpecContentFromParams, updateTaskFromParams } from "../../domain
 import { log } from "../../utils/logger";
 import { applyEditPattern } from "../../domain/ai/edit-pattern-service";
 import { countOccurrences } from "./session-edit-tools";
+import { autoIndexTaskEmbedding } from "../shared/commands/tasks/auto-index-embedding";
 
 // ========================
 // SCHEMAS
@@ -168,6 +169,9 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
           backend: typedArgs.backend,
         });
 
+        // Fire-and-forget embedding re-index after spec update
+        autoIndexTaskEmbedding(typedArgs.taskId);
+
         log.debug("Task edit_file operation completed", { taskId: typedArgs.taskId });
 
         return {
@@ -252,6 +256,9 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
           session: typedArgs.session,
           backend: typedArgs.backend,
         });
+
+        // Fire-and-forget embedding re-index after spec update
+        autoIndexTaskEmbedding(typedArgs.taskId);
 
         log.debug("Task search_replace operation completed", {
           taskId: typedArgs.taskId,

--- a/src/adapters/shared/commands/tasks/auto-index-embedding.ts
+++ b/src/adapters/shared/commands/tasks/auto-index-embedding.ts
@@ -1,0 +1,37 @@
+import { log } from "../../../../utils/logger";
+
+/**
+ * Dependencies that can be injected for testing.
+ */
+export interface AutoIndexDeps {
+  getConfiguration: () => { embeddings?: { autoIndex?: boolean } };
+  createTaskSimilarityService: () => Promise<{ indexTask: (id: string) => Promise<boolean> }>;
+}
+
+/**
+ * Fire-and-forget embedding indexing after task mutations.
+ * Never blocks, never throws -- logs at debug level on failure.
+ *
+ * Accepts optional dependency overrides for testing; in production
+ * the deps are resolved via dynamic imports.
+ */
+export function autoIndexTaskEmbedding(taskId: string, deps?: AutoIndexDeps): void {
+  (async () => {
+    try {
+      const getConfiguration =
+        deps?.getConfiguration ??
+        (await import("../../../../domain/configuration")).getConfiguration;
+      const cfg = getConfiguration();
+      if (cfg.embeddings?.autoIndex === false) return;
+
+      const createTaskSimilarityService =
+        deps?.createTaskSimilarityService ??
+        (await import("./similarity-commands")).createTaskSimilarityService;
+      const service = await createTaskSimilarityService();
+      await service.indexTask(taskId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.debug(`Auto-index skipped for ${taskId}: ${msg}`);
+    }
+  })();
+}

--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -19,6 +19,7 @@ import {
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { PersistenceProvider } from "../../../../domain/persistence/types";
 import { log } from "../../../../utils/logger";
+import { autoIndexTaskEmbedding } from "./auto-index-embedding";
 
 /**
  * Parameters for tasks list command
@@ -276,6 +277,9 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
           log.warn("[tasks.create] No persistence provider; skipping dependsOn");
         }
       }
+
+      // Fire-and-forget embedding indexing for the newly created task
+      autoIndexTaskEmbedding(result.id);
 
       // Build success message
       let message = `Task ${result.id} created: "${result.title}"`;

--- a/src/adapters/shared/commands/tasks/edit-commands.ts
+++ b/src/adapters/shared/commands/tasks/edit-commands.ts
@@ -16,6 +16,7 @@ import { readTextFile } from "../../../../utils/fs";
 import { spawn } from "child_process";
 import { promisify } from "util";
 import chalk from "chalk";
+import { autoIndexTaskEmbedding } from "./auto-index-embedding";
 
 /**
  * Parameters for tasks edit command
@@ -242,6 +243,11 @@ export class TasksEditCommand extends BaseTaskCommand<TasksEditParams> {
       if (updates.tags !== undefined) {
         await service.updateTask?.(validatedTaskId, { tags: updates.tags });
         this.debug("Updated task tags");
+      }
+
+      // Fire-and-forget embedding re-index if content that affects embeddings changed
+      if (updates.title || updates.spec) {
+        autoIndexTaskEmbedding(validatedTaskId);
       }
 
       const message = this.buildUpdateMessage(updates, validatedTaskId);

--- a/src/domain/configuration/schemas/embeddings.ts
+++ b/src/domain/configuration/schemas/embeddings.ts
@@ -6,7 +6,13 @@ export const embeddingsConfigSchema = z
     model: z.string().default("text-embedding-3-small"),
     dimension: z.number().optional(),
     normalize: z.boolean().default(false),
+    autoIndex: z.boolean().default(true),
   })
-  .default({ provider: "openai", model: "text-embedding-3-small", normalize: false });
+  .default({
+    provider: "openai",
+    model: "text-embedding-3-small",
+    normalize: false,
+    autoIndex: true,
+  });
 
 export type EmbeddingsConfig = z.infer<typeof embeddingsConfigSchema>;

--- a/tests/adapters/shared/commands/tasks/auto-index-embedding.test.ts
+++ b/tests/adapters/shared/commands/tasks/auto-index-embedding.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+  autoIndexTaskEmbedding,
+  type AutoIndexDeps,
+} from "../../../../../src/adapters/shared/commands/tasks/auto-index-embedding";
+
+describe("autoIndexTaskEmbedding", () => {
+  test("does not throw when similarity service creation fails", async () => {
+    const deps: AutoIndexDeps = {
+      getConfiguration: () => ({ embeddings: { autoIndex: true } }),
+      createTaskSimilarityService: async () => {
+        throw new Error("No embedding provider configured");
+      },
+    };
+
+    // Should not throw - fire-and-forget pattern swallows errors
+    expect(() => autoIndexTaskEmbedding("mt#999", deps)).not.toThrow();
+
+    // Give the async IIFE time to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+
+  test("is a no-op when autoIndex is false", async () => {
+    let serviceCreated = false;
+
+    const deps: AutoIndexDeps = {
+      getConfiguration: () => ({ embeddings: { autoIndex: false } }),
+      createTaskSimilarityService: async () => {
+        serviceCreated = true;
+        return { indexTask: async () => true };
+      },
+    };
+
+    autoIndexTaskEmbedding("mt#888", deps);
+
+    // Give the async IIFE time to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Service should never have been created since config gate stopped it
+    expect(serviceCreated).toBe(false);
+  });
+
+  test("calls indexTask when autoIndex is true", async () => {
+    const result: { taskId: string | null } = { taskId: null };
+
+    const deps: AutoIndexDeps = {
+      getConfiguration: () => ({ embeddings: { autoIndex: true } }),
+      createTaskSimilarityService: async () => ({
+        indexTask: async (id: string) => {
+          result.taskId = id;
+          return true;
+        },
+      }),
+    };
+
+    autoIndexTaskEmbedding("mt#777", deps);
+
+    // Give the async IIFE time to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(result.taskId as string).toBe("mt#777");
+  });
+});


### PR DESCRIPTION
## Summary

Tasks are now automatically indexed for similarity search when created or edited. No more manual `tasks index-embeddings` needed for routine work.

- **`autoIndexTaskEmbedding()` helper** — fire-and-forget, never blocks or throws, logs at debug level on failure
- **Hooked into**: `tasks.create`, `tasks.edit`, `tasks.spec_edit`, `tasks.edit_file`, `tasks.search_replace`
- **Smart skip**: only re-indexes on title/spec changes, not tags-only or status-only edits
- **Config gate**: `embeddings.autoIndex` (default `true`) — set to `false` to disable

### How it works

After a task is persisted, `autoIndexTaskEmbedding(taskId)` fires off a background promise that:
1. Checks `embeddings.autoIndex` config — skips if false
2. Creates a `TaskSimilarityService` via existing factory
3. Calls `indexTask(taskId)` which uses content-hash to skip if unchanged
4. Catches all errors at debug level — embedding unavailability never affects task operations

## Test plan

- [x] 3 new tests: no-throw on service failure, no-op on autoIndex:false, calls indexTask on autoIndex:true
- [x] 1492 tests pass, 0 failures
- [x] TypeScript clean, ESLint 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and implement this)