### PR TITLE
fix(mt#766): fix broken links, stale backend refs, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Eugene Dobry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,11 @@ The beauty of this approach is that it's already proven. These are the same orga
 Coordinate work items across different storage systems:
 
 ```bash
-# Markdown files for simple projects
-minsky init --tasks-backend markdown
+# Minsky database (default)
+minsky init --tasks-backend minsky
 
 # GitHub Issues for open source
-minsky init --tasks-backend github
-
-# Database for complex workflows
-minsky init --tasks-backend minsky
+minsky init --tasks-backend github-issues
 ```
 
 ### 2. Session-Based Development
@@ -226,7 +223,7 @@ Minsky uses a flexible configuration system supporting both YAML and JSON:
 ```yaml
 # minsky.yaml
 tasks:
-  backend: markdown # or: github, json-file, minsky
+  backend: minsky # or: github-issues
 
 workflows:
   lint:

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,8 +29,8 @@ This directory contains comprehensive documentation for the Minsky development w
 
 ### MCP Integration
 
-- [**MCP README**](../README-MCP.md) - Model Context Protocol server documentation
-- [**MCP Usage**](../README.md#mcp-model-context-protocol-support) - MCP integration and AI agent support
+- [**Shared Command Registry**](./architecture.md#1-shared-command-registry) - How CLI and MCP interfaces share the same command definitions
+- [**MCP Server**](../CONTRIBUTING.md#running-the-mcp-server) - How to start and inspect the MCP server locally
 
 ### Git Workflows
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,10 +1,10 @@
 # Multi-Backend Migration Guide
 
-> **Note**: The `markdown` and `json-file` task backends referenced in this guide have been removed. The active task backends are now `minsky` (PostgreSQL, prefix `mt#`) and `github-issues` (prefix `gh#`). Some examples below still reference the old `md#` prefix and should be updated.
+> **Historical document**: This guide was written when the multi-backend task system was introduced (Task #356). The migration it describes is now complete — qualified IDs (`mt#123`, `gh#456`) are the default. Some commands referenced here (`detect-collisions`, `migrate-rollback`) were planned but not fully implemented. Preserved for reference.
 
 ## Overview
 
-This guide helps you migrate from the legacy single-backend task system to the new multi-backend architecture introduced in Task #356.
+This guide describes the migration from the legacy single-backend task system to the multi-backend architecture introduced in Task #356.
 
 **⚠️ Migration is NOT urgent** - the system provides full backward compatibility with automatic migration.
 


### PR DESCRIPTION
## Summary

- Created MIT LICENSE file (README referenced it, file didn't exist)
- Fixed docs/README.md MCP section: replaced broken `README-MCP.md` link with references to `docs/architecture.md` (shared command registry) and `CONTRIBUTING.md` (MCP server startup)
- Fixed README.md config example: `backend: markdown # or: github, json-file, minsky` → `backend: minsky # or: github-issues`
- Fixed README.md init examples: removed `--tasks-backend markdown`, fixed `github` → `github-issues`
- Fixed docs/migration-guide.md: replaced misleading deprecation banner ("markdown and json-file backends referenced in this guide have been removed") with accurate historical document marker — the guide is about ID qualification, not about removed backends

## Test plan

- [ ] Every `[text](path)` link in README.md resolves to an existing file
- [ ] Every `[text](path)` link in docs/README.md resolves to an existing file
- [ ] `grep -rn "markdown" README.md` returns zero hits referencing removed backends
- [ ] LICENSE file exists at project root

🤖 Had Claude look into it — AI-assisted fixes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>