### PR TITLE
feat(mt#745): Add embedding index coverage to config doctor + CLAUDE.md updates

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,9 @@
 echo "Running tests before push..."
 
-# Run tests and capture exit code before piping
-# Using a temp file avoids PIPESTATUS which requires bash
+# Match pre-commit hook: --timeout prevents hung tests, --bail stops on first failure
+# AGENT=1 ensures clean non-interactive output
 TEST_OUTPUT_FILE=$(mktemp)
-bun test --preload ./tests/setup.ts src tests/adapters tests/domain >"$TEST_OUTPUT_FILE" 2>&1
+AGENT=1 bun test --preload ./tests/setup.ts --timeout=15000 --bail src tests/adapters tests/domain >"$TEST_OUTPUT_FILE" 2>&1
 TEST_EXIT_CODE=$?
 
 # Show only the summary line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID
 8. All file operations in sessions MUST use absolute paths.
 9. **NEVER use bare git CLI** (`git add`, `git commit`, `git push`, `git pull`, `git -C`). Always use MCP tools. Shell `#` in task paths causes parsing issues and permission prompts.
 10. **Always quote all Bash arguments** containing `#`, `$`, or special chars if Bash is unavoidable.
+11. **If MCP session tools fail** (e.g., mt#722 causes session records to vanish), and you must fall back to bare git for commit/push/PR creation, you MUST replicate the safety steps that the MCP tools would have performed: `git fetch origin main && git rebase origin/main` before pushing, to prevent merge conflicts that block CI. A PR with conflicts will not trigger CI — GitHub silently skips it.
 
 ### Session lifecycle: one session, one merge
 
@@ -119,6 +120,7 @@ The `/review-pr` skill requires a **Spec verification** section in every review.
 - **The user decides scope, not the agent.** Never unilaterally decide "this is a good stopping point." If uncertain whether to continue, ask.
 - **Artifact creation is not progress.** Creating tasks, updating specs, writing rules, and process discussion are not substitutes for doing the work. If you can describe exactly what needs to be done, do it.
 - **Before proposing to ship**, check the task spec's success criteria. If items are unmet and actionable, keep working.
+- **Never notice an issue without acting on it.** If you discover a problem, duplication, or architectural concern that's out of scope to fix now, immediately file a task with `mcp__minsky__tasks_create`. Mentioning it in chat is not action — it must become a trackable artifact (task, spec update, or memory). There is no "worth noting for a follow-up" without creating the follow-up.
 
 ## MCP Tools
 

--- a/src/adapters/shared/commands/config.ts
+++ b/src/adapters/shared/commands/config.ts
@@ -703,6 +703,41 @@ const configDoctorRegistration = defineCommand({
       });
     }
 
+    // Embedding index coverage
+    try {
+      const { PersistenceService } = await import("../../../domain/persistence/service");
+      if (PersistenceService.isInitialized()) {
+        const provider = PersistenceService.getProvider();
+        if (provider.capabilities.sql) {
+          const rawSql = await provider.getRawSqlConnection?.();
+          if (rawSql) {
+            const sql = rawSql as import("postgres").Sql;
+            const [taskCount] = await sql.unsafe("SELECT count(*) as count FROM tasks");
+            const [embCount] = await sql.unsafe("SELECT count(*) as count FROM tasks_embeddings");
+            const [lastIdx] = await sql.unsafe(
+              "SELECT max(indexed_at) as last_indexed FROM tasks_embeddings"
+            );
+            const total = Number(taskCount?.count ?? 0);
+            const indexed = Number(embCount?.count ?? 0);
+            const lastIndexed = lastIdx?.last_indexed
+              ? new Date(lastIdx.last_indexed as string).toISOString()
+              : "never";
+            const pct = total > 0 ? Math.round((indexed / total) * 100) : 0;
+            diagnostics.push({
+              check: "Embedding Index Coverage",
+              status: pct >= 90 ? "pass" : pct >= 50 ? "warning" : "error",
+              message: `${indexed}/${total} tasks indexed (${pct}%), last indexed: ${lastIndexed}`,
+              ...(pct < 90 && {
+                suggestion: "Run 'minsky tasks index-embeddings' to index missing tasks",
+              }),
+            });
+          }
+        }
+      }
+    } catch {
+      // Index coverage is best-effort — skip if DB not available
+    }
+
     const errors = diagnostics.filter((d) => d.status === "error");
     const warnings = diagnostics.filter((d) => d.status === "warning");
 


### PR DESCRIPTION
## Summary

- **Config doctor: embedding index coverage** — reports X/Y tasks indexed (percentage), last indexed timestamp. Status: pass (>=90%), warning (>=50%), error (<50%). Includes actionable suggestion to run `tasks index-embeddings` when coverage is low.
- **Pre-push hook fix (mt#775)** — added `--timeout=15000`, `--bail`, and `AGENT=1` to match pre-commit hook. The hook was hanging indefinitely because `bun test` without `--timeout` never exits if any test leaves open handles, and output redirection to a temp file compounds the issue.
- **CLAUDE.md updates** — commits two previously unstaged additions from the mt#724 investigation session:
  - Rule 11: rebase before manual push when MCP tools fail
  - Work completion: always file tasks for noticed issues

## Test plan

- [x] 1509 tests pass, 0 failures
- [x] TypeScript clean, ESLint 0 warnings
- [x] Pre-push hook completes in ~13s (was hanging indefinitely)
- [x] Index coverage check is best-effort — gracefully skips if DB unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and fix this)