### PR TITLE
chore(mt#712): Remove stale spyOn comment residue

### DIFF
--- a/src/domain/git/parameter-based-functions.test.ts
+++ b/src/domain/git/parameter-based-functions.test.ts
@@ -86,11 +86,7 @@ describe("Parameter-Based Git Functions with Dependency Injection", () => {
     });
   });
 
-  // Demonstrate the architectural improvement this DI approach provides
   test("should show improved test architecture with DI", () => {
-    // BEFORE: Global spyOn(GitService.prototype, ...) patterns
-    // AFTER: Clean dependency injection with createTestDeps()
-
     expect(domainDeps).toBeDefined();
     expect(domainDeps.gitService).toBeDefined();
     expect(domainDeps.sessionDB).toBeDefined();


### PR DESCRIPTION
## Summary
- Removes stale BEFORE/AFTER comment in `parameter-based-functions.test.ts` that referenced the old `spyOn(GitService.prototype, ...)` pattern
- This was behavioral residue from the DI migration (mt#712) — the pattern is long gone, so the comment explaining what it replaced is no longer useful

## Test plan
- [ ] `bun test src/domain/git/parameter-based-functions.test.ts` passes
- [ ] No remaining `spyOn` references in production/test code (only the ESLint rule description, which is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)