### PR TITLE
fix(mt#789): Preserve DB record when session filesystem deletion fails

### DIFF
--- a/src/domain/session/session-delete-fs-failure.test.ts
+++ b/src/domain/session/session-delete-fs-failure.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for filesystem failure handling in deleteSessionImpl.
+ *
+ * Verifies that when filesystem removal fails during session deletion,
+ * the DB record is preserved to prevent orphan directories (mt#789).
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { deleteSessionImpl } from "./session-lifecycle-operations";
+import type { SessionRecord } from "./types";
+
+/** Minimal in-memory session provider sufficient for deleteSessionImpl. */
+function makeSessionDB(sessions: SessionRecord[]) {
+  const store = new Map(sessions.map((s) => [s.session, s]));
+  return {
+    getSession: mock(async (id: string) => store.get(id) ?? null),
+    getSessionByTaskId: mock(async () => null),
+    listSessions: mock(async () => Array.from(store.values())),
+    addSession: mock(async () => {}),
+    updateSession: mock(async () => {}),
+    deleteSession: mock(async (id: string) => {
+      const existed = store.has(id);
+      store.delete(id);
+      return existed;
+    }),
+    getRepoPath: mock(async () => "/mock/repo"),
+    getSessionWorkdir: mock(async (id: string) => `/mock/sessions/${id}`),
+  };
+}
+
+describe("deleteSessionImpl — filesystem failure preserves DB record (mt#789)", () => {
+  const SESSION_ID = "test-session-fs-fail";
+
+  let sessionRecord: SessionRecord;
+
+  beforeEach(() => {
+    sessionRecord = {
+      session: SESSION_ID,
+      repoUrl: "https://github.com/edobry/minsky.git",
+      repoName: "minsky",
+      taskId: "mt#789",
+      createdAt: new Date().toISOString(),
+    };
+  });
+
+  it("preserves DB record when rmSync throws", async () => {
+    const sessionDB = makeSessionDB([sessionRecord]);
+
+    const result = await deleteSessionImpl(
+      { name: SESSION_ID, force: false },
+      {
+        sessionDB,
+        fs: {
+          existsSync: () => true,
+          rmSync: () => {
+            throw new Error("EPERM: operation not permitted");
+          },
+        },
+      }
+    );
+
+    // Session should NOT be deleted
+    expect(result.deleted).toBe(false);
+    expect(result.error).toContain("DB record preserved");
+
+    // DB record should still exist
+    const record = await sessionDB.getSession(SESSION_ID);
+    expect(record).not.toBeNull();
+    expect(record!.session).toBe(SESSION_ID);
+
+    // deleteSession should NOT have been called
+    expect(sessionDB.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("still deletes DB record when directory does not exist", async () => {
+    const sessionDB = makeSessionDB([sessionRecord]);
+
+    const result = await deleteSessionImpl(
+      { name: SESSION_ID, force: false },
+      {
+        sessionDB,
+        fs: {
+          existsSync: () => false,
+          rmSync: () => {
+            throw new Error("should not be called");
+          },
+        },
+      }
+    );
+
+    // Session should be deleted (directory didn't exist, so no fs error)
+    expect(result.deleted).toBe(true);
+
+    // DB record should be gone
+    const record = await sessionDB.getSession(SESSION_ID);
+    expect(record).toBeNull();
+  });
+
+  it("deletes both directory and DB record on success", async () => {
+    const sessionDB = makeSessionDB([sessionRecord]);
+    const rmSyncMock = mock(() => {});
+
+    const result = await deleteSessionImpl(
+      { name: SESSION_ID, force: false },
+      {
+        sessionDB,
+        fs: {
+          existsSync: () => true,
+          rmSync: rmSyncMock,
+        },
+      }
+    );
+
+    expect(result.deleted).toBe(true);
+    expect(rmSyncMock).toHaveBeenCalled();
+
+    // DB record should be gone
+    const record = await sessionDB.getSession(SESSION_ID);
+    expect(record).toBeNull();
+  });
+});

--- a/src/domain/session/session-lifecycle-operations.ts
+++ b/src/domain/session/session-lifecycle-operations.ts
@@ -86,9 +86,11 @@ export async function deleteSessionImpl(
   deps: {
     sessionDB: SessionProviderInterface;
     gitService?: GitServiceInterface;
+    fs?: { existsSync: typeof existsSync; rmSync: typeof rmSync };
   }
 ): Promise<DeleteSessionResult> {
   const { name, task, repo } = params;
+  const fsOps = deps.fs ?? { existsSync, rmSync };
 
   // Delete is destructive — require explicit identification, never auto-detect
   if (!name && !task && !repo) {
@@ -138,7 +140,7 @@ export async function deleteSessionImpl(
       sessionRecord.branch ||
       (sessionRecord.taskId ? taskIdToBranchName(sessionRecord.taskId) : resolvedSessionId);
 
-    if (existsSync(sessionWorkspaceDir)) {
+    if (fsOps.existsSync(sessionWorkspaceDir)) {
       try {
         log.debug(`Deleting remote branch '${branchName}' for session '${resolvedSessionId}'`);
         await deps.gitService.execInRepository(
@@ -163,18 +165,22 @@ export async function deleteSessionImpl(
 
   // Remove workspace directory from filesystem (if it exists)
   try {
-    if (existsSync(sessionWorkspaceDir)) {
+    if (fsOps.existsSync(sessionWorkspaceDir)) {
       log.debug(`Removing session workspace directory: ${sessionWorkspaceDir}`);
-      rmSync(sessionWorkspaceDir, { recursive: true, force: true });
+      fsOps.rmSync(sessionWorkspaceDir, { recursive: true, force: true });
       log.debug(`Successfully removed session workspace directory: ${sessionWorkspaceDir}`);
     } else {
       log.debug(`Session workspace directory does not exist, skipping: ${sessionWorkspaceDir}`);
     }
   } catch (error) {
-    // Filesystem removal failure is non-fatal — log but continue with DB deletion
-    log.warn(
-      `Failed to remove session workspace directory '${sessionWorkspaceDir}': ${getErrorMessage(error)}`
-    );
+    // Filesystem removal failed — do NOT delete the DB record, as that would
+    // create an orphan directory with no tracking. Surface the error to the caller.
+    const msg = `Failed to remove session workspace directory '${sessionWorkspaceDir}': ${getErrorMessage(error)}`;
+    log.error(msg);
+    return {
+      deleted: false,
+      error: `${msg}. DB record preserved to prevent orphan directory.`,
+    };
   }
 
   // Delete the session record from the database
@@ -325,9 +331,10 @@ export async function cleanupSessionImpl(
       }
     }
 
-    // 5. Remove session from database
+    // 5. Remove session from database — only if all directory removals succeeded.
+    // If any directory removal failed, preserving the DB record prevents orphan directories.
     let sessionDeleted = false;
-    if (sessionRecord) {
+    if (sessionRecord && errors.length === 0) {
       try {
         sessionDeleted = await deps.sessionDB.deleteSession(sessionId);
         if (sessionDeleted) {
@@ -340,6 +347,10 @@ export async function cleanupSessionImpl(
         log.error(errorMsg, { sessionId, error });
         errors.push(errorMsg);
       }
+    } else if (errors.length > 0) {
+      log.warn(
+        `Skipping DB record deletion for session ${sessionId} — filesystem cleanup had errors. DB record preserved to prevent orphan directories.`
+      );
     }
 
     log.debug("Session cleanup completed", {


### PR DESCRIPTION
## Summary

- Fix delete asymmetry: `deleteSessionImpl` now preserves the DB record when `rmSync` throws, preventing orphan directories
- Fix `cleanupSessionImpl` with the same pattern: skip DB deletion when directory removal has errors
- Add `fs` as injectable deps for testability (DI pattern, no `mock.module`)
- Add 3 regression tests covering: fs failure preserves record, missing dir still deletes, successful case removes both

**Root cause:** During the mt#723 session cleanup audit, we found 24 UUID session directories with no DB records. While most were caused by the mt#722 Postgres error-swallowing bug, the delete ordering asymmetry was a separate live bug that could still create new orphans.

## Test plan

- [x] 3 new tests pass: `session-delete-fs-failure.test.ts`
- [x] 7 existing tests pass: `session-delete-remote-branch.test.ts`
- [x] No behavioral change for the success path — only the failure path is fixed