### PR TITLE
feat(mt#792): Add startup embedding sweep and embeddings status/repair commands

### DIFF
--- a/src/adapters/shared/commands/tasks-modular.ts
+++ b/src/adapters/shared/commands/tasks-modular.ts
@@ -22,6 +22,8 @@ import { createTasksEditCommand } from "./tasks/edit-commands";
 import { createTasksMigrateBackendCommand } from "./tasks/migrate-backend-command";
 import { TasksSimilarCommand, TasksSearchCommand } from "./tasks/similarity-commands";
 import { TasksIndexEmbeddingsCommand } from "./tasks/index-embeddings-command";
+import { TasksEmbeddingsStatusCommand } from "./tasks/embeddings-status-command";
+import { TasksEmbeddingsRepairCommand } from "./tasks/embeddings-repair-command";
 import {
   createTasksDepsAddCommand,
   createTasksDepsRmCommand,
@@ -78,6 +80,8 @@ export class ModularTasksCommandManager {
       const similarCommand = new TasksSimilarCommand();
       const searchCommand = new TasksSearchCommand();
       const indexEmbeddingsCommand = new TasksIndexEmbeddingsCommand();
+      const embeddingsStatusCommand = new TasksEmbeddingsStatusCommand();
+      const embeddingsRepairCommand = new TasksEmbeddingsRepairCommand();
       const depsAddCommand = createTasksDepsAddCommand(getPersistenceProvider);
       const depsRmCommand = createTasksDepsRmCommand(getPersistenceProvider);
       const depsListCommand = createTasksDepsListCommand(getPersistenceProvider);
@@ -275,6 +279,38 @@ export class ModularTasksCommandManager {
             indexEmbeddingsCommand.execute(
               params as Parameters<typeof indexEmbeddingsCommand.execute>[0],
               ctx as Parameters<typeof indexEmbeddingsCommand.execute>[1]
+            ),
+        })
+      );
+
+      // Register embeddings status command
+      sharedCommandRegistry.registerCommand(
+        defineCommand({
+          id: embeddingsStatusCommand.id,
+          category: CommandCategory.TASKS,
+          name: embeddingsStatusCommand.name,
+          description: embeddingsStatusCommand.description,
+          parameters: embeddingsStatusCommand.parameters,
+          execute: (params, ctx) =>
+            embeddingsStatusCommand.execute(
+              params as Parameters<typeof embeddingsStatusCommand.execute>[0],
+              ctx as Parameters<typeof embeddingsStatusCommand.execute>[1]
+            ),
+        })
+      );
+
+      // Register embeddings repair command
+      sharedCommandRegistry.registerCommand(
+        defineCommand({
+          id: embeddingsRepairCommand.id,
+          category: CommandCategory.TASKS,
+          name: embeddingsRepairCommand.name,
+          description: embeddingsRepairCommand.description,
+          parameters: embeddingsRepairCommand.parameters,
+          execute: (params, ctx) =>
+            embeddingsRepairCommand.execute(
+              params as Parameters<typeof embeddingsRepairCommand.execute>[0],
+              ctx as Parameters<typeof embeddingsRepairCommand.execute>[1]
             ),
         })
       );

--- a/src/adapters/shared/commands/tasks.ts
+++ b/src/adapters/shared/commands/tasks.ts
@@ -43,6 +43,8 @@ export * from "./tasks/deps-rendering";
 export * from "./tasks/deps-visualization-commands";
 export * from "./tasks/edit-commands";
 export * from "./tasks/hierarchical-status-command";
+export * from "./tasks/embeddings-status-command";
+export * from "./tasks/embeddings-repair-command";
 export * from "./tasks/index-embeddings-command";
 export * from "./tasks/migrate-backend-command";
 export * from "./tasks/registry-setup";

--- a/src/adapters/shared/commands/tasks/embeddings-repair-command.ts
+++ b/src/adapters/shared/commands/tasks/embeddings-repair-command.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { BaseTaskCommand, type BaseTaskParams } from "./base-task-command";
+import type { CommandExecutionContext } from "../../command-registry";
+import { type CommandParameterMap } from "../../command-registry";
+import { CommonParameters } from "../../common-parameters";
+
+const embeddingsRepairParams = {
+  dryRun: {
+    schema: z.boolean().default(false),
+    description: "Only report what would be done without making changes",
+    required: false,
+  },
+  workspace: CommonParameters.workspace,
+  json: CommonParameters.json,
+} satisfies CommandParameterMap;
+
+interface EmbeddingsRepairParams extends BaseTaskParams {
+  dryRun?: boolean;
+}
+
+export class TasksEmbeddingsRepairCommand extends BaseTaskCommand<EmbeddingsRepairParams> {
+  readonly id = "tasks.embeddings-repair";
+  readonly name = "embeddings-repair";
+  readonly description = "Remove orphaned embeddings and report stale entries";
+  readonly parameters = embeddingsRepairParams;
+
+  async execute(params: EmbeddingsRepairParams, ctx: CommandExecutionContext) {
+    const { PersistenceService } = await import("../../../../domain/persistence/service");
+    if (!PersistenceService.isInitialized()) {
+      return this.formatResult(
+        { success: false, message: "Persistence not initialized" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const provider = PersistenceService.getProvider();
+    if (!provider.capabilities.sql) {
+      return this.formatResult(
+        { success: false, message: "SQL not supported by current provider" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const sql = await provider.getRawSqlConnection?.();
+    if (!sql) {
+      return this.formatResult(
+        { success: false, message: "Could not obtain SQL connection" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const pgSql = sql as import("postgres").Sql;
+    const dryRun = params.dryRun ?? false;
+    const isJson = params.json || ctx.format === "json";
+
+    // Count orphaned embeddings
+    const orphanRows = await pgSql.unsafe(
+      "SELECT count(*)::int AS cnt FROM tasks_embeddings te" +
+        " WHERE NOT EXISTS (SELECT 1 FROM tasks t WHERE t.id = te.task_id)"
+    );
+    const orphansFound = orphanRows[0]?.cnt ?? 0;
+
+    let orphansDeleted = 0;
+
+    if (!dryRun && orphansFound > 0) {
+      const deleteResult = await pgSql.unsafe(
+        "DELETE FROM tasks_embeddings" +
+          " WHERE NOT EXISTS" +
+          " (SELECT 1 FROM tasks t WHERE t.id = tasks_embeddings.task_id)"
+      );
+      orphansDeleted = deleteResult.count ?? orphansFound;
+    }
+
+    // Count stale entries (content_hash mismatch) — report only
+    // Stale entries have a content_hash that no longer matches the task's
+    // current content. Reindexing is done via `index-embeddings --reindex`.
+    const staleRows = await pgSql.unsafe(
+      "SELECT count(*)::int AS cnt FROM tasks_embeddings te" +
+        " JOIN tasks t ON t.id = te.task_id" +
+        " WHERE te.content_hash IS DISTINCT FROM t.content_hash"
+    );
+    const staleCount = staleRows[0]?.cnt ?? 0;
+
+    const result = {
+      success: true,
+      dryRun,
+      orphansDeleted: dryRun ? 0 : orphansDeleted,
+      orphansFound,
+      staleCount,
+    };
+
+    if (!isJson) {
+      const { log } = await import("../../../../utils/logger");
+      if (dryRun) {
+        log.cli("[dry-run] No changes applied.");
+        log.cli(`  Orphaned embeddings found: ${orphansFound}`);
+        log.cli(`  Stale embeddings found:    ${staleCount}`);
+      } else {
+        log.cli(`Orphaned embeddings deleted: ${orphansDeleted}`);
+        log.cli(`Stale embeddings found:      ${staleCount}`);
+        if (staleCount > 0) {
+          log.cli("  (Use 'minsky tasks index-embeddings --reindex' to refresh stale entries)");
+        }
+      }
+    }
+
+    return this.formatResult(result, isJson);
+  }
+}

--- a/src/adapters/shared/commands/tasks/embeddings-status-command.ts
+++ b/src/adapters/shared/commands/tasks/embeddings-status-command.ts
@@ -1,0 +1,97 @@
+import { BaseTaskCommand, type BaseTaskParams } from "./base-task-command";
+import type { CommandExecutionContext, CommandParameterMap } from "../../command-registry";
+import { CommonParameters } from "../../common-parameters";
+
+const embeddingsStatusParams = {
+  workspace: CommonParameters.workspace,
+  json: CommonParameters.json,
+} satisfies CommandParameterMap;
+
+interface EmbeddingsStatusParams extends BaseTaskParams {}
+
+export class TasksEmbeddingsStatusCommand extends BaseTaskCommand<EmbeddingsStatusParams> {
+  readonly id = "tasks.embeddings-status";
+  readonly name = "embeddings-status";
+  readonly description = "Show embedding index coverage and health statistics";
+  readonly parameters = embeddingsStatusParams;
+
+  async execute(params: EmbeddingsStatusParams, ctx: CommandExecutionContext) {
+    const { PersistenceService } = await import("../../../../domain/persistence/service");
+    if (!PersistenceService.isInitialized()) {
+      return this.formatResult(
+        { success: false, message: "Persistence not initialized" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const provider = PersistenceService.getProvider();
+    if (!provider.capabilities.sql) {
+      return this.formatResult(
+        { success: false, message: "SQL not supported by current provider" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const sql = await provider.getRawSqlConnection?.();
+    if (!sql) {
+      return this.formatResult(
+        { success: false, message: "Could not obtain SQL connection" },
+        params.json || ctx.format === "json"
+      );
+    }
+
+    const pgSql = sql as import("postgres").Sql;
+
+    const totalRows = await pgSql.unsafe("SELECT count(*)::int AS cnt FROM tasks");
+    const indexedRows = await pgSql.unsafe("SELECT count(*)::int AS cnt FROM tasks_embeddings");
+    const missingRows = await pgSql.unsafe(
+      "SELECT count(*)::int AS cnt FROM tasks t" +
+        " LEFT JOIN tasks_embeddings te ON t.id = te.task_id" +
+        " WHERE te.task_id IS NULL"
+    );
+    const orphanedRows = await pgSql.unsafe(
+      "SELECT count(*)::int AS cnt FROM tasks_embeddings te" +
+        " WHERE NOT EXISTS (SELECT 1 FROM tasks t WHERE t.id = te.task_id)"
+    );
+    const lastRows = await pgSql.unsafe(
+      "SELECT max(indexed_at) AS last_indexed FROM tasks_embeddings"
+    );
+
+    const total = totalRows[0]?.cnt ?? 0;
+    const indexed = indexedRows[0]?.cnt ?? 0;
+    const missing = missingRows[0]?.cnt ?? 0;
+    const orphaned = orphanedRows[0]?.cnt ?? 0;
+    const lastIndexed = lastRows[0]?.last_indexed ?? null;
+
+    // Pull model/dimension from config
+    const { getConfiguration } = await import("../../../../domain/configuration");
+    const cfg = getConfiguration();
+    const model = cfg.embeddings?.model || "text-embedding-3-small";
+    const { getEmbeddingDimension } = await import("../../../../domain/ai/embedding-models");
+    const dimension = getEmbeddingDimension(model, 1536);
+
+    const result = {
+      success: true,
+      total,
+      indexed,
+      missing,
+      orphaned,
+      lastIndexed,
+      model,
+      dimension,
+    };
+
+    if (!(params.json || ctx.format === "json")) {
+      const { log } = await import("../../../../utils/logger");
+      log.cli(`Tasks total:    ${result.total}`);
+      log.cli(`Indexed:        ${result.indexed}`);
+      log.cli(`Missing:        ${result.missing}`);
+      log.cli(`Orphaned:       ${result.orphaned}`);
+      log.cli(`Last indexed:   ${result.lastIndexed ?? "never"}`);
+      log.cli(`Model:          ${result.model}`);
+      log.cli(`Dimension:      ${result.dimension}`);
+    }
+
+    return this.formatResult(result, params.json || ctx.format === "json");
+  }
+}

--- a/src/adapters/shared/commands/tasks/registry-setup.ts
+++ b/src/adapters/shared/commands/tasks/registry-setup.ts
@@ -50,6 +50,8 @@ export function createAllTaskCommands(container?: AppContainerInterface) {
   const { createTasksMigrateBackendCommand } = require("./migrate-backend-command");
   const { TasksSimilarCommand, TasksSearchCommand } = require("./similarity-commands");
   const { TasksIndexEmbeddingsCommand } = require("./index-embeddings-command");
+  const { TasksEmbeddingsStatusCommand } = require("./embeddings-status-command");
+  const { TasksEmbeddingsRepairCommand } = require("./embeddings-repair-command");
   const {
     createTasksDepsAddCommand,
     createTasksDepsRmCommand,
@@ -75,6 +77,8 @@ export function createAllTaskCommands(container?: AppContainerInterface) {
     new TasksSimilarCommand(),
     new TasksSearchCommand(),
     new TasksIndexEmbeddingsCommand(),
+    new TasksEmbeddingsStatusCommand(),
+    new TasksEmbeddingsRepairCommand(),
     createTasksMigrateBackendCommand(),
     // Dependency management commands
     createTasksDepsAddCommand(getPersistenceProvider),

--- a/src/adapters/shared/commands/tasks/startup-embedding-sweep.ts
+++ b/src/adapters/shared/commands/tasks/startup-embedding-sweep.ts
@@ -1,0 +1,58 @@
+import { log } from "../../../../utils/logger";
+
+const STARTUP_SWEEP_LIMIT = 50;
+const STARTUP_SWEEP_CONCURRENCY = 2;
+
+export async function triggerStartupEmbeddingSweep(): Promise<void> {
+  // Check config gate
+  const { getConfiguration } = await import("../../../../domain/configuration");
+  const cfg = getConfiguration();
+  if (cfg.embeddings?.autoIndex === false) return;
+
+  // Check if persistence supports SQL
+  const { PersistenceService } = await import("../../../../domain/persistence/service");
+  if (!PersistenceService.isInitialized()) return;
+  const provider = PersistenceService.getProvider();
+  if (!provider.capabilities.sql) return;
+
+  // Find tasks missing embeddings
+  const sql = await provider.getRawSqlConnection?.();
+  if (!sql) return;
+  const missing = await (sql as import("postgres").Sql).unsafe(
+    `SELECT t.id FROM tasks t LEFT JOIN tasks_embeddings te` +
+      ` ON t.id = te.task_id WHERE te.task_id IS NULL LIMIT $1`,
+    [STARTUP_SWEEP_LIMIT]
+  );
+
+  if (missing.length === 0) return;
+  log.debug(`Startup sweep: ${missing.length} tasks need embedding indexing`);
+
+  // Index them with low concurrency
+  const { createTaskSimilarityService } = await import("./similarity-commands");
+  const service = await createTaskSimilarityService();
+
+  let indexed = 0;
+  let failed = 0;
+  let i = 0;
+
+  async function worker() {
+    while (true) {
+      const idx = i++;
+      if (idx >= missing.length) break;
+      try {
+        const row = missing[idx];
+        if (!row) continue;
+        const changed = await service.indexTask(row.id);
+        if (changed) indexed++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/insufficient_quota/i.test(msg)) break; // Stop on billing issues
+        failed++;
+      }
+    }
+  }
+
+  const workers = Array.from({ length: STARTUP_SWEEP_CONCURRENCY }, () => worker());
+  await Promise.all(workers);
+  log.debug(`Startup sweep complete: indexed ${indexed}, failed ${failed}`);
+}

--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -283,6 +283,11 @@ export function createStartCommand(): Command {
           }
         }
 
+        // Fire-and-forget background embedding sweep for missing tasks
+        import("../../adapters/shared/commands/tasks/startup-embedding-sweep")
+          .then(({ triggerStartupEmbeddingSweep }) => triggerStartupEmbeddingSweep())
+          .catch(() => {}); // Embedding sweep is best-effort
+
         log.cli("Press Ctrl+C to stop");
 
         // Handle termination signals gracefully when possible

--- a/tests/adapters/shared/commands/tasks/embeddings-status-command.test.ts
+++ b/tests/adapters/shared/commands/tasks/embeddings-status-command.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { TasksEmbeddingsStatusCommand } from "../../../../../src/adapters/shared/commands/tasks/embeddings-status-command";
+import { TasksEmbeddingsRepairCommand } from "../../../../../src/adapters/shared/commands/tasks/embeddings-repair-command";
+
+describe("TasksEmbeddingsStatusCommand", () => {
+  it("has correct id and name", () => {
+    const cmd = new TasksEmbeddingsStatusCommand();
+    expect(cmd.id).toBe("tasks.embeddings-status");
+    expect(cmd.name).toBe("embeddings-status");
+  });
+
+  it("has a description", () => {
+    const cmd = new TasksEmbeddingsStatusCommand();
+    expect(cmd.description).toBeTruthy();
+  });
+
+  it("has parameters defined", () => {
+    const cmd = new TasksEmbeddingsStatusCommand();
+    expect(cmd.parameters).toBeDefined();
+    expect(typeof cmd.parameters).toBe("object");
+  });
+});
+
+describe("TasksEmbeddingsRepairCommand", () => {
+  it("has correct id and name", () => {
+    const cmd = new TasksEmbeddingsRepairCommand();
+    expect(cmd.id).toBe("tasks.embeddings-repair");
+    expect(cmd.name).toBe("embeddings-repair");
+  });
+
+  it("has a description", () => {
+    const cmd = new TasksEmbeddingsRepairCommand();
+    expect(cmd.description).toBeTruthy();
+  });
+
+  it("has dryRun parameter defined", () => {
+    const cmd = new TasksEmbeddingsRepairCommand();
+    expect(cmd.parameters).toBeDefined();
+    expect(cmd.parameters.dryRun).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Completes the embedding pipeline with three features:

- **Startup sweep** — When the MCP server starts, automatically indexes up to 50 tasks that are missing embeddings. Fire-and-forget, capped concurrency (2), respects `embeddings.autoIndex` config gate, stops on quota exhaustion.
- **`tasks embeddings-status`** — Reports total/indexed/missing/orphaned counts, last indexed timestamp, configured model and dimension.
- **`tasks embeddings-repair`** — Deletes orphaned embeddings (for deleted tasks), reports stale count. Supports `--dryRun`.

Both commands auto-expose via MCP (registered in TASKS category).

## Test plan

- [x] 6 new tests for command identity and parameters
- [x] 1585 tests pass, 0 failures
- [x] TypeScript clean, ESLint 0 warnings
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude investigate and implement this)