### PR TITLE
fix(mt#805): remove dead scopeWarning code in prompt generation

### DIFF
--- a/src/domain/session/prompt-generation.ts
+++ b/src/domain/session/prompt-generation.ts
@@ -195,18 +195,12 @@ export function generateSubagentPrompt(params: GeneratePromptParams): GeneratePr
     return result;
   }
 
-  const scopeWarning =
-    scope && scope.length > SCOPE_WARNING_THRESHOLD
-      ? `Scope has ${scope.length} files (exceeds ${SCOPE_WARNING_THRESHOLD}). Consider batching into multiple smaller tasks to stay within subagent capacity limits.`
-      : undefined;
-
   const prompt = generateSinglePrompt(params);
 
   if (type === "review") {
     return {
       prompt,
       suggestedModel: "sonnet",
-      scopeWarning,
     };
   }
 
@@ -215,14 +209,12 @@ export function generateSubagentPrompt(params: GeneratePromptParams): GeneratePr
       prompt,
       suggestedModel: "sonnet",
       suggestedSubagentType: "verify-completion",
-      scopeWarning,
     };
   }
 
   const result: GeneratePromptResult = {
     prompt,
     suggestedModel: "sonnet",
-    scopeWarning,
   };
 
   if (type === "refactor") {


### PR DESCRIPTION
## Summary

Remove dead `scopeWarning` computation that could never trigger — after the `needsBatching` early return, `scope.length > 40` is always false. -8 lines.

The other review finding (unused `getDeps` in prompt-command.ts) was already fixed in a subsequent PR.

(Had Claude look into this — AI-assisted cleanup)