### PR TITLE
fix(mt#687): replace delete-restart guidance with subtask workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,16 @@ Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID
 
 After a session's PR is merged, the session is **frozen** — write operations (`session_pr_create`, `session_pr_edit`, `session_commit`, `session_pr_approve`, `session_update`) will refuse. Read operations still work.
 
-To continue work on the same task with a new PR, delete the old session and start a fresh one:
+For multi-phase work, **use subtasks** — each phase gets its own task, session, and PR:
 
 ```
-mcp__minsky__session_delete (or `minsky session delete <session>`)
-mcp__minsky__session_start  (or `minsky session start --task <task>`)
+mcp__minsky__tasks_create (title: "Next phase", parent: "<parent-task-id>")
+mcp__minsky__session_start (task: "<new-subtask-id>")
 ```
 
-Reusing a session across multiple PRs would silently corrupt PR metadata. The freeze prevents this. Read mt#687 if you're tempted to make this less strict — there's a parked design question about whether the model should change.
+This preserves the 1:1 task↔session invariant while giving each phase its own identity, spec, and status tracking. The parent task tracks progress across subtasks.
+
+**Do NOT use the delete-restart pattern** (`session_delete` → `session_start` on the same task). That is an anti-pattern — it loses context, wastes time on re-cloning, and risks branch collisions. Subtasks are the correct decomposition.
 
 ### Parallel Task Planning
 

--- a/src/domain/session/session-mutability.test.ts
+++ b/src/domain/session/session-mutability.test.ts
@@ -46,9 +46,9 @@ describe("assertSessionMutable", () => {
     );
   });
 
-  test("includes recovery commands in the error message", () => {
+  test("includes subtask guidance in the error message", () => {
     expect(() => assertSessionMutable(mergedRecord(), "do a thing")).toThrow(
-      /minsky session delete test-session/
+      /create a subtask for the next phase/
     );
   });
 

--- a/src/domain/session/session-mutability.ts
+++ b/src/domain/session/session-mutability.ts
@@ -2,9 +2,8 @@
  * Session mutability invariants.
  *
  * Per the one-session-one-merge invariant: once a session's PR has been
- * merged, the session is frozen for write operations. Further work on the
- * same task requires a new session on a new branch. This module provides
- * the gate used by every write-path session operation.
+ * merged, the session is frozen for write operations. Further work should
+ * use subtasks — each phase gets its own task, session, and PR.
  */
 
 import { MinskyError } from "../../errors/index";
@@ -16,13 +15,15 @@ import type { SessionRecord } from "./types";
  */
 export function assertSessionMutable(session: SessionRecord, operation: string): void {
   if (session.prState?.mergedAt) {
+    const taskId = session.taskId ?? "<task-id>";
     throw new MinskyError(
       `Cannot ${operation}: session "${session.session}" has a merged PR ` +
         `(merged at ${session.prState.mergedAt}). Per the one-session-one-merge ` +
         `invariant, merged sessions are frozen for write operations.\n\n` +
-        `To continue work on this task, delete this session and start a fresh one:\n` +
-        `  minsky session delete ${session.session}\n` +
-        `  minsky session start --task ${session.taskId ?? "<task-id>"}`
+        `To continue work, create a subtask for the next phase:\n` +
+        `  minsky tasks create --parent ${taskId} --title "Next phase"\n` +
+        `  minsky session start --task <new-subtask-id>\n\n` +
+        `This gives each phase its own task ID, session, and PR.`
     );
   }
 }


### PR DESCRIPTION
## Summary

Now that subtask support is implemented (mt#238), replace all delete-restart guidance with the subtask workflow.

### Changes

- **`assertSessionMutable` error message**: No longer recommends `session delete` + `session start`. Instead recommends `tasks create --parent` + `session start` with the new subtask ID.
- **CLAUDE.md session lifecycle section**: Subtasks are the correct decomposition for multi-phase work. Delete-restart is explicitly called out as an anti-pattern.
- **Test**: Updated to match new error message (checks for "create a subtask" instead of "session delete").

## Spec verification

**Task:** mt#687

| Criterion | Status | Evidence |
|---|---|---|
| mt#237 Phase 1 implemented | Met | mt#238 merged (PR #436) |
| tasks_create accepts --parent | Met | mt#238 delivered this |
| Multi-phase workflows use subtasks | Met | CLAUDE.md updated with subtask guidance |
| Parent task status aggregates | Deferred | D6: manual for Phase 1, auto-aggregation is Phase 3 |
| CLAUDE.md updated | Met | Session lifecycle section rewritten |
| assertSessionMutable no longer recommends delete-restart | Met | Error message updated |
| Tripwire memory updated | Pending | Will update after merge |
| End-to-end demonstration | Met | mt#238 itself was verified end-to-end against live Supabase |

**Scope note:** Parent status aggregation (criterion 4) was explicitly deferred by design decision D6 in the mt#238 spec — manual status management for Phase 1, automatic propagation is Phase 3 (mt#240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)