### PR TITLE
feat(mt#728): add session.generate_prompt MCP tool for subagent dispatch

### DIFF
--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -32,6 +32,7 @@ import {
 import { createSessionConflictsCommand } from "./session/conflicts-command";
 import { createSessionRepairCommand } from "./session/repair-command";
 import { createSessionEditFileCommand } from "./session/file-commands";
+import { createSessionGeneratePromptCommand } from "./session/prompt-command";
 import { registerSessionChangesetCommands } from "./session/changeset-aliases";
 import { sharedCommandRegistry, type CommandDefinition } from "../command-registry";
 
@@ -87,6 +88,7 @@ export async function registerSessionCommands(
     // Utility
     createSessionConflictsCommand(getDeps),
     createSessionRepairCommand(getDeps),
+    createSessionGeneratePromptCommand(getDeps),
 
     // File
     createSessionEditFileCommand(getDeps),

--- a/src/adapters/shared/commands/session/prompt-command.ts
+++ b/src/adapters/shared/commands/session/prompt-command.ts
@@ -62,6 +62,7 @@ export function createSessionGeneratePromptCommand(getDeps: LazySessionDeps): Co
               .split(",")
               .map((s) => s.trim())
               .filter((s) => s.length > 0)
+              .map((s) => (s.startsWith("/") ? s : `${sessionDir}/${s}`))
           : undefined;
 
       const taskId = task.replace(/^mt#/, "").replace(/^#/, "");

--- a/src/adapters/shared/commands/session/prompt-command.ts
+++ b/src/adapters/shared/commands/session/prompt-command.ts
@@ -1,0 +1,81 @@
+/**
+ * Session Generate Prompt Command
+ *
+ * Generates complete subagent prompt strings for session work.
+ */
+import { CommandCategory, type CommandDefinition } from "../../command-registry";
+import { type LazySessionDeps, withErrorLogging } from "./types";
+import { z } from "zod";
+
+const promptCommandParams = {
+  task: { schema: z.string(), description: "Task ID (required)", required: true },
+  type: {
+    schema: z.enum(["implementation", "refactor", "review", "cleanup"]),
+    description: "Prompt type: implementation, refactor, review, or cleanup",
+    required: true,
+  },
+  instructions: {
+    schema: z.string(),
+    description: "Specific work instructions for the subagent",
+    required: true,
+  },
+  scope: {
+    schema: z.string(),
+    description: "Comma-separated list of file paths to constrain to",
+    required: false,
+  },
+};
+
+export function createSessionGeneratePromptCommand(getDeps: LazySessionDeps): CommandDefinition {
+  return {
+    id: "session.generate_prompt",
+    category: CommandCategory.SESSION,
+    name: "generate_prompt",
+    description: "Generate a complete subagent prompt for session work",
+    parameters: promptCommandParams,
+    execute: withErrorLogging("session.generate_prompt", async (params) => {
+      const { getSessionFromParams } = await import("../../../../domain/session");
+      const { generateSubagentPrompt } = await import(
+        "../../../../domain/session/prompt-generation"
+      );
+      const { resolveSessionDirectory } = await import(
+        "../../../../domain/session/resolve-session-directory"
+      );
+
+      const task = params.task as string;
+      const type = params.type as "implementation" | "refactor" | "review" | "cleanup";
+      const instructions = params.instructions as string;
+      const scopeRaw = params.scope as string | undefined;
+
+      const session = await getSessionFromParams({ task });
+
+      if (!session) {
+        throw new Error(`No session found for task '${task}'`);
+      }
+
+      const sessionId = session.session;
+      const sessionDir = await resolveSessionDirectory(sessionId);
+
+      const scope =
+        scopeRaw && scopeRaw.trim().length > 0
+          ? scopeRaw
+              .split(",")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0)
+          : undefined;
+
+      const taskId = task.replace(/^mt#/, "").replace(/^#/, "");
+
+      const result = generateSubagentPrompt({
+        sessionDir,
+        sessionId,
+        taskId,
+        type,
+        instructions,
+        scope,
+      });
+
+      return { success: true, ...result };
+    }),
+  };
+}

--- a/src/domain/session/prompt-generation.ts
+++ b/src/domain/session/prompt-generation.ts
@@ -1,0 +1,123 @@
+/**
+ * Session Prompt Generation
+ *
+ * Generates complete, correct subagent prompt strings for session work.
+ */
+
+export type PromptType = "implementation" | "refactor" | "review" | "cleanup";
+
+export interface GeneratePromptParams {
+  sessionDir: string;
+  sessionId: string;
+  taskId: string;
+  type: PromptType;
+  instructions: string;
+  scope?: string[];
+}
+
+export interface GeneratePromptResult {
+  prompt: string;
+  suggestedSubagentType?: string;
+  suggestedModel?: string;
+  scopeWarning?: string;
+}
+
+const SCOPE_WARNING_THRESHOLD = 40;
+
+function renderCommonHeader(params: GeneratePromptParams): string {
+  return `You are working in Minsky session at ${params.sessionDir}. All file paths MUST be absolute paths under this directory.
+
+Task mt#${params.taskId}: ${params.type.charAt(0).toUpperCase() + params.type.slice(1)} work
+
+${params.instructions}`;
+}
+
+function renderScopeSection(scope: string[]): string {
+  return `
+## Scope Constraints
+
+Only modify the following files:
+${scope.map((f) => `- ${f}`).join("\n")}`;
+}
+
+function renderCommitInstructions(sessionId: string, taskId: string): string {
+  return `
+## Committing Your Work
+
+When your changes are ready, commit using:
+- Tool: \`mcp__minsky__session_commit\`
+- Parameters: \`sessionId: "${sessionId}"\`, \`all: true\`
+
+## Creating a Pull Request
+
+After committing, create a PR using:
+- Tool: \`mcp__minsky__session_pr_create\`
+- Parameters: \`task: "mt#${taskId}"\`
+
+Do NOT merge the PR.`;
+}
+
+function renderToolingNote(): string {
+  return `
+## Important
+
+Do NOT run Bash commands for formatting, linting, type-checking, or tests — the pre-commit hooks handle all of that.`;
+}
+
+export function generateSubagentPrompt(params: GeneratePromptParams): GeneratePromptResult {
+  const { type, scope, sessionId, taskId } = params;
+
+  const scopeWarning =
+    scope && scope.length > SCOPE_WARNING_THRESHOLD
+      ? `Scope has ${scope.length} files (exceeds ${SCOPE_WARNING_THRESHOLD}). Consider batching into multiple smaller tasks to stay within subagent capacity limits.`
+      : undefined;
+
+  const sections: string[] = [renderCommonHeader(params)];
+
+  if (scope && scope.length > 0) {
+    sections.push(renderScopeSection(scope));
+  }
+
+  if (type === "review") {
+    sections.push(`
+## Review Instructions
+
+Report findings as structured output. Do NOT make any changes.`);
+    sections.push(renderToolingNote());
+
+    return {
+      prompt: sections.join("\n"),
+      suggestedModel: "sonnet",
+      scopeWarning,
+    };
+  }
+
+  if (type === "refactor") {
+    sections.push(`
+## Coherence Verification
+
+After making changes, re-read each modified file end-to-end and verify: no stale comments, no dead exports, no orphan code.`);
+  }
+
+  if (type === "cleanup") {
+    sections.push(`
+## Batching Guidance
+
+For large scopes, commit after each batch of ~10 files rather than all at once.`);
+  }
+
+  sections.push(renderCommitInstructions(sessionId, taskId));
+  sections.push(renderToolingNote());
+
+  const result: GeneratePromptResult = {
+    prompt: sections.join("\n"),
+    suggestedModel: "sonnet",
+    scopeWarning,
+  };
+
+  if (type === "refactor") {
+    result.suggestedSubagentType = "refactor";
+  }
+
+  return result;
+}

--- a/tests/domain/session/prompt-generation.test.ts
+++ b/tests/domain/session/prompt-generation.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "bun:test";
+import {
+  generateSubagentPrompt,
+  type GeneratePromptParams,
+} from "../../../src/domain/session/prompt-generation";
+
+const MCP_SESSION_COMMIT = "mcp__minsky__session_commit";
+const MCP_SESSION_PR_CREATE = "mcp__minsky__session_pr_create";
+const EXPECTED_MODEL = "sonnet";
+
+const baseParams: GeneratePromptParams = {
+  sessionDir: "/Users/test/.local/state/minsky/sessions/abc-123",
+  sessionId: "abc-123",
+  taskId: "456",
+  type: "implementation",
+  instructions: "Add a new feature to do X.",
+};
+
+describe("generateSubagentPrompt", () => {
+  describe("common sections", () => {
+    it("includes the session directory in the prompt", () => {
+      const result = generateSubagentPrompt(baseParams);
+      expect(result.prompt).toContain(baseParams.sessionDir);
+    });
+
+    it("includes the task ID in the prompt header", () => {
+      const result = generateSubagentPrompt(baseParams);
+      expect(result.prompt).toContain("mt#456");
+    });
+
+    it("includes the caller's instructions in the prompt", () => {
+      const result = generateSubagentPrompt(baseParams);
+      expect(result.prompt).toContain("Add a new feature to do X.");
+    });
+
+    it("includes absolute path requirement", () => {
+      const result = generateSubagentPrompt(baseParams);
+      expect(result.prompt).toContain("All file paths MUST be absolute paths under this directory");
+    });
+  });
+
+  describe("implementation type", () => {
+    it("includes commit instructions with sessionId", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.prompt).toContain(MCP_SESSION_COMMIT);
+      expect(result.prompt).toContain(`sessionId: "${baseParams.sessionId}"`);
+      expect(result.prompt).toContain("all: true");
+    });
+
+    it("includes PR instructions with task", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.prompt).toContain(MCP_SESSION_PR_CREATE);
+      expect(result.prompt).toContain(`task: "mt#${baseParams.taskId}"`);
+    });
+
+    it("includes 'Do NOT merge' instruction", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.prompt).toContain("Do NOT merge the PR");
+    });
+
+    it("includes no-bash instruction", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.prompt).toContain(
+        "Do NOT run Bash commands for formatting, linting, type-checking, or tests"
+      );
+    });
+
+    it("suggests sonnet as the model for implementation", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.suggestedModel).toBe(EXPECTED_MODEL);
+    });
+
+    it("does not suggest a subagent type for implementation", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.suggestedSubagentType).toBeUndefined();
+    });
+  });
+
+  describe("refactor type", () => {
+    it("includes coherence verification reminder", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "refactor" });
+      expect(result.prompt).toContain("re-read each modified file end-to-end");
+      expect(result.prompt).toContain("no stale comments, no dead exports, no orphan code");
+    });
+
+    it("includes commit and PR instructions", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "refactor" });
+      expect(result.prompt).toContain(MCP_SESSION_COMMIT);
+      expect(result.prompt).toContain(MCP_SESSION_PR_CREATE);
+    });
+
+    it("suggests refactor subagent type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "refactor" });
+      expect(result.suggestedSubagentType).toBe("refactor");
+    });
+
+    it("suggests sonnet as the model for refactor", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "refactor" });
+      expect(result.suggestedModel).toBe(EXPECTED_MODEL);
+    });
+  });
+
+  describe("review type", () => {
+    it("omits commit instructions", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.prompt).not.toContain(MCP_SESSION_COMMIT);
+    });
+
+    it("omits PR instructions", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.prompt).not.toContain(MCP_SESSION_PR_CREATE);
+    });
+
+    it("includes 'Report findings' instruction", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.prompt).toContain("Report findings as structured output");
+    });
+
+    it("includes 'Do NOT make any changes' instruction", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.prompt).toContain("Do NOT make any changes");
+    });
+
+    it("suggests sonnet as the model for review", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.suggestedModel).toBe(EXPECTED_MODEL);
+    });
+
+    it("does not suggest a subagent type for review", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.suggestedSubagentType).toBeUndefined();
+    });
+  });
+
+  describe("cleanup type", () => {
+    it("includes batching guidance", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "cleanup" });
+      expect(result.prompt).toContain("commit after each batch of ~10 files");
+    });
+
+    it("includes commit and PR instructions", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "cleanup" });
+      expect(result.prompt).toContain(MCP_SESSION_COMMIT);
+      expect(result.prompt).toContain(MCP_SESSION_PR_CREATE);
+    });
+
+    it("suggests sonnet as the model for cleanup", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "cleanup" });
+      expect(result.suggestedModel).toBe(EXPECTED_MODEL);
+    });
+
+    it("does not suggest a subagent type for cleanup", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "cleanup" });
+      expect(result.suggestedSubagentType).toBeUndefined();
+    });
+  });
+
+  describe("scope handling", () => {
+    it("lists files in the prompt when scope is provided", () => {
+      const scope = ["src/foo.ts", "src/bar.ts"];
+      const result = generateSubagentPrompt({ ...baseParams, scope });
+      expect(result.prompt).toContain("src/foo.ts");
+      expect(result.prompt).toContain("src/bar.ts");
+    });
+
+    it("does not include scope section when scope is not provided", () => {
+      const result = generateSubagentPrompt({ ...baseParams, scope: undefined });
+      expect(result.prompt).not.toContain("Scope Constraints");
+    });
+
+    it("does not produce a scope warning for 40 files", () => {
+      const scope = Array.from({ length: 40 }, (_, i) => `src/file${i}.ts`);
+      const result = generateSubagentPrompt({ ...baseParams, scope });
+      expect(result.scopeWarning).toBeUndefined();
+    });
+
+    it("produces a scope warning for more than 40 files", () => {
+      const scope = Array.from({ length: 41 }, (_, i) => `src/file${i}.ts`);
+      const result = generateSubagentPrompt({ ...baseParams, scope });
+      expect(result.scopeWarning).toBeDefined();
+      expect(result.scopeWarning).toContain("41");
+    });
+
+    it("scope warning mentions batching", () => {
+      const scope = Array.from({ length: 50 }, (_, i) => `src/file${i}.ts`);
+      const result = generateSubagentPrompt({ ...baseParams, scope });
+      expect(result.scopeWarning).toContain("batching");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `session.generate_prompt` MCP tool that generates complete, correct subagent prompt strings
- Implements 4 prompt types: `implementation`, `refactor`, `review`, `cleanup`
- Each generated prompt includes session dir, session UUID, task ID, commit/PR instructions, and guard rails
- Warns when scope exceeds 40 files (subagent context budget)
- 29 tests covering all prompt types, scope handling, and edge cases

## Motivation

The prompt is the interface contract between orchestrator and subagent. Currently hand-crafted from behavioral rules (memory files). mt#672 proved this breaks under load: wrong task IDs, missing sessionIds, unbounded scope. This tool makes correct prompts the easy path.

See [Notion design note](https://www.notion.so/346937f03cb481908efdf88ea877c125) for the full analysis.

## Test plan

- [x] 29 unit tests for `generateSubagentPrompt()` covering all 4 types
- [ ] Manual test: generate a prompt via MCP, dispatch via Agent tool, verify subagent commits with correct task ID

(Had Claude look into this — AI-assisted implementation)