### PR TITLE
feat(mt#798): add dependency cycle detection to TaskGraphService

### DIFF
--- a/src/domain/tasks/task-graph-service.ts
+++ b/src/domain/tasks/task-graph-service.ts
@@ -149,6 +149,13 @@ export class TaskGraphService {
       throw new Error("A task cannot depend on itself");
     }
 
+    // Cycle prevention: if fromId is transitively reachable from toId,
+    // adding fromId→toId would create a cycle
+    const transitiveDeps = await this.getTransitiveDependencies(toId);
+    if (transitiveDeps.has(fromId)) {
+      throw new Error(`Cycle detected: ${toId} already transitively depends on ${fromId}`);
+    }
+
     const exists = await this.repo.findEdge(fromId, toId, "depends");
     if (exists) {
       return { created: false };
@@ -239,6 +246,26 @@ export class TaskGraphService {
       current = parent;
     }
     return ancestors;
+  }
+
+  /**
+   * BFS over "depends" edges from a task, returning all transitive dependencies.
+   * Used for cycle detection before adding a new dependency edge.
+   */
+  async getTransitiveDependencies(taskId: string, maxNodes = 100): Promise<Set<string>> {
+    const visited = new Set<string>();
+    const queue = [taskId];
+    while (queue.length > 0 && visited.size < maxNodes) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const deps = await this.listDependencies(current);
+      for (const dep of deps) {
+        if (!visited.has(dep)) queue.push(dep);
+      }
+    }
+    visited.delete(taskId); // don't include the starting node itself
+    return visited;
   }
 
   // ── Bulk operations (all types by default) ────────────────────────────

--- a/tests/domain/tasks/task-graph-service.test.ts
+++ b/tests/domain/tasks/task-graph-service.test.ts
@@ -101,6 +101,40 @@ describe("TaskGraphService (in-memory)", () => {
       await expect(svc.addDependency("md#1", "2")).rejects.toThrow();
     });
 
+    it("prevents direct dependency cycle: A→B, B→A", async () => {
+      const svc = createService([["mt#1", "mt#2", "depends"]]);
+      await expect(svc.addDependency("mt#2", "mt#1")).rejects.toThrow(/Cycle detected/);
+    });
+
+    it("prevents indirect dependency cycle: A→B→C, C→A", async () => {
+      const svc = createService([
+        ["mt#1", "mt#2", "depends"],
+        ["mt#2", "mt#3", "depends"],
+      ]);
+      await expect(svc.addDependency("mt#3", "mt#1")).rejects.toThrow(/Cycle detected/);
+    });
+
+    it("allows non-cyclic dependency chains", async () => {
+      const svc = createService([
+        ["mt#1", "mt#2", "depends"],
+        ["mt#2", "mt#3", "depends"],
+      ]);
+      // mt#1 depending on mt#3 is fine (parallel dependency, not a cycle)
+      const r = await svc.addDependency("mt#1", "mt#3");
+      expect(r.created).toBe(true);
+    });
+
+    it("allows diamond dependencies (not cycles)", async () => {
+      const svc = createService([
+        ["mt#1", "mt#2", "depends"],
+        ["mt#1", "mt#3", "depends"],
+        ["mt#2", "mt#4", "depends"],
+      ]);
+      // mt#3 also depending on mt#4 creates a diamond, not a cycle
+      const r = await svc.addDependency("mt#3", "mt#4");
+      expect(r.created).toBe(true);
+    });
+
     it("removes dependency and lists dependents", async () => {
       const svc = createService([
         ["md#1", "db#2"],


### PR DESCRIPTION
## Summary

`addDependency()` now prevents circular dependencies. Before creating an edge, it runs BFS over "depends" edges from the target to check if the source is transitively reachable. If so, the edge is rejected.

This is a subtask of mt#239 (Phase 2: Task Dependencies), broken out as a discrete piece.

### Changes

- **`task-graph-service.ts`**: `addDependency()` calls `getTransitiveDependencies()` before creating edges. New `getTransitiveDependencies()` method does BFS with configurable max node limit (default 100).
- **Tests**: 4 new tests — direct cycle, indirect cycle, non-cyclic chain (allowed), diamond pattern (allowed).

## Spec verification

**Task:** mt#798

| Criterion | Status | Evidence |
|---|---|---|
| Cycle detection in addDependency | Met | `task-graph-service.ts:152-157`, BFS check |
| Direct cycles rejected | Met | Test: "prevents direct dependency cycle" |
| Indirect cycles rejected | Met | Test: "prevents indirect dependency cycle" |
| Non-cyclic graphs allowed | Met | Tests: "allows non-cyclic chains" + "allows diamond dependencies" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)