### PR TITLE
chore(mt#768): add package.json description and keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,20 @@
 {
   "name": "minsky",
+  "description": "A development workflow orchestration platform that creates collaborative environments for both human and AI developers through organizational cybernetic principles.",
+  "keywords": [
+    "minsky",
+    "workflow",
+    "orchestration",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "developer-tools",
+    "cybernetics",
+    "task-management",
+    "session",
+    "git",
+    "cli"
+  ],
   "module": "src/cli.ts",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Added `description` field to package.json matching the README tagline
- Added `keywords` array with 12 relevant terms for discoverability
- Checked for README-MCP.md — does not exist; README.md has only brief MCP mentions

## Test plan

- [ ] `node -e "console.log(require('./package.json').description)"` outputs non-empty string
- [ ] `node -e "console.log(require('./package.json').keywords.length)"` outputs 12

Part of the legibility campaign (mt#763-773). Addresses Gap 3: No Public Description Field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)