### PR TITLE
fix: correct ESLint rule count and add theory-of-operation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ bun run validate-all   # run all checks (format + lint + typecheck + tests)
 
 ### Custom ESLint rules
 
-The project enforces 11 custom rules under the `custom/` prefix:
+The project enforces 12 custom rules under the `custom/` prefix:
 
 | Rule                            | Level | Purpose                                         |
 | ------------------------------- | ----- | ----------------------------------------------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ This directory contains comprehensive documentation for the Minsky development w
 ## Core Concepts
 
 - [**Domain Concepts**](../src/domain/concepts.md) - Core Minsky concepts (Repository, Session, Workspace)
-- [**Architecture Overview**](../README.md#architecture) - System architecture and design patterns
+- [**Theory of Operation**](./theory-of-operation.md) - How cybernetic theory maps to code modules (VSM, environmental pre-delegation)
+- [**Architecture Overview**](./architecture.md) - System architecture, command registry, persistence, DI
 
 ## Feature Documentation
 


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md: "11 custom rules" → "12 custom rules" (flagged during PR #447 review, table correctly lists 12)
- docs/README.md: added `theory-of-operation.md` link to Core Concepts section (created by mt#764 but never linked from docs index)
- docs/README.md: fixed Architecture Overview link from `../README.md#architecture` anchor (which doesn't exist) to `./architecture.md` (which does)

## Test plan

- [ ] `grep "12 custom rules" CONTRIBUTING.md` returns a hit
- [ ] docs/README.md links to theory-of-operation.md and architecture.md resolve

🤖 Had Claude look into it — AI-assisted cleanup