### PR TITLE
refactor(mt#774): Fix TaskSimilarityService dual-service anti-pattern

### DIFF
--- a/src/domain/storage/migrations/pg/meta/_journal.json
+++ b/src/domain/storage/migrations/pg/meta/_journal.json
@@ -104,7 +104,7 @@
       "idx": 14,
       "version": "7",
       "when": 1756335587327,
-      "tag": "0014_ambiguous_rawhide_kid",
+      "tag": "0014_dapper_changeling",
       "breakpoints": true
     },
     {

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -3,7 +3,9 @@ import { log } from "../../utils/logger";
 import type { EmbeddingService } from "../ai/embeddings/types";
 import type { VectorStorage, SearchResult } from "../storage/vector/types";
 import { createHash } from "crypto";
-import { createTaskSimilarityCore } from "../similarity/create-task-similarity-core";
+import { SimilaritySearchService } from "../similarity/similarity-search-service";
+import { EmbeddingsSimilarityBackend } from "../similarity/backends/embeddings-backend";
+import { LexicalSimilarityBackend } from "../similarity/backends/lexical-backend";
 import { first } from "../../utils/array-safety";
 
 export interface TaskSimilarityServiceConfig {
@@ -21,6 +23,8 @@ export interface TaskSearchResponse {
 }
 
 export class TaskSimilarityService {
+  private searchService: SimilaritySearchService | null = null;
+
   constructor(
     private readonly embeddingService: EmbeddingService,
     private readonly vectorStorage: VectorStorage,
@@ -32,24 +36,35 @@ export class TaskSimilarityService {
     private readonly config: TaskSimilarityServiceConfig = {}
   ) {}
 
+  /** Build or return the cached SimilaritySearchService from injected deps */
+  private getSearchService(): SimilaritySearchService {
+    if (!this.searchService) {
+      const embeddingsBackend = new EmbeddingsSimilarityBackend(
+        this.embeddingService,
+        this.vectorStorage
+      );
+      const lexicalBackend = new LexicalSimilarityBackend({
+        getById: this.findTaskById,
+        listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
+        getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
+      });
+      this.searchService = new SimilaritySearchService([embeddingsBackend, lexicalBackend]);
+    }
+    return this.searchService;
+  }
+
   /** Expose service configuration for diagnostics */
   getConfig(): TaskSimilarityServiceConfig {
     return this.config;
   }
 
   async similarToTask(taskId: string, limit = 10, threshold?: number): Promise<TaskSearchResponse> {
-    // Delegate to generic core; embeddings backend will be first if available
-    const core = await createTaskSimilarityCore({
-      getById: this.findTaskById,
-      listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
-      getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
-    });
     const task = await this.findTaskById(taskId);
     if (!task) {
       return { results: [], backend: "none", degraded: false };
     }
     const content = await this.extractTaskContent(task);
-    const response = await core.search({ queryText: content, limit });
+    const response = await this.getSearchService().search({ queryText: content, limit });
     return {
       results: response.items.map((i) => ({
         id: i.id,
@@ -68,12 +83,7 @@ export class TaskSimilarityService {
     threshold?: number,
     filters?: Record<string, unknown>
   ): Promise<TaskSearchResponse> {
-    const core = await createTaskSimilarityCore({
-      getById: this.findTaskById,
-      listCandidateIds: async () => (await this.searchTasks({})).map((t) => t.id),
-      getContent: async (id: string) => (await this.getTaskSpecContent(id)).content,
-    });
-    const response = await core.search({ queryText: query, limit, filters });
+    const response = await this.getSearchService().search({ queryText: query, limit, filters });
     return {
       results: response.items.map((i) => ({
         id: i.id,


### PR DESCRIPTION
## Summary

- **Fix dual-service anti-pattern**: `TaskSimilarityService.searchByText()` and `similarToTask()` were ignoring injected `embeddingService` and `vectorStorage`, instead calling `createTaskSimilarityCore()` which created entirely new instances from global config. Now the service lazily builds a `SimilaritySearchService` from its injected deps and caches it.
- **Correct migration journal tag**: Entry 0014 tag corrected from `0014_ambiguous_rawhide_kid` to `0014_dapper_changeling` to match the actual migration file.

## Changes

**`src/domain/tasks/task-similarity-service.ts`**:
- Replaced `createTaskSimilarityCore` import with direct imports of `SimilaritySearchService`, `EmbeddingsSimilarityBackend`, `LexicalSimilarityBackend`
- Added private `getSearchService()` that lazily constructs and caches a `SimilaritySearchService` from injected deps
- Updated `searchByText()` and `similarToTask()` to use `this.getSearchService()` instead of `createTaskSimilarityCore()`
- `indexTask()` left unchanged (already used injected deps correctly)

**`src/domain/storage/migrations/pg/meta/_journal.json`**:
- Fixed tag for entry idx 14

## Coherence Verification

**Files re-read**: `src/domain/tasks/task-similarity-service.ts`, `src/domain/similarity/create-task-similarity-core.ts`, `src/domain/similarity/task-similarity-service.core.test.ts`, `src/domain/similarity/similarity-search-service.ts`, `src/domain/similarity/backends/embeddings-backend.ts`, `src/domain/similarity/backends/lexical-backend.ts`

**Q1 single purpose**: pass — task-similarity-service.ts remains focused on task similarity operations
**Q2 comment honesty**: pass — no comments reference createTaskSimilarityCore or deleted patterns
**Q3 naming honesty**: pass — all names still reflect their purpose
**Q4 redundant siblings**: pass — create-task-similarity-core.ts is a factory for other callers, not redundant with the service
**Q5 dead exports**: pass — grep confirms createTaskSimilarityCore is only in its own file (no callers remain, but the task spec says to keep it for rules/tools usage)
**Q6 orphan code**: pass — no code existed solely to support the removed import
**Q7 stray artifacts**: pass — no .backup/.bak/.old/.tmp files found

**Items fixed in this PR (beyond original scope)**: migration journal tag fix (mt#780)
**Items deferred (with justification)**: none

## Test plan

- [ ] Existing test `task-similarity-service.core.test.ts` passes (prototype patching of `EmbeddingsSimilarityBackend.isAvailable` still works with lazy construction)
- [ ] `searchByText` returns lexical results when embeddings unavailable
- [ ] `similarToTask` returns results via lexical backend
- [ ] `indexTask` continues to use injected deps directly (unchanged)

Generated with Claude Code (claude-opus-4-6)