### PR TITLE
refactor(mt#795): Wire all session commands through getDeps — eliminate ad-hoc provider creation

### DIFF
--- a/src/adapters/shared/commands/session/basic-commands.ts
+++ b/src/adapters/shared/commands/session/basic-commands.ts
@@ -21,9 +21,11 @@ export function createSessionListCommand(getDeps: LazySessionDeps): CommandDefin
     description: "List all sessions",
     parameters: sessionListCommandParams,
     execute: withErrorLogging("session.list", async (params: Record<string, unknown>) => {
-      const { listSessionsFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      let sessions = await listSessionsFromParams({
+      let sessions = await service.list({
         repo: params.repo as string | undefined,
         json: params.json as boolean | undefined,
       });
@@ -57,9 +59,11 @@ export function createSessionGetCommand(getDeps: LazySessionDeps): CommandDefini
     description: "Get details of a specific session",
     parameters: sessionGetCommandParams,
     execute: withErrorLogging("session.get", async (params: Record<string, unknown>) => {
-      const { getSessionFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      const session = await getSessionFromParams({
+      const session = await service.get({
         name: params.name as string | undefined,
         task: params.task as string | undefined,
         repo: params.repo as string | undefined,
@@ -106,20 +110,30 @@ export function createSessionStartCommand(getDeps: LazySessionDeps): CommandDefi
       }
 
       const { startSessionFromParams } = await import("../../../../domain/session");
+      const deps = await getDeps();
 
-      const session = await startSessionFromParams({
-        name: params.name as string | undefined,
-        task: params.task as string | undefined,
-        description: params.description as string | undefined,
-        branch: params.branch as string | undefined,
-        repo: params.repo as string | undefined,
-        session: params.session as string | undefined,
-        json: (params.json as boolean | undefined) ?? false,
-        quiet: (params.quiet as boolean | undefined) ?? false,
-        noStatusUpdate: (params.noStatusUpdate as boolean | undefined) ?? false,
-        skipInstall: (params.skipInstall as boolean | undefined) ?? false,
-        packageManager: params.packageManager as "bun" | "npm" | "yarn" | "pnpm" | undefined,
-      });
+      const session = await startSessionFromParams(
+        {
+          name: params.name as string | undefined,
+          task: params.task as string | undefined,
+          description: params.description as string | undefined,
+          branch: params.branch as string | undefined,
+          repo: params.repo as string | undefined,
+          session: params.session as string | undefined,
+          json: (params.json as boolean | undefined) ?? false,
+          quiet: (params.quiet as boolean | undefined) ?? false,
+          noStatusUpdate: (params.noStatusUpdate as boolean | undefined) ?? false,
+          skipInstall: (params.skipInstall as boolean | undefined) ?? false,
+          packageManager: params.packageManager as "bun" | "npm" | "yarn" | "pnpm" | undefined,
+        },
+        {
+          sessionDB: deps.sessionProvider,
+          gitService: deps.gitService,
+          taskService: deps.taskService,
+          workspaceUtils: deps.workspaceUtils,
+          getRepositoryBackend: deps.getRepositoryBackend,
+        }
+      );
 
       return {
         success: true,
@@ -139,11 +153,11 @@ export function createSessionDirCommand(getDeps: LazySessionDeps): CommandDefini
     description: "Get the directory of a session",
     parameters: sessionDirCommandParams,
     execute: withErrorLogging("session.dir", async (params: Record<string, unknown>) => {
-      const { getSessionDirFromParams } = await import(
-        "../../../../domain/session/commands/dir-command"
-      );
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      const directory = await getSessionDirFromParams({
+      const directory = await service.getDir({
         name: params.name as string | undefined,
         task: params.task as string | undefined,
         repo: params.repo as string | undefined,

--- a/src/adapters/shared/commands/session/conflicts-command.ts
+++ b/src/adapters/shared/commands/session/conflicts-command.ts
@@ -63,7 +63,8 @@ export function createSessionConflictsCommand(getDeps: LazySessionDeps): Command
         files: params.files as string | undefined,
       };
 
-      const result = await scanSessionConflicts(sessionParams, options);
+      const deps = await getDeps();
+      const result = await scanSessionConflicts(sessionParams, options, deps.sessionProvider);
       const formattedOutput = formatSessionConflictResults(result, options.format);
 
       return {

--- a/src/adapters/shared/commands/session/management-commands.ts
+++ b/src/adapters/shared/commands/session/management-commands.ts
@@ -19,9 +19,11 @@ export function createSessionDeleteCommand(getDeps: LazySessionDeps): CommandDef
     description: "Delete a session",
     parameters: sessionDeleteCommandParams,
     execute: withErrorLogging("session.delete", async (params: Record<string, unknown>) => {
-      const { deleteSessionFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      const result = await deleteSessionFromParams({
+      const result = await service.delete({
         name: params.name as string | undefined,
         task: params.task as string | undefined,
         force: (params.force as boolean | undefined) ?? false,
@@ -46,9 +48,11 @@ export function createSessionUpdateCommand(getDeps: LazySessionDeps): CommandDef
     description: "Update a session",
     parameters: sessionUpdateCommandParams,
     execute: withErrorLogging("session.update", async (params: Record<string, unknown>) => {
-      const { updateSessionFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      await updateSessionFromParams({
+      await service.update({
         name: params.name as string | undefined,
         task: params.task as string | undefined,
         repo: params.repo as string | undefined,

--- a/src/adapters/shared/commands/session/prompt-command.ts
+++ b/src/adapters/shared/commands/session/prompt-command.ts
@@ -34,7 +34,7 @@ export function createSessionGeneratePromptCommand(getDeps: LazySessionDeps): Co
     description: "Generate a complete subagent prompt for session work",
     parameters: promptCommandParams,
     execute: withErrorLogging("session.generate_prompt", async (params) => {
-      const { getSessionFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
       const { generateSubagentPrompt } = await import(
         "../../../../domain/session/prompt-generation"
       );
@@ -42,12 +42,15 @@ export function createSessionGeneratePromptCommand(getDeps: LazySessionDeps): Co
         "../../../../domain/session/resolve-session-directory"
       );
 
+      const deps = await getDeps();
+      const service = new SessionService(deps);
+
       const task = params.task as string;
       const type = params.type as "implementation" | "refactor" | "review" | "cleanup" | "audit";
       const instructions = params.instructions as string;
       const scopeRaw = params.scope as string | undefined;
 
-      const session = await getSessionFromParams({ task });
+      const session = await service.get({ task });
 
       if (!session) {
         throw new Error(`No session found for task '${task}'`);

--- a/src/adapters/shared/commands/session/prompt-command.ts
+++ b/src/adapters/shared/commands/session/prompt-command.ts
@@ -57,7 +57,6 @@ export function createSessionGeneratePromptCommand(getDeps: LazySessionDeps): Co
       }
 
       const sessionId = session.session;
-      const deps = await getDeps();
       const sessionDir = await resolveSessionDirectory(sessionId, deps.sessionProvider);
 
       const scope =

--- a/src/adapters/shared/commands/session/workflow-commands.ts
+++ b/src/adapters/shared/commands/session/workflow-commands.ts
@@ -32,14 +32,18 @@ export function createSessionCommitCommand(getDeps: LazySessionDeps): CommandDef
     parameters: sessionCommitCommandParams,
     execute: withErrorLogging("session.commit", async (params: Record<string, unknown>) => {
       const { sessionCommit } = await import("../../../../domain/session/session-commands");
+      const deps = await getDeps();
 
-      const result = await sessionCommit({
-        session: (params.sessionId as string | undefined) ?? "",
-        message: (params.message as string | undefined) ?? "",
-        all: params.all as boolean | undefined,
-        amend: params.amend as boolean | undefined,
-        noStage: params.noStage as boolean | undefined,
-      });
+      const result = await sessionCommit(
+        {
+          session: (params.sessionId as string | undefined) ?? "",
+          message: (params.message as string | undefined) ?? "",
+          all: params.all as boolean | undefined,
+          amend: params.amend as boolean | undefined,
+          noStage: params.noStage as boolean | undefined,
+        },
+        deps.sessionProvider
+      );
 
       return {
         success: result.success,
@@ -73,13 +77,23 @@ export function createSessionApproveCommand(getDeps: LazySessionDeps): CommandDe
     parameters: sessionApproveCommandParams,
     execute: withErrorLogging("session.approve", async (params: Record<string, unknown>) => {
       const { approveSessionFromParams } = await import("../../../../domain/session");
+      const deps = await getDeps();
 
-      const result = await approveSessionFromParams({
-        session: params.name as string | undefined,
-        task: params.task as string | undefined,
-        repo: params.repo as string | undefined,
-        json: params.json as boolean | undefined,
-      });
+      const result = await approveSessionFromParams(
+        {
+          session: params.name as string | undefined,
+          task: params.task as string | undefined,
+          repo: params.repo as string | undefined,
+          json: params.json as boolean | undefined,
+        },
+        {
+          sessionDB: deps.sessionProvider,
+          gitService: deps.gitService,
+          taskService: deps.taskService,
+          workspaceUtils: deps.workspaceUtils,
+          getCurrentSession: deps.getCurrentSession,
+        }
+      );
 
       return { success: true, result };
     }),
@@ -94,9 +108,11 @@ export function createSessionInspectCommand(getDeps: LazySessionDeps): CommandDe
     description: "Inspect the current session (auto-detected from workspace)",
     parameters: sessionInspectCommandParams,
     execute: withErrorLogging("session.inspect", async (params: Record<string, unknown>) => {
-      const { inspectSessionFromParams } = await import("../../../../domain/session");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
 
-      const result = await inspectSessionFromParams({
+      const result = await service.inspect({
         json: params.json as boolean | undefined,
       });
 
@@ -313,15 +329,25 @@ export function createSessionPrApproveCommand(getDeps: LazySessionDeps): Command
     parameters: sessionApproveCommandParams,
     execute: withErrorLogging("session.pr.approve", async (params: Record<string, unknown>) => {
       const { approveSessionFromParams } = await import("../../../../domain/session");
+      const deps = await getDeps();
 
-      const result = await approveSessionFromParams({
-        session: params.name as string | undefined,
-        task: params.task as string | undefined,
-        repo: params.repo as string | undefined,
-        json: params.json as boolean | undefined,
-        reviewComment:
-          (params.comment as string | undefined) || (params.reviewComment as string | undefined),
-      });
+      const result = await approveSessionFromParams(
+        {
+          session: params.name as string | undefined,
+          task: params.task as string | undefined,
+          repo: params.repo as string | undefined,
+          json: params.json as boolean | undefined,
+          reviewComment:
+            (params.comment as string | undefined) || (params.reviewComment as string | undefined),
+        },
+        {
+          sessionDB: deps.sessionProvider,
+          gitService: deps.gitService,
+          taskService: deps.taskService,
+          workspaceUtils: deps.workspaceUtils,
+          getCurrentSession: deps.getCurrentSession,
+        }
+      );
 
       return { success: true, result };
     }),


### PR DESCRIPTION
## Summary

Migrates all 12 session commands that bypassed `getDeps()` to use container-managed dependencies. After this change, no command handler creates ad-hoc providers — all session operations use the pre-initialized `sessionProvider` from the DI container.

This eliminates the per-call re-initialization path that amplified the cache-before-init (mt#793) and error-swallowing (mt#794) bugs. With all three fixes together, the MCP `session_list` empty-after-reconnect bug (mt#788) is structurally prevented.

## Changes

**Simple delegates** — replaced `*FromParams` imports with `new SessionService(deps)`:
- `session.list` → `service.list()`
- `session.get` → `service.get()`
- `session.dir` → `service.getDir()`
- `session.inspect` → `service.inspect()`
- `session.delete` → `service.delete()`
- `session.update` → `service.update()`

**Complex commands** — pass container deps to domain functions:
- `session.start` → passes full deps to `startSessionFromParams`
- `session.commit` → passes `deps.sessionProvider` to `sessionCommit`
- `session.approve` / `session.pr.approve` → passes deps to `approveSessionFromParams`
- `session.conflicts` → passes `deps.sessionProvider` to `scanSessionConflicts`
- `session.generate_prompt` → uses `SessionService(deps).get()` for session lookup

## Task

Part of mt#788. Subtask mt#795 (depends on mt#793 PR #463 + mt#794 PR #470, both merged).

Full suite: 1595 pass, 0 fail.