### PR TITLE
feat(mt#777): add PostToolUse hook to validate task spec structure on creation

### DIFF
--- a/.claude/hooks/validate-task-spec.ts
+++ b/.claude/hooks/validate-task-spec.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+// PostToolUse hook: Validate task spec structure after tasks_create
+//
+// Blocks task creation if the spec content is missing required sections.
+// Short specs (under 100 chars) pass through — not all tasks need full structure.
+//
+// Required sections: ## Success Criteria, ## Acceptance Tests
+
+import { readInput, writeOutput } from "./types";
+import type { ToolHookInput } from "./types";
+
+const input = await readInput<ToolHookInput>();
+
+// Get spec content from the tool input (spec or deprecated description alias)
+const specContent =
+  (input.tool_input.spec as string | undefined) ??
+  (input.tool_input.description as string | undefined) ??
+  "";
+
+// Short specs pass through — quick tasks don't need full structure
+if (specContent.length < 100) {
+  process.exit(0);
+}
+
+// Check for required sections
+const missingHeadings: string[] = [];
+
+if (!/^## Success Criteria/m.test(specContent)) {
+  missingHeadings.push("## Success Criteria");
+}
+
+if (!/^## Acceptance Tests/m.test(specContent)) {
+  missingHeadings.push("## Acceptance Tests");
+}
+
+if (missingHeadings.length > 0) {
+  const title = (input.tool_input.title as string) ?? "unknown";
+  writeOutput({
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: [
+        `⚠️ Task "${title}" spec is missing required sections: ${missingHeadings.join(", ")}`,
+        "",
+        "Task specs over 100 chars must include:",
+        "  - ## Success Criteria — measurable criteria for task completion",
+        "  - ## Acceptance Tests — concrete tests to verify the work",
+        "",
+        "Please update the task spec with the missing sections using tasks_spec_edit.",
+      ].join("\n"),
+    },
+  });
+  process.exit(1);
+}
+
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,17 @@
         ]
       },
       {
+        "matcher": "mcp__minsky__tasks_create",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-task-spec.ts",
+            "timeout": 5,
+            "statusMessage": "Validating task spec structure..."
+          }
+        ]
+      },
+      {
         "matcher": "mcp__minsky__session_pr_merge|mcp__github__merge_pull_request",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Adds a PostToolUse hook on `mcp__minsky__tasks_create` that validates the spec content has required structural sections. This is environmental enforcement — relying on rules in CLAUDE.md failed under throughput pressure (11 tasks created without success criteria in the legibility campaign).

### How it works

- Fires after every `mcp__minsky__tasks_create` call
- Reads spec content from `tool_input.spec` (or deprecated `description` alias)
- **Short specs (<100 chars) pass through** — quick tasks don't need full structure
- **Specs ≥100 chars must contain:**
  - `## Success Criteria` heading
  - `## Acceptance Tests` heading
- If either is missing, the hook **blocks** (exit 1) with a clear message listing missing sections and instructions to fix via `tasks_spec_edit`

### Files

- `.claude/hooks/validate-task-spec.ts` — hook implementation (TypeScript/Bun, follows existing hook patterns)
- `.claude/settings.json` — registered as PostToolUse hook with `mcp__minsky__tasks_create` matcher

## Test plan

- [ ] Create a task with a short description (<100 chars): hook passes
- [ ] Create a task with a full structured spec (## Success Criteria + ## Acceptance Tests): hook passes
- [ ] Create a task with a long spec missing required sections: hook blocks with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)