### PR TITLE
docs(mt#799): adopt session.generate_prompt in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,29 @@ Subagents have limited tool-call budgets and context windows. They cannot detect
 - **If a subagent returns incomplete work** (changes applied but not committed/PR'd), check the session's `git diff` and `git status`, then finish the commit/PR from the main agent.
 - **For cascading changes** (where editing one file forces changes in its callers), the blast radius is unpredictable. Err on the side of smaller scope and let the cascade determine one wave's natural boundary.
 
+### Subagent Prompt Generation
+
+**Always use `session.generate_prompt`** to generate subagent prompts instead of hand-crafting them. The tool ensures correct sessionId, taskId, absolute paths, scope bounds, and guard rails — eliminating the class of failures seen in mt#672 (wrong task IDs, missing sessionIds, unbounded scope).
+
+**Workflow:**
+
+1. Start a session: `mcp__minsky__session_start`
+2. Generate the prompt: `mcp__minsky__session_generate_prompt` with `task`, `type`, and `instructions`
+3. Dispatch: pass the returned `prompt` string to the Agent tool, using `suggestedModel` and `suggestedSubagentType` from the result
+4. Review and merge as normal
+
+**Prompt types:**
+
+- `implementation` — Feature work with commit + PR instructions
+- `refactor` — Structural changes, suggests `subagent_type: "refactor"`
+- `review` — Read-only, no commit/PR instructions
+- `cleanup` — Mechanical fixes with batching guidance
+- `audit` — Post-merge spec verification, suggests `subagent_type: "verify-completion"`
+
+**Scope batching:** When `scope` has > 40 files, the tool returns multiple prompts in the `batches` array (~30 files each). Dispatch each batch as a separate subagent with intermediate commits.
+
+**Do NOT hand-craft subagent prompts.** The tool handles session resolution, metadata injection, guard rails, and scope validation. Hand-crafting bypasses these safety mechanisms.
+
 ## Minsky Session Workflow
 
 Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID>/` (branch names follow `task/<backend>-<id>` format). The correct working pattern:


### PR DESCRIPTION
## Summary

- Add "Subagent Prompt Generation" section to CLAUDE.md
- Documents the workflow: start session → generate prompt → dispatch → review
- Lists all 5 prompt types and their behaviors
- Documents scope batching for large tasks
- Includes enforcement directive: "Do NOT hand-craft subagent prompts"

## Motivation

The `session.generate_prompt` tool was built (mt#728, mt#787, mt#791) but nothing told the orchestrating agent to use it. This closes the adoption gap — making the tool the default path instead of the old hand-crafted pattern.

(Had Claude look into this — AI-assisted documentation)