### PR TITLE
refactor(mt#761): Add optional sessionProvider parameter to domain functions (Phase 3d of mt#761)

### DIFF
--- a/src/domain/context/components/session-context.ts
+++ b/src/domain/context/components/session-context.ts
@@ -7,6 +7,7 @@ import {
 // Reuse existing Minsky session utilities
 import { getCurrentSessionContext, isSessionWorkspace } from "../../workspace";
 import { getSharedSessionProvider } from "../../session/session-provider-cache";
+import type { SessionProviderInterface } from "../../session/index";
 
 interface SessionContextInputs {
   workspacePath: string;
@@ -46,7 +47,8 @@ export const SessionContextComponent: ContextComponent = {
 
       if (isInSession) {
         // Get current session context
-        const sessionDB = await getSharedSessionProvider();
+        const sessionDB: SessionProviderInterface =
+          context.sessionProvider ?? (await getSharedSessionProvider());
         const sessionContext = await getCurrentSessionContext(workspacePath, {
           sessionDbOverride: sessionDB,
         });
@@ -57,7 +59,8 @@ export const SessionContextComponent: ContextComponent = {
 
           // Get full session record with additional metadata
           try {
-            const sessionProvider = await getSharedSessionProvider();
+            const sessionProvider: SessionProviderInterface =
+              context.sessionProvider ?? (await getSharedSessionProvider());
             const fullSessionRecord = await sessionProvider.getSession(sessionId);
 
             if (fullSessionRecord) {

--- a/src/domain/context/components/types.ts
+++ b/src/domain/context/components/types.ts
@@ -16,6 +16,8 @@ export interface ComponentInput {
   filesInContext?: string[];
   // Optional rules service for testing isolation
   rulesService?: unknown;
+  // Optional session provider for DI (avoids reaching into shared singleton)
+  sessionProvider?: import("../../session/index").SessionProviderInterface;
   // ... other potential inputs
 }
 

--- a/src/domain/git/commands/subcommands/checkout-subcommand.ts
+++ b/src/domain/git/commands/subcommands/checkout-subcommand.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../adapters/shared/command-registry";
 import { checkoutFromParams } from "../checkout-command";
 import { getSharedSessionProvider } from "../../../session/session-provider-cache";
+import type { SessionProviderInterface } from "../../../session/index";
 import { log } from "../../../../utils/logger";
 import {
   REPO_DESCRIPTION,
@@ -57,11 +58,12 @@ export async function executeCheckoutCommand(
   parameters: {
     [K in keyof typeof checkoutCommandParams]: z.infer<(typeof checkoutCommandParams)[K]["schema"]>;
   },
-  context: CommandExecutionContext
+  context: CommandExecutionContext,
+  sessionProvider?: SessionProviderInterface,
 ): Promise<unknown> {
   const { branch, session, repo, preview, autoResolve, conflictStrategy } = parameters;
 
-  const sessionProvider = await getSharedSessionProvider();
+  const resolvedSessionProvider = sessionProvider ?? (await getSharedSessionProvider());
   const result = await checkoutFromParams(
     {
       branch,
@@ -71,7 +73,7 @@ export async function executeCheckoutCommand(
       autoResolve,
       conflictStrategy,
     },
-    { sessionProvider }
+    { sessionProvider: resolvedSessionProvider }
   );
 
   if (context.debug) {

--- a/src/domain/git/commands/subcommands/checkout-subcommand.ts
+++ b/src/domain/git/commands/subcommands/checkout-subcommand.ts
@@ -59,7 +59,7 @@ export async function executeCheckoutCommand(
     [K in keyof typeof checkoutCommandParams]: z.infer<(typeof checkoutCommandParams)[K]["schema"]>;
   },
   context: CommandExecutionContext,
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<unknown> {
   const { branch, session, repo, preview, autoResolve, conflictStrategy } = parameters;
 

--- a/src/domain/git/commands/subcommands/commit-subcommand.ts
+++ b/src/domain/git/commands/subcommands/commit-subcommand.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../adapters/shared/command-registry";
 import { commitChangesFromParams } from "../commit-command";
 import { getSharedSessionProvider } from "../../../session/session-provider-cache";
+import type { SessionProviderInterface } from "../../../session/index";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -65,11 +66,12 @@ interface CommitCommandContext extends CommandExecutionContext {
  * Execute the commit command
  */
 export async function executeCommitCommand(
-  context: CommitCommandContext
+  context: CommitCommandContext,
+  sessionProvider?: SessionProviderInterface,
 ): Promise<{ commitHash: string; message: string }> {
   const { message, all, amend, noStage, repo, session } = context.parameters;
 
-  const sessionProvider = await getSharedSessionProvider();
+  const resolvedSessionProvider = sessionProvider ?? (await getSharedSessionProvider());
   const result = await commitChangesFromParams(
     {
       message,
@@ -79,7 +81,7 @@ export async function executeCommitCommand(
       amend,
       noStage,
     },
-    { sessionProvider }
+    { sessionProvider: resolvedSessionProvider }
   );
 
   if (context.debug) {

--- a/src/domain/git/commands/subcommands/commit-subcommand.ts
+++ b/src/domain/git/commands/subcommands/commit-subcommand.ts
@@ -67,7 +67,7 @@ interface CommitCommandContext extends CommandExecutionContext {
  */
 export async function executeCommitCommand(
   context: CommitCommandContext,
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<{ commitHash: string; message: string }> {
   const { message, all, amend, noStage, repo, session } = context.parameters;
 

--- a/src/domain/git/commands/subcommands/merge-subcommand.ts
+++ b/src/domain/git/commands/subcommands/merge-subcommand.ts
@@ -60,7 +60,7 @@ export async function executeMergeCommand(
     [K in keyof typeof mergeCommandParams]: z.infer<(typeof mergeCommandParams)[K]["schema"]>;
   },
   context: CommandExecutionContext,
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<unknown> {
   const { sourceBranch, targetBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;

--- a/src/domain/git/commands/subcommands/merge-subcommand.ts
+++ b/src/domain/git/commands/subcommands/merge-subcommand.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../adapters/shared/command-registry";
 import { mergeFromParams } from "../merge-command";
 import { getSharedSessionProvider } from "../../../session/session-provider-cache";
+import type { SessionProviderInterface } from "../../../session/index";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -58,12 +59,13 @@ export async function executeMergeCommand(
   parameters: {
     [K in keyof typeof mergeCommandParams]: z.infer<(typeof mergeCommandParams)[K]["schema"]>;
   },
-  context: CommandExecutionContext
+  context: CommandExecutionContext,
+  sessionProvider?: SessionProviderInterface,
 ): Promise<unknown> {
   const { sourceBranch, targetBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;
 
-  const sessionProvider = await getSharedSessionProvider();
+  const resolvedSessionProvider = sessionProvider ?? (await getSharedSessionProvider());
   const result = await mergeFromParams(
     {
       sourceBranch,
@@ -74,7 +76,7 @@ export async function executeMergeCommand(
       autoResolve,
       conflictStrategy,
     },
-    { sessionProvider }
+    { sessionProvider: resolvedSessionProvider }
   );
 
   if (context.debug) {

--- a/src/domain/git/commands/subcommands/rebase-subcommand.ts
+++ b/src/domain/git/commands/subcommands/rebase-subcommand.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../adapters/shared/command-registry";
 import { rebaseFromParams } from "../rebase-command";
 import { getSharedSessionProvider } from "../../../session/session-provider-cache";
+import type { SessionProviderInterface } from "../../../session/index";
 import { log } from "../../../../utils/logger";
 import { REPO_DESCRIPTION, SESSION_DESCRIPTION } from "../../../../utils/option-descriptions";
 
@@ -58,12 +59,13 @@ export async function executeRebaseCommand(
   parameters: {
     [K in keyof typeof rebaseCommandParams]: z.infer<(typeof rebaseCommandParams)[K]["schema"]>;
   },
-  context: CommandExecutionContext
+  context: CommandExecutionContext,
+  sessionProvider?: SessionProviderInterface,
 ): Promise<unknown> {
   const { baseBranch, featureBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;
 
-  const sessionProvider = await getSharedSessionProvider();
+  const resolvedSessionProvider = sessionProvider ?? (await getSharedSessionProvider());
   const result = await rebaseFromParams(
     {
       baseBranch,
@@ -74,7 +76,7 @@ export async function executeRebaseCommand(
       autoResolve,
       conflictStrategy,
     },
-    { sessionProvider }
+    { sessionProvider: resolvedSessionProvider }
   );
 
   if (context.debug) {

--- a/src/domain/git/commands/subcommands/rebase-subcommand.ts
+++ b/src/domain/git/commands/subcommands/rebase-subcommand.ts
@@ -60,7 +60,7 @@ export async function executeRebaseCommand(
     [K in keyof typeof rebaseCommandParams]: z.infer<(typeof rebaseCommandParams)[K]["schema"]>;
   },
   context: CommandExecutionContext,
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<unknown> {
   const { baseBranch, featureBranch, session, repo, preview, autoResolve, conflictStrategy } =
     parameters;

--- a/src/domain/session/commands/subcommands/pr-subcommand.ts
+++ b/src/domain/session/commands/subcommands/pr-subcommand.ts
@@ -41,7 +41,7 @@ export const prSessionSubcommand: CommandExecutionHandler = async (params) => {
  * Use this factory when you want to pass a provider from a DI container.
  */
 export function createPrSessionSubcommand(
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): CommandExecutionHandler {
   return async (params) => {
     const { args, options } = params;

--- a/src/domain/session/commands/subcommands/pr-subcommand.ts
+++ b/src/domain/session/commands/subcommands/pr-subcommand.ts
@@ -1,6 +1,7 @@
 import { CommandExecutionHandler } from "../../../../adapters/shared/command-registry";
 import { sessionPr } from "../pr-command";
 import { getSharedSessionProvider } from "../../session-provider-cache";
+import type { SessionProviderInterface } from "../../index";
 import { createGitService } from "../../../git";
 
 export const prSessionSubcommand: CommandExecutionHandler = async (params) => {
@@ -34,3 +35,43 @@ export const prSessionSubcommand: CommandExecutionHandler = async (params) => {
     );
   }
 };
+
+/**
+ * Create the PR subcommand handler with optional injected session provider.
+ * Use this factory when you want to pass a provider from a DI container.
+ */
+export function createPrSessionSubcommand(
+  sessionProvider?: SessionProviderInterface,
+): CommandExecutionHandler {
+  return async (params) => {
+    const { args, options } = params;
+
+    let sessionId: string | undefined;
+    if (args && args.length > 0) {
+      sessionId = args[0];
+    }
+
+    const noStatusUpdate = options?.["no-status-update"] === true;
+
+    try {
+      const sessionDB = sessionProvider ?? (await getSharedSessionProvider());
+      const gitService = createGitService();
+      const prDescription = await sessionPr(
+        {
+          session: sessionId,
+          noStatusUpdate,
+          title: "",
+        } as Parameters<typeof sessionPr>[0],
+        { sessionDB, gitService }
+      );
+      return {
+        success: true,
+        data: { prDescription },
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to create PR: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  };
+}

--- a/src/domain/session/resolve-session-directory.ts
+++ b/src/domain/session/resolve-session-directory.ts
@@ -26,7 +26,7 @@ import { log } from "../../utils/logger";
  */
 export async function resolveSessionDirectory(
   sessionId: string,
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<string> {
   log.debug(`Resolving session directory for: ${sessionId}`);
 

--- a/src/domain/session/resolve-session-directory.ts
+++ b/src/domain/session/resolve-session-directory.ts
@@ -7,6 +7,7 @@
  */
 
 import { getSharedSessionProvider, _setProviderForTesting } from "./session-provider-cache";
+import type { SessionProviderInterface } from "./index";
 import { log } from "../../utils/logger";
 
 /**
@@ -19,13 +20,17 @@ import { log } from "../../utils/logger";
  *   3. Filesystem path resolution via getRepoPath
  *
  * @param sessionId - The session identifier (e.g. "task-mt#123")
+ * @param sessionProvider - Optional pre-created provider; falls back to shared singleton
  * @returns The absolute filesystem path to the session's working directory
  * @throws Error if the session is not found or the path cannot be resolved
  */
-export async function resolveSessionDirectory(sessionId: string): Promise<string> {
+export async function resolveSessionDirectory(
+  sessionId: string,
+  sessionProvider?: SessionProviderInterface,
+): Promise<string> {
   log.debug(`Resolving session directory for: ${sessionId}`);
 
-  const provider = await getSharedSessionProvider();
+  const provider = sessionProvider ?? (await getSharedSessionProvider());
 
   const session = await provider.getSession(sessionId);
   if (!session) {

--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -94,7 +94,7 @@ export interface SessionApproveParams {
  */
 export async function pureSessionApprove(
   params: SessionApproveParams,
-  sessionProvider?: import("./types").SessionProviderInterface,
+  sessionProvider?: import("./types").SessionProviderInterface
 ): Promise<{
   success: boolean;
   message: string;
@@ -143,7 +143,7 @@ export async function sessionCommit(
     amend?: boolean;
     noStage?: boolean;
   },
-  sessionProvider?: import("./types").SessionProviderInterface,
+  sessionProvider?: import("./types").SessionProviderInterface
 ): Promise<{
   success: boolean;
   nothingToCommit?: boolean;

--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -92,7 +92,10 @@ export interface SessionApproveParams {
 /**
  * Pure session approve domain function
  */
-export async function pureSessionApprove(params: SessionApproveParams): Promise<{
+export async function pureSessionApprove(
+  params: SessionApproveParams,
+  sessionProvider?: import("./types").SessionProviderInterface,
+): Promise<{
   success: boolean;
   message: string;
 }> {
@@ -106,7 +109,7 @@ export async function pureSessionApprove(params: SessionApproveParams): Promise<
   const { getSharedSessionProvider } = await import("./session-provider-cache.js");
 
   try {
-    const sessionDB = await getSharedSessionProvider();
+    const sessionDB = sessionProvider ?? (await getSharedSessionProvider());
     const _result = await approveSessionPr(
       {
         session: params.session,
@@ -132,13 +135,16 @@ export async function pureSessionApprove(params: SessionApproveParams): Promise<
  *
  * Note: Always pushes after commit - in session context these operations should be atomic
  */
-export async function sessionCommit(params: {
-  session: string;
-  message: string;
-  all?: boolean;
-  amend?: boolean;
-  noStage?: boolean;
-}): Promise<{
+export async function sessionCommit(
+  params: {
+    session: string;
+    message: string;
+    all?: boolean;
+    amend?: boolean;
+    noStage?: boolean;
+  },
+  sessionProvider?: import("./types").SessionProviderInterface,
+): Promise<{
   success: boolean;
   nothingToCommit?: boolean;
   commitHash: string | null;
@@ -167,7 +173,7 @@ export async function sessionCommit(params: {
   // Enforce merged-PR-freeze invariant
   const { getSharedSessionProvider } = await import("./session-provider-cache.js");
   const { assertSessionMutable } = await import("./session-mutability.js");
-  const sessionDBForFreeze = await getSharedSessionProvider();
+  const sessionDBForFreeze = sessionProvider ?? (await getSharedSessionProvider());
   const sessionRecordForFreeze = await sessionDBForFreeze.getSession(params.session);
   if (sessionRecordForFreeze) {
     assertSessionMutable(sessionRecordForFreeze, "commit changes");

--- a/src/domain/session/session-conflicts-operations.ts
+++ b/src/domain/session/session-conflicts-operations.ts
@@ -66,7 +66,7 @@ export interface SessionConflictParams {
 export async function scanSessionConflicts(
   params: SessionConflictParams,
   options: SessionConflictScanOptions = {},
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<SessionConflictScanResult> {
   try {
     let sessionPath: string;

--- a/src/domain/session/session-conflicts-operations.ts
+++ b/src/domain/session/session-conflicts-operations.ts
@@ -8,6 +8,7 @@
 import { analyzeConflictRegions } from "../git/conflict-analysis-operations";
 import { getCurrentSessionContext } from "../workspace";
 import { getSharedSessionProvider } from "./session-provider-cache";
+import type { SessionProviderInterface } from "./index";
 import { getSessionDirFromParams } from "../session";
 import { getCurrentWorkingDirectory } from "../../utils/process";
 import { execAsync } from "../../utils/exec";
@@ -64,7 +65,8 @@ export interface SessionConflictParams {
  */
 export async function scanSessionConflicts(
   params: SessionConflictParams,
-  options: SessionConflictScanOptions = {}
+  options: SessionConflictScanOptions = {},
+  sessionProvider?: SessionProviderInterface,
 ): Promise<SessionConflictScanResult> {
   try {
     let sessionPath: string;
@@ -84,7 +86,7 @@ export async function scanSessionConflicts(
     } else {
       // Auto-detect current session from working directory
       const cwd = getCurrentWorkingDirectory();
-      const sessionDB = await getSharedSessionProvider();
+      const sessionDB = sessionProvider ?? (await getSharedSessionProvider());
       const context = await getCurrentSessionContext(cwd, { sessionDbOverride: sessionDB });
 
       if (!context) {

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -26,7 +26,7 @@ import { first } from "../../utils/array-safety";
  */
 async function resolveRepoPath(
   options: { repo?: string; session?: string },
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<string> {
   const provider = sessionProvider ?? (await getSharedSessionProvider());
   return resolveRepoPathBase(options, { sessionProvider: provider });

--- a/src/domain/tasks/taskCommands.ts
+++ b/src/domain/tasks/taskCommands.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { resolveRepoPath as resolveRepoPathBase } from "../repo-utils";
 import { getSharedSessionProvider } from "../session/session-provider-cache";
+import type { SessionProviderInterface } from "../session/index";
 import { getErrorMessage } from "../../errors/index";
 import { log } from "../../utils/logger";
 import {
@@ -23,9 +24,12 @@ import { first } from "../../utils/array-safety";
  * Module-level wrapper that lazily creates a sessionProvider for bare resolveRepoPath calls.
  * This is a composition boundary — domain functions above should receive deps injected.
  */
-async function resolveRepoPath(options: { repo?: string; session?: string }): Promise<string> {
-  const sessionProvider = await getSharedSessionProvider();
-  return resolveRepoPathBase(options, { sessionProvider });
+async function resolveRepoPath(
+  options: { repo?: string; session?: string },
+  sessionProvider?: SessionProviderInterface,
+): Promise<string> {
+  const provider = sessionProvider ?? (await getSharedSessionProvider());
+  return resolveRepoPathBase(options, { sessionProvider: provider });
 }
 
 // Re-export task data types

--- a/src/utils/repo.ts
+++ b/src/utils/repo.ts
@@ -1,5 +1,6 @@
 import { resolveRepoPath as resolveRepoPathInternal } from "../domain/repo-utils";
 import { getSharedSessionProvider } from "../domain/session/session-provider-cache";
+import type { SessionProviderInterface } from "../domain/session/index";
 
 export interface RepoResolutionOptions {
   session?: string;
@@ -12,7 +13,10 @@ export interface RepoResolutionOptions {
  *
  * Note: This is a composition boundary — uses the shared session provider cache.
  */
-export async function resolveRepoPath(options: RepoResolutionOptions = {}): Promise<string> {
-  const sessionProvider = await getSharedSessionProvider();
-  return resolveRepoPathInternal(options, { sessionProvider });
+export async function resolveRepoPath(
+  options: RepoResolutionOptions = {},
+  sessionProvider?: SessionProviderInterface,
+): Promise<string> {
+  const provider = sessionProvider ?? (await getSharedSessionProvider());
+  return resolveRepoPathInternal(options, { sessionProvider: provider });
 }

--- a/src/utils/repo.ts
+++ b/src/utils/repo.ts
@@ -15,7 +15,7 @@ export interface RepoResolutionOptions {
  */
 export async function resolveRepoPath(
   options: RepoResolutionOptions = {},
-  sessionProvider?: SessionProviderInterface,
+  sessionProvider?: SessionProviderInterface
 ): Promise<string> {
   const provider = sessionProvider ?? (await getSharedSessionProvider());
   return resolveRepoPathInternal(options, { sessionProvider: provider });


### PR DESCRIPTION
## Summary

Phase 3d/3e of mt#761 DI migration. Adds optional `sessionProvider?: SessionProviderInterface` parameter to 12 domain functions that previously called `getSharedSessionProvider()` unconditionally. Each function retains a `?? await getSharedSessionProvider()` fallback for full backward compatibility.

**Files changed:**
- `src/domain/git/commands/subcommands/checkout-subcommand.ts` — `executeCheckoutCommand`
- `src/domain/git/commands/subcommands/commit-subcommand.ts` — `executeCommitCommand`
- `src/domain/git/commands/subcommands/merge-subcommand.ts` — `executeMergeCommand`
- `src/domain/git/commands/subcommands/rebase-subcommand.ts` — `executeRebaseCommand`
- `src/domain/session/resolve-session-directory.ts` — `resolveSessionDirectory`
- `src/domain/session/session-commands.ts` — `pureSessionApprove`, `sessionCommit`
- `src/domain/session/session-conflicts-operations.ts` — `scanSessionConflicts`
- `src/domain/session/commands/subcommands/pr-subcommand.ts` — added `createPrSessionSubcommand` factory; existing `prSessionSubcommand` const unchanged
- `src/domain/tasks/taskCommands.ts` — local `resolveRepoPath` wrapper
- `src/domain/context/components/session-context.ts` — `gatherInputs` via `context.sessionProvider`
- `src/domain/context/components/types.ts` — added `sessionProvider?` field to `ComponentInput`
- `src/utils/repo.ts` — `resolveRepoPath`

**Not changed** (already DI-capable via constructor deps):
- `src/domain/changeset/adapters/local-git-adapter.ts` — already uses `deps?.sessionProvider` in constructor
- `src/domain/changeset/adapters/github-adapter.ts` — already uses `deps?.sessionProvider` in constructor

## Test plan

- [ ] TypeScript compiles: `bun run tsc --noEmit`
- [ ] Domain tests pass: `bun test --preload ./tests/setup.ts --timeout=15000 src/domain/session/ src/domain/git/ src/domain/tasks/ src/domain/context/ src/domain/changeset/ src/utils/`
- [ ] No existing callers broken (all parameters are optional with singleton fallback)

## Coherence Verification

**Files re-read**: checkout-subcommand.ts, commit-subcommand.ts, merge-subcommand.ts, rebase-subcommand.ts, resolve-session-directory.ts, session-commands.ts, session-conflicts-operations.ts, pr-subcommand.ts, taskCommands.ts, session-context.ts, types.ts (context), repo.ts

**Q1 single purpose**: pass — each file retains its original single purpose; only parameter signatures expanded

**Q2 comment honesty**: pass — `resolve-session-directory.ts` docstring updated to document the new `sessionProvider` parameter

**Q3 naming honesty**: pass — `createPrSessionSubcommand` factory name accurately reflects its role; `prSessionSubcommand` const retained unchanged for backward compatibility

**Q4 redundant siblings**: pass — no new redundancy introduced; `createPrSessionSubcommand` is an additive factory, not a replacement

**Q5 dead exports**: issue (pre-existing, not caused by this PR): `prSessionSubcommand` in `pr-subcommand.ts` has no import sites. This was already dead before this PR. Deferred as out of scope for this refactor.

**Q6 orphan code**: pass — no orphan code introduced; the `SessionProviderInterface` import in `session-context.ts` is actively used in two type annotations

**Q7 stray artifacts**: pass — no backup/tmp files created

**Items fixed in this PR (beyond original scope)**: Updated `resolve-session-directory.ts` docstring to document the new optional parameter.

**Items deferred (with justification)**: Pre-existing dead export `prSessionSubcommand` in `pr-subcommand.ts` — not caused by this PR, requires separate investigation of whether this file should be removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)