### PR TITLE
fix(mt#784): use .returning() for DELETE count instead of broken rowCount

### DIFF
--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -398,11 +398,10 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
    */
   async deleteEntity(id: string): Promise<boolean> {
     await this.ensureConnection();
-    const result = await this.drizzle!.delete(postgresSessions).where(
-      eq(postgresSessions.session, id)
-    );
-    const rowCount = (result as { rowCount?: number }).rowCount ?? 0;
-    return rowCount > 0;
+    const deleted = await this.drizzle!.delete(postgresSessions)
+      .where(eq(postgresSessions.session, id))
+      .returning({ session: postgresSessions.session });
+    return deleted.length > 0;
   }
 
   /**

--- a/src/domain/tasks/github-issues-api.ts
+++ b/src/domain/tasks/github-issues-api.ts
@@ -366,9 +366,12 @@ export async function deleteIssue(
         if (db) {
           const { tasksTable } = await import("../storage/schemas/task-embeddings");
           const { eq } = await import("drizzle-orm");
-          const result = await db.delete(tasksTable).where(eq(tasksTable.id, taskId));
+          const deleted = await db
+            .delete(tasksTable)
+            .where(eq(tasksTable.id, taskId))
+            .returning({ id: tasksTable.id });
           log.debug(`Deleted task ${taskId} from database`, {
-            rowCount: (result as { rowCount?: number }).rowCount,
+            deletedCount: deleted.length,
           });
         } else {
           log.debug(`No database connection available for task ${taskId} deletion`);

--- a/src/domain/tasks/minskyTaskBackend.ts
+++ b/src/domain/tasks/minskyTaskBackend.ts
@@ -145,12 +145,11 @@ export class MinskyTaskBackend implements TaskBackend {
   }
 
   async deleteTask(id: string, options?: DeleteTaskOptions): Promise<boolean> {
-    const result = await this.db.delete(tasksTable).where(eq(tasksTable.id, id));
-    const rowCount =
-      result && typeof result === "object" && "rowCount" in result
-        ? (result.rowCount as number)
-        : 0;
-    return rowCount > 0;
+    const deleted = await this.db
+      .delete(tasksTable)
+      .where(eq(tasksTable.id, id))
+      .returning({ id: tasksTable.id });
+    return deleted.length > 0;
   }
 
   getWorkspacePath(): string {

--- a/src/domain/tasks/task-graph-service.ts
+++ b/src/domain/tasks/task-graph-service.ts
@@ -59,7 +59,7 @@ function createDrizzleRepo(db: PostgresJsDatabase): TaskRelationshipsRepository 
       await db.insert(taskRelationshipsTable).values({ fromTaskId: fromId, toTaskId: toId, type });
     },
     async deleteEdge(fromId, toId, type) {
-      const res = await db
+      const deleted = await db
         .delete(taskRelationshipsTable)
         .where(
           and(
@@ -67,16 +67,18 @@ function createDrizzleRepo(db: PostgresJsDatabase): TaskRelationshipsRepository 
             eq(taskRelationshipsTable.toTaskId, toId),
             eq(taskRelationshipsTable.type, type)
           )
-        );
-      return (res as { rowCount?: number })?.rowCount ?? 0;
+        )
+        .returning({ id: taskRelationshipsTable.id });
+      return deleted.length;
     },
     async deleteEdgesFrom(fromId, type) {
-      const res = await db
+      const deleted = await db
         .delete(taskRelationshipsTable)
         .where(
           and(eq(taskRelationshipsTable.fromTaskId, fromId), eq(taskRelationshipsTable.type, type))
-        );
-      return (res as { rowCount?: number })?.rowCount ?? 0;
+        )
+        .returning({ id: taskRelationshipsTable.id });
+      return deleted.length;
     },
     async listFrom(taskId, type) {
       const rows = await db


### PR DESCRIPTION
## Summary

Drizzle ORM's DELETE result strips postgres.js metadata (`count`, `command`), so `(res as { rowCount }).rowCount` is always `undefined`, falling back to 0. This caused `removeDependency` and `removeParent` to always return `{ removed: false }` even when the delete succeeded.

### Root cause

- **Raw postgres.js** DELETE returns `{ count: 1, command: "DELETE" }` ✅
- **Drizzle ORM** DELETE returns `[]` with no `rowCount` or `count` ❌

### Fix

Use `.returning({ id: taskRelationshipsTable.id })` on DELETE queries and check `deleted.length`. This is the idiomatic Drizzle approach that works through connection poolers like Supabase.

### Changes

- `deleteEdge`: `.returning()` + `.length` instead of `rowCount`
- `deleteEdgesFrom`: same pattern

## Spec verification

| Criterion | Status | Evidence |
|---|---|---|
| DELETE operations return correct count | Met | `.returning()` returns actual deleted rows |
| Backward compatible | Met | Only the count mechanism changed, not behavior |

🤖 Generated with [Claude Code](https://claude.com/claude-code)