### PR TITLE
feat(mt#782): Persist branch name in session record at creation time

### DIFF
--- a/src/domain/session/session-start-operations.ts
+++ b/src/domain/session/session-start-operations.ts
@@ -190,21 +190,23 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
       }
     }
 
-    // Prepare session record but don't add to DB yet (branch no longer persisted)
+    // Define branchName before session record so it can be persisted
+    const branchName = branch || (taskId ? taskIdToBranchName(taskId) : sessionId);
+
+    // Prepare session record but don't add to DB yet
     const baseSessionRecord: SessionRecord = {
       session: sessionId,
       repoUrl,
       repoName,
       createdAt: new Date().toISOString(),
       taskId: taskId ? SessionBackwardCompatibility.toStorageFormat(taskId) : undefined,
+      branch: branchName,
     };
 
     // Enhance session record with multi-backend information
     const sessionRecord = SessionMultiBackendIntegration.enhanceSessionRecord(baseSessionRecord);
 
     let sessionAdded = false;
-    // Define branchName outside try block so it's available in return statement
-    const branchName = branch || (taskId ? taskIdToBranchName(taskId) : sessionId);
 
     try {
       // First clone the repo

--- a/src/domain/session/session-update-operations.ts
+++ b/src/domain/session/session-update-operations.ts
@@ -12,6 +12,7 @@ import type { SessionProviderInterface, SessionRecord, Session } from "../sessio
 import { resolveSessionContextWithFeedback } from "./session-context-resolver";
 import { gitFetchWithTimeout } from "../../utils/git-exec";
 import { assertSessionMutable } from "./session-mutability";
+import { taskIdToBranchName } from "../tasks/task-id";
 
 export interface UpdateSessionDependencies {
   gitService: GitServiceInterface;
@@ -112,13 +113,14 @@ export async function updateSessionImpl(
           // Extract task ID from session ID - simpler and more reliable approach
           const taskId = sessionId.startsWith("task#") ? sessionId : undefined;
 
-          // Create session record (branch no longer persisted)
+          // Create session record
           const newSessionRecord: SessionRecord = {
             session: sessionId,
             repoName,
             repoUrl,
             createdAt: new Date().toISOString(),
             taskId,
+            branch: taskId ? taskIdToBranchName(taskId) : sessionId,
           };
 
           await deps.sessionDB.addSession(newSessionRecord);

--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -266,7 +266,10 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
       }
     }
 
-    // Prepare session record but don't add to DB yet (branch no longer persisted)
+    // Define branchName before session record so it can be persisted
+    const branchName = branch || (taskId ? taskIdToBranchName(taskId) : sessionId);
+
+    // Prepare session record but don't add to DB yet
     // Detect repository backend type up-front so session records have correct backendType
     const sessionRecord: SessionRecord = {
       session: sessionId,
@@ -275,11 +278,10 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
       createdAt: new Date().toISOString(),
       taskId,
       backendType,
+      branch: branchName,
     };
 
     let sessionAdded = false;
-    // Define branchName outside try block so it's available in return statement
-    const branchName = branch || (taskId ? taskIdToBranchName(taskId) : sessionId);
 
     try {
       // First clone the repo.  Use cloneSource so that an explicit --repo path can

--- a/src/domain/session/types.ts
+++ b/src/domain/session/types.ts
@@ -18,7 +18,8 @@ export interface SessionRecord {
   /** Task ID in storage format (plain number string, e.g., "283") */
   taskId?: string;
   backendType?: "local" | "remote" | "github"; // Added for repository backend support
-  // Removed: branch (no longer stored persistently)
+  /** Git branch name created for this session */
+  branch?: string;
   prState?: {
     branchName: string;
     commitHash?: string; // Hash of the prepared merge commit
@@ -38,8 +39,6 @@ export interface SessionRecord {
   name?: string;
   workspacePath?: string;
   sessionPath?: string;
-  /** Branch name - removed from persistent schema but kept for test compatibility */
-  branch?: string;
   /** @deprecated Use `createdAt` instead */
   created?: string;
   github?: {


### PR DESCRIPTION
## Summary

- Un-deprecates the `branch` field on `SessionRecord` and moves it from legacy/compatibility to a core field
- Stores the computed branch name in the session record during `startSessionImpl` (previously computed but deliberately not persisted)
- Adds branch persistence to the orphan session self-repair path in `session-update-operations.ts`
- Fixes a broken import of `taskIdToBranchName` in `session-update-operations.ts`

## Motivation

Prerequisite for mt#756 (session_delete should clean up remote branches). Without reliably stored branch names, deletion would have to re-derive the branch from the task ID, which is fragile — explicit `--branch` overrides would be lost, and the derivation logic could change over time.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Existing session start and mutability tests pass (11/11)
- [ ] CI build + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)