### PR TITLE
feat(mt#761): thread DI container through command execution (Phase 3a)

### DIFF
--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -151,10 +151,21 @@ export function registerSharedCommandsWithMcp(
 
           try {
             // Create execution context for shared command
+            // Get the app container set by the composition root (mt#761).
+            let appContainer;
+            try {
+              const { getAppContainer } = await import(
+                "../shared/bridges/cli/command-generator-core"
+              );
+              appContainer = getAppContainer();
+            } catch {
+              // Container not available — backward compatibility
+            }
             const context: CommandExecutionContext = {
               interface: "mcp",
               debug: Boolean(args?.debug),
               format: args?.json === "true" ? "json" : "text", // Use json format only when explicitly requested
+              container: appContainer,
             };
             log.debug(`[MCP] Created execution context: ${command.id}`, { context });
 

--- a/src/adapters/shared/bridges/cli/command-generator-core.ts
+++ b/src/adapters/shared/bridges/cli/command-generator-core.ts
@@ -42,6 +42,27 @@ export interface CommandGeneratorDependencies {
 }
 
 /**
+ * Module-scoped container reference, set once from the CLI composition root.
+ * Injected into CommandExecutionContext so execute handlers can access DI services.
+ * @see mt#761
+ */
+let _appContainer: import("../../../../composition/types").AppContainerInterface | undefined;
+
+/** Set the app container for CLI command execution contexts. Called once from cli.ts. */
+export function setAppContainer(
+  container: import("../../../../composition/types").AppContainerInterface
+): void {
+  _appContainer = container;
+}
+
+/** Get the app container (for MCP integration and other context creators). */
+export function getAppContainer():
+  | import("../../../../composition/types").AppContainerInterface
+  | undefined {
+  return _appContainer;
+}
+
+/**
  * Core command generator implementation
  */
 export class CommandGeneratorCore {
@@ -151,6 +172,7 @@ export class CommandGeneratorCore {
           interface: "cli",
           debug: !!rawParameters.debug,
           format: rawParameters.json ? "json" : "text",
+          container: _appContainer,
           cliSpecificData: {
             command: commandInstance,
             rawArgs: commandInstance.args,

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -47,6 +47,12 @@ export interface CommandExecutionContext {
   format?: string;
   /** Workspace path for the current context */
   workspacePath?: string;
+  /**
+   * DI container — provides access to services without singleton reach-ins.
+   * Available after container.initialize() has been called (i.e., during command execution).
+   * Optional for backward compatibility during the migration period (mt#761).
+   */
+  container?: import("../../composition/types").AppContainerInterface;
 }
 
 /**

--- a/src/adapters/shared/commands/index.ts
+++ b/src/adapters/shared/commands/index.ts
@@ -5,6 +5,7 @@
  * This file serves as the central point for registering all shared commands.
  */
 
+import type { AppContainerInterface } from "../../../composition/types";
 import { registerGitCommands } from "./git";
 import { registerTasksCommands } from "./tasks";
 import { registerSessionCommands } from "./session";
@@ -19,17 +20,19 @@ import { registerChangesetCommands } from "./changeset";
 import { registerValidateCommands } from "./validate";
 
 /**
- * Register all shared commands in the shared command registry
+ * Register all shared commands in the shared command registry.
+ * @param container Optional DI container — when provided, command groups can
+ *   resolve services from it instead of reaching into singletons.
  */
-export async function registerAllSharedCommands(): Promise<void> {
+export async function registerAllSharedCommands(container?: AppContainerInterface): Promise<void> {
   // Register git commands
   registerGitCommands();
 
   // Register tasks commands
   registerTasksCommands();
 
-  // Register session commands (async)
-  await registerSessionCommands();
+  // Register session commands (async) — pass container for DI migration (mt#761)
+  await registerSessionCommands(undefined, container);
 
   // Register rules commands
   registerRulesCommands();

--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -4,6 +4,7 @@
  * Constructs and registers all session commands (and changeset aliases)
  * in the shared command registry.
  */
+import type { AppContainerInterface } from "../../../composition/types";
 import { type SessionCommandDependencies, type LazySessionDeps } from "./session/types";
 import {
   createSessionListCommand,
@@ -41,13 +42,20 @@ import { sharedCommandRegistry, type CommandDefinition } from "../command-regist
  * command registry.
  */
 export async function registerSessionCommands(
-  partialDeps?: Partial<SessionCommandDependencies>
+  partialDeps?: Partial<SessionCommandDependencies>,
+  container?: AppContainerInterface
 ): Promise<void> {
   // Lazy resolver: defers persistence initialization and domain module loading
   // to first command execution. CLI bootstrap only registers metadata.
   let cachedDeps: SessionCommandDependencies | null = null;
   const getDeps: LazySessionDeps = async () => {
     if (cachedDeps) return cachedDeps;
+    // Prefer container-provided sessionDeps if available (mt#761 DI migration).
+    // Falls back to singleton for backward compatibility during migration.
+    if (container?.has("sessionDeps")) {
+      cachedDeps = container.get("sessionDeps");
+      return cachedDeps;
+    }
     const { getSharedSessionProvider } = await import(
       "../../../domain/session/session-provider-cache"
     );

--- a/src/adapters/shared/commands/session/changeset-aliases.ts
+++ b/src/adapters/shared/commands/session/changeset-aliases.ts
@@ -92,9 +92,10 @@ async function executeSessionChangesetList(
     let sessionFilter: string | undefined;
     if (!params.all) {
       try {
-        const { getSharedSessionProvider } = await import("../../../../domain/session");
         const { execAsync } = await import("../../../../utils/exec");
-        const sessionDB = await getSharedSessionProvider();
+        const sessionDB = ctx?.container?.has("sessionProvider")
+          ? ctx.container.get("sessionProvider")
+          : await (await import("../../../../domain/session")).getSharedSessionProvider();
         const currentSessionId = await getCurrentSession(process.cwd(), execAsync, sessionDB);
         if (currentSessionId) {
           sessionFilter = currentSessionId;
@@ -198,9 +199,10 @@ async function executeSessionChangesetGet(
     // If no ID specified, try to find current session's changeset
     if (!changesetId) {
       try {
-        const { getSharedSessionProvider } = await import("../../../../domain/session");
         const { execAsync: execAsyncFn } = await import("../../../../utils/exec");
-        const sessionDB2 = await getSharedSessionProvider();
+        const sessionDB2 = ctx?.container?.has("sessionProvider")
+          ? ctx.container.get("sessionProvider")
+          : await (await import("../../../../domain/session")).getSharedSessionProvider();
         const currentSessionId = await getCurrentSession(process.cwd(), execAsyncFn, sessionDB2);
         if (currentSessionId) {
           const sessionProvider = sessionDB2;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,11 @@ export const cli = new Command("minsky")
  * Create the CLI command structure
  */
 export async function createCli(container: AppContainerInterface): Promise<Command> {
+  // Make the container available to CLI command execution contexts (mt#761).
+  // Execute handlers access it via context.container.get("serviceName").
+  const { setAppContainer } = await import("./adapters/shared/bridges/cli/command-generator-core");
+  setAppContainer(container);
+
   // Setup common command customizations with the CLI instance
   setupCommonCommandCustomizations(cli);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ export async function createCli(container: AppContainerInterface): Promise<Comma
 
   // Register shared commands (session, tasks, git, rules, config, etc.)
   const { registerAllSharedCommands } = await import("./adapters/shared/commands/index");
-  await registerAllSharedCommands();
+  await registerAllSharedCommands(container);
 
   // Register all commands via CLI command factory (which applies customizations)
   cliFactory.registerAllCommands(cli);


### PR DESCRIPTION
## Summary

Phase 3a of mt#761: Thread the DI container through the command execution infrastructure so execute handlers can resolve services from it instead of calling singletons.

### Changes

1. **`CommandExecutionContext`** (`command-registry.ts`): Added optional `container` field so all execute handlers can access DI services via `context.container?.get("serviceName")`.

2. **Container injection for CLI** (`command-generator-core.ts`): Module-scoped `setAppContainer()`/`getAppContainer()` functions. Set once from `cli.ts`, injected into every `CliExecutionContext`.

3. **Container injection for MCP** (`shared-command-integration.ts`): MCP context creation uses `getAppContainer()` to include the container.

4. **`registerAllSharedCommands(container?)`** (`commands/index.ts`): Accepts optional container, threads it to `registerSessionCommands()`.

5. **Session `LazySessionDeps`** (`session.ts`): Now resolves from `container.get("sessionDeps")` when available, falling back to `getSharedSessionProvider()` singleton during migration.

6. **Changeset aliases** (`changeset-aliases.ts`): 2 `getSharedSessionProvider()` calls replaced with `ctx?.container?.get("sessionProvider")` with singleton fallback.

### Migration pattern established

Execute handlers can now access the container via their existing `context` parameter:
```typescript
execute: async (params, context) => {
  const sessionProvider = context.container?.has("sessionProvider")
    ? context.container.get("sessionProvider")
    : await getSharedSessionProvider(); // fallback during migration
}
```

This pattern will be applied to remaining singleton call sites in subsequent batches.

## Test plan

- [x] TypeScript typecheck passes
- [x] 1555 tests pass (pre-push verified)
- [x] CLI functional test: session --help (0.23s), tasks list works
- [x] No startup regression