### PR TITLE
fix(mt#769): fix Stop hook output schema and close 8 completed tasks

### DIFF
--- a/.claude/hooks/typecheck-on-stop.ts
+++ b/.claude/hooks/typecheck-on-stop.ts
@@ -7,15 +7,13 @@
 // Consolidates: typecheck-on-stop.sh, typecheck-on-subagent-stop.sh, typecheck-tracked-roots.sh
 
 import { existsSync, readFileSync, unlinkSync } from "fs";
-import { readInput, writeOutput, execSync } from "./types";
+import { readInput, execSync } from "./types";
 import type { StopHookInput } from "./types";
 
 const input = await readInput<StopHookInput>();
 
 const sessionId = input.session_id ?? "default";
 const agentId = input.agent_id;
-const hookEventName = input.hook_event_name ?? "Stop";
-
 // Determine state file: keyed by session_id and (if subagent) agent_id
 const stateFile = agentId
   ? `/tmp/claude-typecheck-roots-${sessionId}-${agentId}.txt`
@@ -59,12 +57,12 @@ for (const root of roots) {
 
 if (failedRoots.length > 0) {
   const preview = allErrors.split("\n").slice(0, 60).join("\n");
-  writeOutput({
-    hookSpecificOutput: {
-      hookEventName,
-      additionalContext: `TypeScript errors must be fixed before completing:\n${preview}\n\nTotal: ${totalCount} error(s). Fix all type errors before returning.`,
-    },
-  });
+  // Stop hooks use decision/reason schema, NOT hookSpecificOutput
+  const output = {
+    decision: "block",
+    reason: `TypeScript errors must be fixed before completing:\n${preview}\n\nTotal: ${totalCount} error(s). Fix all type errors before returning.`,
+  };
+  process.stdout.write(JSON.stringify(output));
   process.exit(2);
 }
 


### PR DESCRIPTION
## Summary

- **Fix Stop hook output schema**: `typecheck-on-stop.ts` was using `hookSpecificOutput` (PostToolUse schema) instead of `decision`/`reason` (Stop hook schema). This caused raw JSON validation errors to be shown to users instead of routing the error to Claude for action.
- **Close 8 completed tasks**: mt#033, mt#159, mt#254, mt#403, mt#405, mt#523, mt#529, mt#770 — all verified as already done through prior work.
- **Create follow-up tasks**: mt#812 (aspirational review), mt#813 (KEEP tasks priority work).

## Test plan

- [x] TypeScript compiles cleanly
- [x] Stop hook no longer uses hookSpecificOutput
- [x] Stop hook uses `decision: "block"` + `reason:` for type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)