### PR TITLE
refactor(mt#778): unify description/spec naming — Part A + C

### DIFF
--- a/src/adapters/mcp/schemas/task-parameters.ts
+++ b/src/adapters/mcp/schemas/task-parameters.ts
@@ -34,16 +34,16 @@ export const TaskStatusSchema = z.nativeEnum(TaskStatus, {
 });
 
 /**
- * Task description schema
+ * Task spec content schema
  */
-export const TaskDescriptionSchema = z.string().optional();
+export const TaskSpecContentSchema = z.string().optional();
 
 /**
  * Task creation parameters schema
  */
 export const TaskCreateParametersSchema = BaseBackendParametersSchema.extend({
   title: TaskTitleSchema,
-  description: TaskDescriptionSchema,
+  spec: TaskSpecContentSchema,
   force: ForceSchema,
 });
 

--- a/src/adapters/shared/commands/tasks/base-task-command.ts
+++ b/src/adapters/shared/commands/tasks/base-task-command.ts
@@ -156,8 +156,8 @@ export abstract class BaseTaskCommand<TParams = BaseTaskParams, TResult = unknow
 
           // Note: Task objects don't contain spec content directly
           // Spec content needs to be fetched separately via getTaskSpecContent
-          if (taskObj.description) {
-            output += `Description: ${taskObj.description}\n`;
+          if (taskObj.spec) {
+            output += `Spec: ${taskObj.spec}\n`;
           }
 
           if (taskObj.specPath) {

--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -287,15 +287,18 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
       // Validate required parameters
       this.validateRequired(params.title, "title");
 
-      // Validate that either description or specPath is provided
-      if (!params.description && !params.specPath) {
-        throw new ValidationError("Either --description or --spec-path must be provided");
+      // Resolve spec content: prefer params.spec, fall back to deprecated params.description
+      const specContent = params.spec || params.description;
+
+      // Validate that either spec or specPath is provided
+      if (!specContent && !params.specPath) {
+        throw new ValidationError("Either --spec or --spec-path must be provided");
       }
 
-      // Both description and specPath provided is an error
-      if (params.description && params.specPath) {
+      // Both spec and specPath provided is an error
+      if (specContent && params.specPath) {
         throw new ValidationError(
-          "Cannot provide both --description and --spec-path - use one or the other"
+          "Cannot provide both --spec and --spec-path - use one or the other"
         );
       }
 
@@ -316,7 +319,7 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
       const { createTaskFromTitleAndSpec } = await import("../../../../domain/tasks");
       const result = await createTaskFromTitleAndSpec({
         title: params.title,
-        spec: params.description, // Map description to spec
+        spec: specContent, // spec content (or deprecated description alias)
         specPath: params.specPath,
         force: params.force ?? false,
         backend: params.backend,

--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -57,7 +57,7 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
       title?: string;
       status?: string;
       specPath?: string;
-      description?: string;
+      spec?: string;
     }> = [];
 
     for (const result of searchResults) {
@@ -78,8 +78,8 @@ export class TasksSimilarCommand extends BaseTaskCommand<TasksSimilarParams> {
             title: task.title,
             status: task.status,
             specPath: includeSpecPath ? task.specPath : undefined,
-            // Only include description if details requested
-            description: includeDetails ? task.description : undefined,
+            // Only include spec if details requested
+            spec: includeDetails ? task.spec : undefined,
           });
         } else {
           // Task not found, include minimal info
@@ -182,7 +182,7 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
       title?: string;
       status?: string;
       specPath?: string;
-      description?: string;
+      spec?: string;
     }> = [];
 
     for (const result of searchResults) {
@@ -203,8 +203,8 @@ export class TasksSearchCommand extends BaseTaskCommand<TasksSearchParams> {
             title: task.title,
             status: task.status,
             specPath: includeSpecPath ? task.specPath : undefined,
-            // Only include description if details requested
-            description: includeDetails ? task.description : undefined,
+            // Only include spec if details requested
+            spec: includeDetails ? task.spec : undefined,
           });
         } else {
           // Task not found, include minimal info

--- a/src/adapters/shared/commands/tasks/task-parameters.ts
+++ b/src/adapters/shared/commands/tasks/task-parameters.ts
@@ -44,11 +44,11 @@ export const taskStatusParam = {
  */
 export const taskCreationParams = {
   title: TaskParameters.title,
-  description: TaskParameters.description,
+  spec: TaskParameters.spec,
   force: CommonParameters.force,
   specPath: {
     schema: z.string(),
-    description: "Path to file containing task description",
+    description: "Path to file containing task specification",
     required: false,
   },
   githubRepo: {

--- a/src/adapters/shared/common-parameters.ts
+++ b/src/adapters/shared/common-parameters.ts
@@ -278,11 +278,11 @@ export const TaskParameters = {
   } as CommandParameterDefinition,
 
   /**
-   * Task description parameter
+   * Task spec parameter (also accepts deprecated 'description' alias)
    */
-  description: {
+  spec: {
     schema: z.string(),
-    description: "Task description",
+    description: "Task specification content",
     required: false,
   } as CommandParameterDefinition,
 

--- a/src/commands/context/generate-comparison.ts
+++ b/src/commands/context/generate-comparison.ts
@@ -41,7 +41,7 @@ export async function displayModelComparison(models: string[], options: Generate
             id: "mt#461",
             title: "Context Visualization Redesign",
             status: TaskStatus.IN_PROGRESS,
-            description: "Implementing context visualization using new component architecture",
+            spec: "Implementing context visualization using new component architecture",
           },
           userQuery: options.prompt || "Generating context visualization analysis",
           userPrompt: options.prompt,

--- a/src/commands/context/generate-types.ts
+++ b/src/commands/context/generate-types.ts
@@ -70,7 +70,7 @@ export interface GenerateRequest {
   input: {
     environment: { os: string; shell: string };
     workspacePath: string;
-    task: { id: string; title: string; status: string; description: string };
+    task: { id: string; title: string; status: string; spec?: string };
     userQuery: string;
     userPrompt?: string;
     targetModel: string;

--- a/src/commands/context/generate.ts
+++ b/src/commands/context/generate.ts
@@ -165,7 +165,7 @@ function buildGenerateRequest(components: string[], options: GenerateOptions): G
         id: "md#082",
         title: "Add Context Management Commands for Environment-Agnostic AI Collaboration",
         status: TaskStatus.IN_PROGRESS,
-        description: "Implementing modular context component system for testbench development",
+        spec: "Implementing modular context component system for testbench development",
       },
       userQuery:
         options.prompt ||

--- a/src/domain/context/components/task-context.ts
+++ b/src/domain/context/components/task-context.ts
@@ -29,7 +29,7 @@ export const TaskContextComponent: ContextComponent = {
       taskId: task?.id,
       taskTitle: task?.title,
       taskStatus: task?.status,
-      taskDescription: task?.description,
+      taskDescription: task?.spec,
       userQuery,
     } as TaskContextInputs;
   },

--- a/src/domain/context/components/types.ts
+++ b/src/domain/context/components/types.ts
@@ -1,7 +1,7 @@
 export interface ComponentInput {
   environment?: { os?: string; shell?: string };
   workspacePath?: string;
-  task?: { id: string; title: string; status: string; description: string };
+  task?: { id: string; title: string; status: string; spec?: string };
   userQuery?: string;
   userPrompt?: string;
   targetModel?: string;

--- a/src/domain/schemas/task-schemas.ts
+++ b/src/domain/schemas/task-schemas.ts
@@ -45,14 +45,14 @@ export const TaskPrioritySchema = z.enum(["low", "medium", "high", "urgent"]).de
 export const TaskTitleSchema = z.string().min(1, "Task title cannot be empty");
 
 /**
- * Task description schema - used across all interfaces
+ * Task spec content schema - used across all interfaces
  */
-export const TaskDescriptionSchema = z.string().optional();
+export const TaskSpecContentSchema = z.string().optional();
 
 /**
- * Task description path schema - used across all interfaces
+ * Task spec path schema - used across all interfaces
  */
-export const TaskDescriptionPathSchema = z.string().optional();
+export const TaskSpecPathSchema = z.string().optional();
 
 /**
  * Task tag schema - used across all interfaces
@@ -84,8 +84,8 @@ export const TaskDueDateSchema = z.string().datetime().optional();
 export const TaskCreateParametersSchema = z
   .object({
     title: TaskTitleSchema,
-    description: TaskDescriptionSchema,
-    specPath: TaskDescriptionPathSchema,
+    spec: TaskSpecContentSchema,
+    specPath: TaskSpecPathSchema,
     priority: TaskPrioritySchema,
     tags: TaskTagsSchema,
     assignee: TaskAssigneeSchema,
@@ -101,8 +101,8 @@ export const TaskUpdateParametersSchema = z
   .object({
     taskId: TaskIdSchema,
     title: TaskTitleSchema.optional(),
-    description: TaskDescriptionSchema,
-    specPath: TaskDescriptionPathSchema,
+    spec: TaskSpecContentSchema,
+    specPath: TaskSpecPathSchema,
     priority: TaskPrioritySchema.optional(),
     status: TaskStatusSchema.optional(),
     tags: TaskTagsSchema,
@@ -178,8 +178,8 @@ export const TaskSpecParametersSchema = z
 export const MultiBackendTaskCreateParametersSchema = z
   .object({
     title: TaskTitleSchema,
-    description: TaskDescriptionSchema,
-    specPath: TaskDescriptionPathSchema,
+    spec: TaskSpecContentSchema,
+    specPath: TaskSpecPathSchema,
     priority: TaskPrioritySchema,
     tags: TaskTagsSchema,
     assignee: TaskAssigneeSchema,
@@ -196,8 +196,8 @@ export const MultiBackendTaskUpdateParametersSchema = z
   .object({
     taskId: NormalizedTaskIdSchema, // Auto-migrates legacy IDs
     title: TaskTitleSchema.optional(),
-    description: TaskDescriptionSchema,
-    specPath: TaskDescriptionPathSchema,
+    spec: TaskSpecContentSchema,
+    specPath: TaskSpecPathSchema,
     priority: TaskPrioritySchema.optional(),
     status: TaskStatusSchema.optional(),
     tags: TaskTagsSchema,
@@ -279,7 +279,7 @@ export const TaskMigrationParametersSchema = z
 export const BaseTaskDataSchema = z.object({
   id: TaskIdSchema,
   title: TaskTitleSchema,
-  description: TaskDescriptionSchema,
+  spec: TaskSpecContentSchema,
   status: TaskStatusSchema,
   priority: TaskPrioritySchema,
   tags: TaskTagsSchema,
@@ -350,7 +350,7 @@ export const TaskStatusResponseSchema = z.union([
 
 export type TaskPriority = z.infer<typeof TaskPrioritySchema>;
 export type TaskTitle = z.infer<typeof TaskTitleSchema>;
-export type TaskDescription = z.infer<typeof TaskDescriptionSchema>;
+export type TaskSpecContent = z.infer<typeof TaskSpecContentSchema>;
 export type TaskTags = z.infer<typeof TaskTagsSchema>;
 export type TaskCreateParameters = z.infer<typeof TaskCreateParametersSchema>;
 export type TaskUpdateParameters = z.infer<typeof TaskUpdateParametersSchema>;

--- a/src/domain/session/session-start-task-id-bug.test.ts
+++ b/src/domain/session/session-start-task-id-bug.test.ts
@@ -20,7 +20,7 @@ describe("Task ID Generation Bug Reproduction", () => {
       {
         id: TEST_CONSTANTS.TASK_IDS.EXISTING_HIGH,
         title: "Existing high numbered task",
-        description: "This simulates existing task md#371",
+        spec: "This simulates existing task md#371",
         status: TaskStatus.TODO,
         specPath: "process/tasks/md#371.md",
       },
@@ -42,7 +42,7 @@ describe("Task ID Generation Bug Reproduction", () => {
       {
         id: TEST_CONSTANTS.TASK_IDS.EXISTING_HIGH,
         title: "Existing high numbered task",
-        description: "This simulates existing task md#371",
+        spec: "This simulates existing task md#371",
         status: TaskStatus.TODO,
         specPath: "process/tasks/md#371.md",
       },
@@ -65,9 +65,9 @@ describe("Task ID Generation Bug Reproduction", () => {
   it("should show the difference between correct and buggy approaches", () => {
     // Multiple tasks with gaps to make the bug more obvious
     const tasksWithGaps: TaskData[] = [
-      { id: "md#50", title: "Task 50", description: "", status: TaskStatus.TODO, specPath: "" },
-      { id: "md#100", title: "Task 100", description: "", status: TaskStatus.TODO, specPath: "" },
-      { id: "md#371", title: "Task 371", description: "", status: TaskStatus.TODO, specPath: "" },
+      { id: "md#50", title: "Task 50", spec: "", status: TaskStatus.TODO, specPath: "" },
+      { id: "md#100", title: "Task 100", spec: "", status: TaskStatus.TODO, specPath: "" },
+      { id: "md#371", title: "Task 371", spec: "", status: TaskStatus.TODO, specPath: "" },
     ];
 
     const correctNext = getNextTaskId(tasksWithGaps);
@@ -89,18 +89,18 @@ describe("Task ID Generation Bug Reproduction", () => {
   it("should show that getNextTaskId handles qualified IDs correctly", () => {
     // Mix of qualified and unqualified IDs (real-world scenario)
     const mixedTasks: TaskData[] = [
-      { id: "md#300", title: "Task 300", description: "", status: TaskStatus.TODO, specPath: "" },
+      { id: "md#300", title: "Task 300", spec: "", status: TaskStatus.TODO, specPath: "" },
       {
         id: "gh#45",
         title: "GitHub Task 45",
-        description: "",
+        spec: "",
         status: TaskStatus.TODO,
         specPath: "",
       },
       {
         id: "md#371",
         title: "Qualified Task 371",
-        description: "",
+        spec: "",
         status: TaskStatus.TODO,
         specPath: "",
       },

--- a/src/domain/tasks-core-functions.test.ts
+++ b/src/domain/tasks-core-functions.test.ts
@@ -40,7 +40,7 @@ const mockTask: Task = {
   id: `md#${TEST_VALUE}`,
   title: "Test Task",
   status: TASK_STATUS.TODO,
-  description: "This is a test task",
+  spec: "This is a test task",
 };
 
 describe("interface-agnostic task functions", () => {

--- a/src/domain/tasks/backend-filtering-regression.test.ts
+++ b/src/domain/tasks/backend-filtering-regression.test.ts
@@ -17,36 +17,31 @@ describe("Backend CLOSED task filtering regression test", () => {
   beforeEach(() => {
     // Test data with mixed statuses including CLOSED tasks
     mockTasks = [
-      { id: "test#001", title: "Todo Task", status: TASK_STATUS.TODO, description: "A todo task" },
+      { id: "test#001", title: "Todo Task", status: TASK_STATUS.TODO },
       {
         id: "test#002",
         title: "In Progress Task",
         status: TASK_STATUS.IN_PROGRESS,
-        description: "An in-progress task",
       },
       {
         id: "test#003",
         title: "Done Task",
         status: TASK_STATUS.DONE,
-        description: "A completed task",
       },
       {
         id: "test#004",
         title: "Closed Task",
         status: TASK_STATUS.CLOSED,
-        description: "A closed task",
       },
       {
         id: "test#005",
         title: "Blocked Task",
         status: TASK_STATUS.BLOCKED,
-        description: "A blocked task",
       },
       {
         id: "test#006",
         title: "Another Done Task",
         status: TASK_STATUS.DONE,
-        description: "Another completed task",
       },
     ];
   });

--- a/src/domain/tasks/github-issues-api.ts
+++ b/src/domain/tasks/github-issues-api.ts
@@ -244,7 +244,7 @@ export async function createIssueFromSpec(
     owner,
     repo,
     title: spec.title,
-    body: spec.description || "",
+    body: spec.body || "",
     labels: [...getLabelsForTaskStatus("TODO", statusLabels), ...(tags || [])],
   });
 
@@ -255,7 +255,7 @@ export async function createIssueFromSpec(
     title: spec.title,
     status: "TODO",
     specPath,
-    description: spec.description || "",
+    spec: spec.body || "",
   };
 }
 
@@ -291,7 +291,7 @@ export async function createIssueFromTitleAndDescription(
     id: taskId,
     title,
     status: "TODO",
-    description,
+    spec: description,
   };
 }
 
@@ -327,8 +327,7 @@ export async function createIssueFromTitleAndSpec(
     id: taskId,
     title,
     status: "TODO",
-    description: spec,
-    specPath: undefined,
+    spec: spec,
   };
 }
 

--- a/src/domain/tasks/github-issues-mapping.ts
+++ b/src/domain/tasks/github-issues-mapping.ts
@@ -85,7 +85,7 @@ export function parseGitHubTaskSpec(content: string): TaskSpecData {
 
   return {
     title,
-    description: descriptionLines.join("\n"),
+    body: descriptionLines.join("\n"),
     metadata,
   };
 }
@@ -94,12 +94,12 @@ export function parseGitHubTaskSpec(content: string): TaskSpecData {
  * Format a TaskSpecData object into markdown content.
  */
 export function formatGitHubTaskSpec(spec: TaskSpecData): string {
-  const { title, description, metadata } = spec;
+  const { title, body, metadata } = spec;
 
   let content = `# Task ${metadata?.taskId || "#000"}: ${title}\n\n`;
 
-  if (description) {
-    content += `## Description\n${description}\n\n`;
+  if (body) {
+    content += `## Description\n${body}\n\n`;
   }
 
   if (metadata?.githubIssue) {
@@ -133,7 +133,7 @@ export function convertIssueToTaskData(
   return {
     id: taskId,
     title: issue.title,
-    description: issue.body || "",
+    spec: issue.body || "",
     status,
     specPath: getTaskSpecPath(taskId, issue.title),
     tags,
@@ -149,7 +149,7 @@ export function convertTaskDataToIssueFormat(
 ): Record<string, unknown> {
   return {
     title: task.title,
-    body: task.description,
+    body: task.spec || "",
     labels: getLabelsForTaskStatus(task.status, statusLabels),
     state: task.status === "DONE" ? "closed" : "open",
   };

--- a/src/domain/tasks/githubIssuesTaskBackend.test.ts
+++ b/src/domain/tasks/githubIssuesTaskBackend.test.ts
@@ -108,7 +108,7 @@ describe("GitHubIssuesTaskBackend", () => {
       expect(tasks.length).toBe(1);
       expect(tasks[0]?.id).toBe("gh#001");
       expect(tasks[0]?.title).toBe("Test Issue #001");
-      expect(tasks[0]?.description).toBe("Test description");
+      expect(tasks[0]?.spec).toBe("Test description");
       expect(tasks[0]?.status).toBe(TaskStatus.TODO);
     });
 
@@ -164,7 +164,7 @@ describe("GitHubIssuesTaskBackend", () => {
         {
           id: "#001",
           title: "Test Task",
-          description: "Test description",
+          spec: "Test description",
           status: TaskStatus.TODO,
           specPath: PATH_TEST_PATTERNS.TASK_MD_001,
         },
@@ -195,7 +195,7 @@ This is a test task description.
       const spec = backend.parseTaskSpec(specContent);
 
       expect(spec.title).toBe("Test Task");
-      expect(spec.description).toBe("This is a test task description.");
+      expect(spec.body).toBe("This is a test task description.");
       expect(spec.metadata?.taskId).toBe("#001");
     });
   });
@@ -204,7 +204,7 @@ This is a test task description.
     test("should format task specification data", () => {
       const spec = {
         title: "Test Task",
-        description: "Test description",
+        body: "Test description",
         metadata: {
           taskId: "001",
           githubIssue: {

--- a/src/domain/tasks/githubIssuesTaskBackend.ts
+++ b/src/domain/tasks/githubIssuesTaskBackend.ts
@@ -231,7 +231,7 @@ export class GitHubIssuesTaskBackend implements TaskBackend {
         title: taskData.title,
         status: taskData.status,
         specPath: taskData.specPath,
-        description: taskData.description,
+        spec: taskData.spec,
         tags: taskData.tags || [],
       }));
 

--- a/src/domain/tasks/mock-backend-factory.ts
+++ b/src/domain/tasks/mock-backend-factory.ts
@@ -37,7 +37,7 @@ function bridgeToTaskBackend(backend: MultiBackendTaskBackend): TaskBackend {
       const mockSpec: TaskSpec = {
         id: options?.id ?? `mock-${Date.now()}`,
         title,
-        description: spec,
+        spec,
         status: options?.status ?? "TODO",
       };
       return backend.createTask(mockSpec);
@@ -65,7 +65,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         id: `${prefix}#mock-${Math.random().toString(36).substr(2, 9)}`,
         title: spec.title,
         status: spec.status || "TODO",
-        spec: spec.description,
+        spec: spec.spec,
         metadata: {},
       };
     }),
@@ -124,7 +124,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         spec: {
           id: taskId,
           title: `Exported Task ${taskId}`,
-          description: `Task exported from ${name} backend`,
+          spec: `Task exported from ${name} backend`,
           status: "TODO",
         },
         metadata: {
@@ -142,7 +142,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         id: `${prefix}#${importedId}`,
         title: data.spec.title,
         status: data.spec.status || "TODO",
-        spec: data.spec.description,
+        spec: data.spec.spec,
         metadata: {
           ...data.metadata,
           importedAt: new Date().toISOString(),
@@ -191,21 +191,21 @@ export const mockTaskSpecs = {
   simple: (): TaskSpec => ({
     id: "simple-test-task",
     title: "Simple Test Task",
-    description: "A simple task for testing",
+    spec: "A simple task for testing",
     status: "TODO",
   }),
 
   complex: (): TaskSpec => ({
     id: "complex-test-task",
     title: "Complex Test Task",
-    description: "A complex task with metadata",
+    spec: "A complex task with metadata",
     status: "IN_PROGRESS",
   }),
 
   minimal: (): TaskSpec => ({
     id: "minimal-task",
     title: "Minimal Task",
-    description: "",
+    spec: "",
     status: "TODO",
   }),
 };

--- a/src/domain/tasks/mock-backend-factory.ts
+++ b/src/domain/tasks/mock-backend-factory.ts
@@ -65,7 +65,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         id: `${prefix}#mock-${Math.random().toString(36).substr(2, 9)}`,
         title: spec.title,
         status: spec.status || "TODO",
-        description: spec.description,
+        spec: spec.description,
         metadata: {},
       };
     }),
@@ -84,7 +84,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         id: `${prefix}#${taskId}`,
         title: updates.title || `Updated Mock Task`,
         status: updates.status || "TODO",
-        description: updates.description,
+        spec: updates.spec,
         metadata: updates.metadata || {},
       };
     }),
@@ -142,7 +142,7 @@ export function createMockBackend(name: string, prefix: string): MultiBackendTas
         id: `${prefix}#${importedId}`,
         title: data.spec.title,
         status: data.spec.status || "TODO",
-        description: data.spec.description,
+        spec: data.spec.description,
         metadata: {
           ...data.metadata,
           importedAt: new Date().toISOString(),

--- a/src/domain/tasks/multi-backend-service.ts
+++ b/src/domain/tasks/multi-backend-service.ts
@@ -29,7 +29,7 @@ export interface MultiBackendTaskBackend {
 export interface TaskSpec {
   id: string;
   title: string;
-  description: string;
+  spec: string;
   status: string;
 }
 

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -275,8 +275,8 @@ export class TaskSimilarityService {
       log.debug(
         `Failed to get spec content for task ${task.id}: ${error instanceof Error ? error.message : String(error)}`
       );
-      if (task.description) {
-        parts.push(task.description);
+      if (task.spec) {
+        parts.push(task.spec);
       }
     }
 

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -42,7 +42,7 @@ import {
   taskStatusGetParamsSchema,
   taskStatusSetParamsSchema,
   taskCreateParamsSchema,
-  taskCreateFromTitleAndDescriptionParamsSchema,
+  taskCreateFromTitleAndSpecParamsSchema,
   taskSpecContentParamsSchema,
   taskDeleteParamsSchema,
   type TaskListParams,
@@ -50,7 +50,7 @@ import {
   type TaskStatusGetParams,
   type TaskStatusSetParams,
   type TaskCreateParams,
-  type TaskCreateFromTitleAndDescriptionParams,
+  type TaskCreateFromTitleAndSpecParams,
   type TaskSpecContentParams,
   type TaskDeleteParams,
 } from "../../schemas/tasks";
@@ -460,7 +460,7 @@ export async function createTaskFromParams(
  * (exported for tests that import from ./tasks/taskCommands)
  */
 export async function createTaskFromTitleAndSpec(
-  params: TaskCreateFromTitleAndDescriptionParams,
+  params: TaskCreateFromTitleAndSpecParams,
   deps?: {
     resolveRepoPath?: typeof resolveRepoPath;
     createConfiguredTaskService?: (options: TaskServiceOptions) => Promise<TaskServiceInterface>;
@@ -468,7 +468,7 @@ export async function createTaskFromTitleAndSpec(
   }
 ): Promise<Task> {
   // Validate params
-  const validParams = taskCreateFromTitleAndDescriptionParamsSchema.parse(params);
+  const validParams = taskCreateFromTitleAndSpecParamsSchema.parse(params);
 
   // Resolve workspace path (prefer injected main path)
   const workspacePath =

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -383,9 +383,6 @@ export async function updateTaskFromParams(
     if (params.title !== undefined) {
       updates.title = params.title;
     }
-    if (params.spec !== undefined) {
-      updates.specPath = params.spec;
-    }
 
     // Update the task
     const updatedTask = await taskService.updateTask?.(qualifiedTaskId, updates);
@@ -459,10 +456,10 @@ export async function createTaskFromParams(
 }
 
 /**
- * Create a task from title and description
+ * Create a task from title and spec
  * (exported for tests that import from ./tasks/taskCommands)
  */
-export async function createTaskFromTitleAndDescription(
+export async function createTaskFromTitleAndSpec(
   params: TaskCreateFromTitleAndDescriptionParams,
   deps?: {
     resolveRepoPath?: typeof resolveRepoPath;

--- a/src/domain/tasks/taskFunctions.test.ts
+++ b/src/domain/tasks/taskFunctions.test.ts
@@ -59,7 +59,7 @@ describe("Task Functions", () => {
       expect(task0.id).toBe("#001");
       expect(task0.title).toBe("First task");
       expect(task0.status).toBe(TaskStatus.TODO);
-      expect(task0.description).toBe("Description line 1\nDescription line 2");
+      expect(task0.spec).toBe("Description line 1\nDescription line 2");
 
       const task1 = elementAt(tasks, 1);
       expect(task1.id).toBe("#002");
@@ -100,7 +100,7 @@ Code block with task-like content:
           id: "#001",
           title: "First task",
           status: TaskStatus.TODO,
-          description: "Description line 1\nDescription line 2",
+          spec: "Description line 1\nDescription line 2",
         },
         {
           id: "#002",
@@ -350,7 +350,7 @@ This is a test description.
 
       const spec = parseTaskSpecFromMarkdown(markdown);
       expect(spec.title).toBe("Task #TEST_VALUE: Test Task Title");
-      expect(spec.description).toBe(TEST_DATA_PATTERNS.TEST_DESCRIPTION);
+      expect(spec.body).toBe(TEST_DATA_PATTERNS.TEST_DESCRIPTION);
       // The function doesn't extract IDs from titles, so don't expect one
       expect(spec.id).toBeUndefined();
     });
@@ -365,7 +365,7 @@ ${RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER}
 
       const spec = parseTaskSpecFromMarkdown(markdown);
       expect(spec.title).toBe("No ID Task");
-      expect(spec.description).toBe(RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER);
+      expect(spec.body).toBe(RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER);
       expect(spec.id).toBeUndefined();
     });
 
@@ -379,17 +379,17 @@ ${RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER}
 
       const spec = parseTaskSpecFromMarkdown(markdown);
       expect(spec.title).toBe("Just a general title");
-      expect(spec.description).toBe(RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER);
+      expect(spec.body).toBe(RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER);
     });
 
     test("should return empty values for invalid input", () => {
       expect(parseTaskSpecFromMarkdown("")).toEqual({
         title: "",
-        description: "",
+        body: "",
       });
       expect(parseTaskSpecFromMarkdown("No headers")).toEqual({
         title: "",
-        description: "",
+        body: "",
       });
     });
   });
@@ -398,7 +398,7 @@ ${RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER}
     test("should format task spec to markdown with ID", () => {
       const spec = {
         title: "Test Task",
-        description: TEST_DATA_PATTERNS.TEST_DESCRIPTION,
+        body: TEST_DATA_PATTERNS.TEST_DESCRIPTION,
         id: "#TEST_VALUE",
       };
 
@@ -410,7 +410,7 @@ ${RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER}
     test("should format task spec without ID", () => {
       const spec = {
         title: "Test Task Without ID",
-        description: RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER,
+        body: RULES_TEST_PATTERNS.DESCRIPTION_PLACEHOLDER,
       };
 
       const markdown = formatTaskSpecToMarkdown(spec);

--- a/src/domain/tasks/taskFunctions.ts
+++ b/src/domain/tasks/taskFunctions.ts
@@ -63,7 +63,7 @@ export function parseTasksFromMarkdown(content: string): TaskData[] {
       id: id,
       title,
       status,
-      description: description.trim(),
+      spec: description.trim(),
     });
   }
 
@@ -301,7 +301,7 @@ export function filterTasks(tasks: TaskData[], filter?: TaskFilter): TaskData[] 
  */
 export function parseTaskSpecFromMarkdown(content: string): TaskSpecData {
   if (!content) {
-    return { title: "", description: "" };
+    return { title: "", body: "" };
   }
 
   const lines = content.toString().split("\n");
@@ -309,7 +309,7 @@ export function parseTaskSpecFromMarkdown(content: string): TaskSpecData {
   // Extract title from the first heading
   const titleLine = lines.find((line) => line.startsWith("# "));
   if (!titleLine) {
-    return { title: "", description: "" };
+    return { title: "", body: "" };
   }
 
   // Title is the text after the leading "# ", normalize legacy "Task: X" to just "X"
@@ -317,21 +317,21 @@ export function parseTaskSpecFromMarkdown(content: string): TaskSpecData {
   const noIdLegacyMatch = rawTitle.match(/^Task:\s*(.+)$/);
   const title = noIdLegacyMatch ? noIdLegacyMatch[1] || rawTitle : rawTitle;
 
-  // Extract description from the Context section
+  // Extract body from the Context section
   const contextIndex = lines.findIndex((line) => line.trim() === "## Context");
-  let description = "";
+  let body = "";
 
   if (contextIndex !== -1) {
     for (let i = contextIndex + 1; i < lines.length; i++) {
       const line = lines[i] || "";
       if (line.trim().startsWith("## ")) break;
-      if (line.trim()) description += `${line.trim()}\n`;
+      if (line.trim()) body += `${line.trim()}\n`;
     }
   }
 
   return {
     title,
-    description: description.trim(),
+    body: body.trim(),
   };
 }
 
@@ -349,7 +349,7 @@ export function formatTaskSpecToMarkdown(spec: TaskSpecData): string {
   const contextSection = `
 ## Context
 
-${spec.description}
+${spec.body}
 
 ## Requirements
 

--- a/src/domain/tasks/types.ts
+++ b/src/domain/tasks/types.ts
@@ -57,7 +57,6 @@ export interface Task {
   backend?: string;
   /** Parent task ID if this is a subtask (populated from task graph, not stored in backend) */
   parentTaskId?: string;
-  description?: string;
   metadata?: Record<string, unknown>;
   spec?: string;
   tags?: string[];
@@ -114,7 +113,6 @@ export interface TaskListOptions {
 export interface CreateTaskOptions {
   force?: boolean;
   spec?: string; // This is the spec content for creation
-  description?: string; // Alternative to spec for description-based creation
   id?: string; // Specific ID to use instead of generating one
   status?: string; // Specific status to use instead of defaulting to TODO
   tags?: string[]; // Tags/labels for thematic batching

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -116,7 +116,10 @@ export const taskCreateParamsSchema = z
   .object({
     title: z.string().min(1).describe("Title for the task"),
     spec: z.string().optional().describe("Spec text for the task"),
-    description: z.string().optional().describe("Description text for the task (alias for spec)"),
+    description: z
+      .string()
+      .optional()
+      .describe("Description text for the task (DEPRECATED: use spec instead)"),
     specPath: z.string().optional().describe("Path to file containing task spec"),
     force: flagSchema("Force creation even if task already exists"),
     backend: z
@@ -135,11 +138,11 @@ export const taskCreateParamsSchema = z
   .merge(commonCommandOptionsSchema)
   .refine(
     (data) => {
-      // Either spec/description or specPath must be provided
+      // Either spec or specPath must be provided (description is deprecated alias for spec)
       return data.spec || data.description || data.specPath;
     },
     {
-      message: "Either --description or --spec-path must be provided",
+      message: "Either --spec or --spec-path must be provided",
     }
   );
 
@@ -177,8 +180,8 @@ export const taskCreateFromTitleAndDescriptionParamsSchema = z
   })
   .merge(commonCommandOptionsSchema)
   .refine((data) => data.spec || data.specPath, {
-    message: "Either 'description' or 'descriptionPath' must be provided",
-    path: ["description"],
+    message: "Either 'spec' or 'specPath' must be provided",
+    path: ["spec"],
   });
 
 /**

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -152,16 +152,16 @@ export const taskCreateParamsSchema = z
 export type TaskCreateParams = z.infer<typeof taskCreateParamsSchema>;
 
 /**
- * Type for task create from title and description parameters
+ * Type for task create from title and spec parameters
  */
-export type TaskCreateFromTitleAndDescriptionParams = z.infer<
-  typeof taskCreateFromTitleAndDescriptionParamsSchema
+export type TaskCreateFromTitleAndSpecParams = z.infer<
+  typeof taskCreateFromTitleAndSpecParamsSchema
 >;
 
 /**
- * Schema for task create from title and description parameters
+ * Schema for task create from title and spec parameters
  */
-export const taskCreateFromTitleAndDescriptionParamsSchema = z
+export const taskCreateFromTitleAndSpecParamsSchema = z
   .object({
     title: z.string().min(1).describe("Title for the task (required)"),
     spec: z.string().optional().describe("Spec text for the task"),

--- a/src/types/tasks/taskData.ts
+++ b/src/types/tasks/taskData.ts
@@ -22,7 +22,6 @@ export interface TaskData {
   /** Task ID in storage format (plain number string, e.g., "283") */
   id: string;
   title: string;
-  description?: string;
   spec?: string;
   status: TaskStatus;
   specPath?: string;
@@ -65,7 +64,7 @@ export interface TaskFilter {
  */
 export interface TaskSpecData {
   title: string;
-  description: string;
+  body: string;
   id?: string;
   metadata?: Record<string, unknown>;
 }
@@ -116,7 +115,7 @@ export function toTaskData(task: Record<string, unknown>): TaskData {
   return {
     id: task["id"] as string,
     title: task["title"] as string,
-    description: task["description"] as string | undefined,
+    spec: task["spec"] as string | undefined,
     status: task["status"] as TaskData["status"],
     specPath: task["specPath"] as string | undefined,
     worklog: task["worklog"] as TaskData["worklog"],
@@ -133,7 +132,7 @@ export function fromTaskData(taskData: TaskData): Record<string, unknown> {
   return {
     id: taskData!.id,
     title: taskData!.title,
-    description: taskData!.description,
+    spec: taskData!.spec,
     status: taskData!.status,
     specPath: taskData!.specPath,
     worklog: taskData!.worklog,

--- a/src/utils/test-utils/factories.ts
+++ b/src/utils/test-utils/factories.ts
@@ -16,7 +16,7 @@ export function createTaskData(overrides: Partial<TaskData> = {}): TaskData {
     id: defaultId,
     title: "Test Task",
     status: TaskStatus.TODO,
-    description: "This is a test task",
+    spec: "This is a test task",
     worklog: [
       {
         timestamp: new Date().toISOString(),

--- a/tests/integration/github-issues-backend.integration.test.ts
+++ b/tests/integration/github-issues-backend.integration.test.ts
@@ -133,8 +133,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
       test("should create a new GitHub issue from task spec", async () => {
         const taskSpec = {
           title: `${INTEGRATION_CONFIG.testPrefix} Test Task Creation`,
-          description:
-            "This is a test task created by integration tests.\n\nIt should be automatically cleaned up.",
+          spec: "This is a test task created by integration tests.\n\nIt should be automatically cleaned up.",
           status: "TODO" as TaskStatus,
         };
 
@@ -143,7 +142,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         expect(task).toBeDefined();
         expect(task.id).toBeTruthy();
         expect(task.title).toBe(taskSpec.title);
-        expect(task.spec).toBe(taskSpec.description);
+        expect(task.spec).toBe(taskSpec.spec);
         expect(task.status).toBe("TODO");
 
         // Verify issue was created in GitHub
@@ -157,7 +156,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         });
 
         expect(issue.title).toBe(taskSpec.title);
-        expect(issue.body).toBe(taskSpec.description);
+        expect(issue.body).toBe(taskSpec.spec);
         expect(issue.state).toBe("open");
 
         // Verify Minsky labels are applied
@@ -259,7 +258,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         // Create a test task first
         const taskSpec = {
           title: `${INTEGRATION_CONFIG.testPrefix} Fetch Test`,
-          description: "Testing task retrieval",
+          spec: "Testing task retrieval",
           status: "TODO" as TaskStatus,
         };
 
@@ -276,7 +275,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         const testTask = tasks.find((task) => task.id === createdTask.id);
         expect(testTask).toBeDefined();
         expect(testTask?.title).toBe(taskSpec.title);
-        expect(testTask?.spec).toBe(taskSpec.description);
+        expect(testTask?.spec).toBe(taskSpec.spec);
       });
 
       test("should get individual task by ID", async () => {

--- a/tests/integration/github-issues-backend.integration.test.ts
+++ b/tests/integration/github-issues-backend.integration.test.ts
@@ -143,7 +143,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         expect(task).toBeDefined();
         expect(task.id).toBeTruthy();
         expect(task.title).toBe(taskSpec.title);
-        expect(task.description).toBe(taskSpec.description);
+        expect(task.spec).toBe(taskSpec.description);
         expect(task.status).toBe("TODO");
 
         // Verify issue was created in GitHub
@@ -276,7 +276,7 @@ describe.if(!!(process.env.RUN_INTEGRATION_TESTS && INTEGRATION_CONFIG.token))(
         const testTask = tasks.find((task) => task.id === createdTask.id);
         expect(testTask).toBeDefined();
         expect(testTask?.title).toBe(taskSpec.title);
-        expect(testTask?.description).toBe(taskSpec.description);
+        expect(testTask?.spec).toBe(taskSpec.description);
       });
 
       test("should get individual task by ID", async () => {


### PR DESCRIPTION
## Summary

Unifies the task system's dual `description`/`spec` naming to use `spec` everywhere (Part A + C of mt#778). Also fixes two bugs.

### Changes

- **Type layer:** Remove `description` from `Task`, `TaskData`, `CreateTaskOptions` — `spec` is the single field
- **TaskSpecData:** Rename `.description` → `.body` (the parsed spec body content)
- **TaskSpec:** Rename `.description` → `.spec` in `multi-backend-service.ts`
- **Schemas:** `TaskDescriptionSchema` → `TaskSpecContentSchema`, `TaskDescriptionPathSchema` → `TaskSpecPathSchema`
- **Functions:** `createTaskFromTitleAndDescription` → `createTaskFromTitleAndSpec`
- **Adapter layer:** `crud-commands.ts` resolves `params.spec || params.description` (deprecated alias support)
- **CLI:** `--description` retained as deprecated alias with deprecation notice
- **Bug fix:** Remove erroneous `updates.specPath = params.spec` in `updateTaskFromParams`
- **Bug fix:** Error message corrected from `'description'/'descriptionPath'` → `'spec'/'specPath'`

### Files changed (32)

**Types/schemas** (7): taskData.ts, types.ts, schemas/tasks.ts, domain/schemas/task-schemas.ts, domain/schemas/index.ts, adapters/mcp/schemas/task-parameters.ts, common-parameters.ts

**Domain** (8): taskCommands.ts, taskFunctions.ts, github-issues-mapping.ts, github-issues-api.ts, githubIssuesTaskBackend.ts, task-similarity-service.ts, mock-backend-factory.ts, multi-backend-service.ts

**Adapters** (5): crud-commands.ts, base-task-command.ts, similarity-commands.ts, task-parameters.ts, task-context.ts

**Context** (3): types.ts, generate.ts, generate-comparison.ts, generate-types.ts

**Tests** (9): taskFunctions.test.ts, githubIssuesTaskBackend.test.ts, taskCommands.test.ts, tasks-core-functions.test.ts, session-start-task-id-bug.test.ts, backend-filtering-regression.test.ts, factories.ts, github-issues-backend.integration.test.ts

## Test plan

- [x] TypeScript compiles with zero errors
- [x] All `description` references removed from task types/interfaces (grep verified)
- [x] Deprecated `--description` alias retained in CLI schema
- [x] Both bug fixes verified (specPath assignment, error messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)