### PR TITLE
fix(mt#756): Use stored branch name for remote branch cleanup in session_delete

### DIFF
--- a/src/domain/session/session-lifecycle-operations.ts
+++ b/src/domain/session/session-lifecycle-operations.ts
@@ -132,9 +132,11 @@ export async function deleteSessionImpl(
 
   // Delete the remote git branch if a git service is available
   if (deps.gitService && sessionRecord) {
-    const branchName = sessionRecord.taskId
-      ? taskIdToBranchName(sessionRecord.taskId)
-      : resolvedSessionId;
+    // Prefer the stored branch name (persisted since mt#782), fall back to
+    // computing from taskId for sessions created before that change.
+    const branchName =
+      sessionRecord.branch ||
+      (sessionRecord.taskId ? taskIdToBranchName(sessionRecord.taskId) : resolvedSessionId);
 
     if (existsSync(sessionWorkspaceDir)) {
       try {


### PR DESCRIPTION
## Summary

- `session_delete` already had remote branch deletion logic, but it computed the branch name from `taskId` using `taskIdToBranchName()` instead of reading the stored value
- Now prefers `sessionRecord.branch` (persisted since mt#782 / PR #443), with fallback to the computed value for sessions created before that change
- This ensures explicit `--branch` overrides and any future branch naming changes are respected during cleanup

## Context

Prerequisite PR #443 (mt#782) ensured branch names are always stored in session records at creation time. This PR completes mt#756 by making `session_delete` use that stored value.

## Test plan

- [x] TypeScript compiles cleanly
- [ ] CI build + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)