### PR TITLE
feat(mt#761): create composition roots and wire CLI to DI container (Phase 2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -204,6 +204,8 @@ export default [
             "**/src/domain/tasks/taskCommands.ts",
             // Utility composition roots
             "**/src/utils/repo.ts",
+            // DI composition roots (the canonical place for singleton resolution)
+            "**/src/composition/**/*.ts",
             // Adapter-layer composition roots (commands wire up DI providers)
             "**/src/adapters/shared/commands/**/*.ts",
             // CLI command composition roots

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { log } from "./utils/logger";
 import { exit } from "./utils/process";
 import { setupCommonCommandCustomizations, cliFactory } from "./adapters/cli/cli-command-factory";
 import { validateError } from "./schemas/error";
+import type { AppContainerInterface } from "./composition/types";
 
 /**
  * Root CLI command
@@ -28,31 +29,20 @@ export const cli = new Command("minsky")
   });
 
 /**
- * Lazy PersistenceService initialization.
- * Deferred from startup to first command execution so the CLI bootstrap
- * (Commander parsing, help display) doesn't pay the DB connection cost.
- */
-let persistenceInitialized = false;
-async function ensurePersistence(): Promise<void> {
-  if (persistenceInitialized) return;
-  const { PersistenceService } = await import("./domain/persistence/service");
-  await PersistenceService.initialize();
-  log.debug("PersistenceService initialized (lazy, on first command)");
-  persistenceInitialized = true;
-}
-
-/**
  * Create the CLI command structure
  */
-export async function createCli(): Promise<Command> {
+export async function createCli(container: AppContainerInterface): Promise<Command> {
   // Setup common command customizations with the CLI instance
   setupCommonCommandCustomizations(cli);
 
-  // Initialize persistence lazily via preAction hook — only when a command
-  // actually executes, not during registration or help display. Session commands
-  // use LazySessionDeps to defer provider resolution to execution time.
+  // Initialize the container lazily via preAction hook — only when a command
+  // actually executes, not during registration or help display. This defers
+  // the DB connection (~1s) past Commander parsing.
   cli.hook("preAction", async () => {
-    await ensurePersistence();
+    if (!container.has("persistence")) {
+      await container.initialize();
+      log.debug("Container initialized (lazy, on first command)");
+    }
   });
 
   // Register shared commands (session, tasks, git, rules, config, etc.)
@@ -105,15 +95,16 @@ export async function createCli(): Promise<Command> {
  * This is only executed when this file is run directly
  */
 async function main(): Promise<void> {
-  // Create CLI — persistence is initialized lazily via preAction hook
-  const cliInstance = await createCli();
+  // Create the DI container with real service factories (deferred initialization)
+  const { createCliContainer } = await import("./composition/cli");
+  const container = await createCliContainer();
+
+  // Create CLI — container is initialized lazily via preAction hook
+  const cliInstance = await createCli(container);
   await cliInstance.parseAsync();
 
-  // Clean up PersistenceService on exit (only if it was initialized)
-  if (persistenceInitialized) {
-    const { PersistenceService } = await import("./domain/persistence/service");
-    await PersistenceService.close();
-  }
+  // Clean up container resources on exit (closes DB connections, etc.)
+  await container.close();
 
   // Still need explicit exit until all resource leaks are fixed
   // The improvements to workspace manager help, but there are other sources

--- a/src/composition/cli.ts
+++ b/src/composition/cli.ts
@@ -1,0 +1,102 @@
+/**
+ * CLI Composition Root
+ *
+ * Builds an AppContainer configured for CLI usage: real service implementations
+ * with deferred initialization. The container's initialize() is called from the
+ * preAction hook in cli.ts, so help display and command parsing don't pay the
+ * DB connection cost.
+ *
+ * This replaces the ad-hoc PersistenceService.initialize() + ensurePersistence()
+ * pattern that was scattered across cli.ts.
+ *
+ * @see mt#761 spec, "Phase 2: Create composition roots and wire CLI"
+ */
+
+import { AppContainer } from "./container";
+import type { AppContainerInterface } from "./types";
+
+/**
+ * Create a container with real service factories for CLI usage.
+ * Does NOT call initialize() — the caller controls when async services start.
+ */
+export async function createCliContainer(): Promise<AppContainerInterface> {
+  const container = new AppContainer();
+
+  // --- Infrastructure (async) ---
+
+  container.register(
+    "persistence",
+    async () => {
+      const { PersistenceService } = await import("../domain/persistence/service");
+      await PersistenceService.initialize();
+      return PersistenceService.getProvider();
+    },
+    {
+      dispose: async () => {
+        const { PersistenceService } = await import("../domain/persistence/service");
+        await PersistenceService.close();
+      },
+    }
+  );
+
+  // --- Session layer (depends on persistence) ---
+
+  container.register("sessionProvider", async (c) => {
+    const { createSessionProvider } = await import("../domain/session/session-db-adapter");
+    const persistence = c.get("persistence");
+    return await createSessionProvider(undefined, {
+      persistenceService: {
+        isInitialized: () => true,
+        getProvider: () => persistence,
+      },
+    });
+  });
+
+  // --- Domain services ---
+
+  container.register("gitService", async () => {
+    const { createGitService } = await import("../domain/git/git-service-factory");
+    return createGitService();
+  });
+
+  container.register("taskService", async (c) => {
+    const { createConfiguredTaskService } = await import("../domain/tasks/taskService");
+    return createConfiguredTaskService({
+      workspacePath: process.cwd(),
+      persistenceProvider: c.get("persistence"),
+    });
+  });
+
+  container.register("workspaceUtils", async (c) => {
+    const { createWorkspaceUtils } = await import("../domain/workspace");
+    return createWorkspaceUtils(c.get("sessionProvider"));
+  });
+
+  container.register("repositoryBackend", async () => {
+    const { getRepositoryBackendFromConfig } = await import(
+      "../domain/session/repository-backend-detection"
+    );
+    return getRepositoryBackendFromConfig();
+  });
+
+  // --- Composite: SessionDeps bundle ---
+
+  container.register("sessionDeps", async (c) => {
+    const { getCurrentSession } = await import("../domain/workspace");
+    const { execAsync } = await import("../utils/exec");
+    const sessionProvider = c.get("sessionProvider");
+    return {
+      sessionProvider,
+      gitService: c.get("gitService"),
+      taskService: c.get("taskService"),
+      workspaceUtils: c.get("workspaceUtils"),
+      getCurrentSession: async (repoPath: string) => {
+        const result = await getCurrentSession(repoPath, execAsync, sessionProvider);
+        return result ?? null;
+      },
+      getRepositoryBackend: async () => c.get("repositoryBackend"),
+    };
+  });
+
+  return container;
+}

--- a/src/composition/index.ts
+++ b/src/composition/index.ts
@@ -8,6 +8,8 @@
  */
 
 export { AppContainer } from "./container";
+export { createCliContainer } from "./cli";
+export { createTestContainer } from "./test";
 export type {
   AppServices,
   ServiceKey,

--- a/src/composition/test.ts
+++ b/src/composition/test.ts
@@ -1,0 +1,98 @@
+/**
+ * Test Composition Root
+ *
+ * Builds an AppContainer with fake/stub implementations for testing.
+ * No I/O, no database connections, no filesystem access.
+ *
+ * Usage in tests:
+ *   const container = createTestContainer({ persistence: myFakePersistence });
+ *   const sessionProvider = container.get("sessionProvider");
+ *
+ * @see mt#761 spec, "Phase 2: Create composition roots"
+ */
+
+import { AppContainer } from "./container";
+import type { AppServices, AppContainerInterface } from "./types";
+
+/**
+ * Create a container with fake implementations for testing.
+ * Override specific services by passing them in the overrides parameter.
+ * No initialize() call needed — all services are set directly.
+ */
+export function createTestContainer(overrides: Partial<AppServices> = {}): AppContainerInterface {
+  const container = new AppContainer();
+
+  // Default fakes — minimal stubs that satisfy the type constraints.
+  // Tests override the services they actually care about.
+  /* eslint-disable @typescript-eslint/no-explicit-any, custom/no-excessive-as-unknown */
+  const defaults: AppServices = {
+    persistence: {
+      capabilities: { sql: false, vector: false },
+      getCapabilities: () => ({ sql: false, vector: false }),
+      getStorage: () => ({}) as any,
+      initialize: async () => {},
+      close: async () => {},
+    } as unknown as AppServices["persistence"],
+
+    sessionProvider: {
+      getSession: async () => null,
+      listSessions: async () => [],
+      addSession: async () => {},
+      deleteSession: async () => {},
+      updateSession: async () => {},
+    } as unknown as AppServices["sessionProvider"],
+
+    gitService: {
+      clone: async () => ({ workdir: "", session: "" }),
+      branch: async () => ({ workdir: "", branch: "" }),
+      branchWithoutSession: async () => ({ workdir: "", branch: "" }),
+      execInRepository: async () => "",
+      getSessionWorkdir: () => "",
+      stashChanges: async () => ({ workdir: "", stashed: false }),
+      fetchLatest: async () => ({ workdir: "", updated: false }),
+      mergeBranch: async () => ({ workdir: "", merged: false, conflicts: false }),
+      push: async () => ({ workdir: "", pushed: false }),
+      popStash: async () => ({ workdir: "", stashed: false }),
+      getStatus: async () => ({ modified: [], untracked: [], deleted: [] }),
+      getCurrentBranch: async () => "main",
+      hasUncommittedChanges: async () => false,
+      fetchDefaultBranch: async () => "main",
+      predictMergeConflicts: async () => ({ hasConflicts: false, conflictingFiles: [] }) as any,
+      analyzeBranchDivergence: async () => ({}) as any,
+      mergeWithConflictPrevention: async () => ({}) as any,
+      smartSessionUpdate: async () => ({}) as any,
+    } as unknown as AppServices["gitService"],
+
+    taskService: {
+      listTasks: async () => [],
+      getTask: async () => null,
+      getTaskStatus: async () => undefined,
+      setTaskStatus: async () => {},
+      createTask: async () => ({ id: "mt#1", title: "test", status: "TODO" }) as any,
+      createTaskFromTitleAndSpec: async () =>
+        ({ id: "mt#1", title: "test", status: "TODO" }) as any,
+      deleteTask: async () => {},
+    } as unknown as AppServices["taskService"],
+
+    workspaceUtils: {
+      isSessionWorkspace: async () => false,
+      getSessionFromWorkspace: async () => null,
+    } as unknown as AppServices["workspaceUtils"],
+
+    repositoryBackend: {
+      repoUrl: "https://github.com/test/repo.git",
+      backendType: "github" as any,
+    },
+
+    sessionDeps: {} as any, // Tests that need sessionDeps should override this
+  };
+
+  /* eslint-enable @typescript-eslint/no-explicit-any, custom/no-excessive-as-unknown */
+
+  // Apply defaults then overrides
+  for (const key of Object.keys(defaults) as (keyof AppServices)[]) {
+    container.set(key, (overrides[key] ?? defaults[key]) as AppServices[typeof key]);
+  }
+
+  return container;
+}


### PR DESCRIPTION
## Summary

Phase 2 of mt#761: Create composition roots and wire the CLI entry point to use the DI container from Phase 1.

### What was built

**`src/composition/cli.ts`** — CLI composition root. Registers real service factories:
- `persistence`: initializes PersistenceService, returns provider (async, with dispose)
- `sessionProvider`: creates session provider using persistence from container
- `gitService`, `taskService`, `workspaceUtils`: domain service factories
- `repositoryBackend`: reads from project config
- `sessionDeps`: composite bundle wiring all services together

**`src/composition/test.ts`** — Test composition root. Provides minimal fake stubs for all services via `set()`. Tests override only the services they care about. No `initialize()` needed.

**`src/cli.ts`** — Updated to:
- Create container via `createCliContainer()`
- Pass container to `createCli()`
- Initialize container lazily in `preAction` hook (persistence deferred past help display)
- Close container on exit

**`eslint.config.js`** — Added `**/src/composition/**/*.ts` to `no-singleton-reach-in` allowlist (composition roots ARE where singletons should be resolved).

### Startup time (not regressed)

| Command | Before | After |
|---------|--------|-------|
| `session --help` | 0.24s | 0.25s |
| `--help` | 0.62s | 0.58s |
| `tasks list` | 2.1s | 2.2s |

## Test plan

- [x] 17 container unit tests pass
- [x] Full test suite passes (1506 tests, verified by pre-commit hook)
- [x] TypeScript typecheck passes
- [x] ESLint: 0 errors, 0 warnings
- [x] CLI functional test: help, tasks list all work correctly