### PR TITLE
feat(mt#675): Adopt tsgo (native TypeScript compiler) for type checking hooks

### DIFF
--- a/.claude/hooks/SPEC.md
+++ b/.claude/hooks/SPEC.md
@@ -49,8 +49,8 @@ All hooks share types and a sync exec helper from `types.ts`. They are self-cont
 3. Exits silently if file is not `.ts` or `.tsx`
 4. **Session-aware root detection**: if file path starts with `$HOME/.local/state/minsky/sessions/`, extracts session root; otherwise uses `$CLAUDE_PROJECT_DIR`
 5. **State tracking**: appends `project_root` to `/tmp/claude-typecheck-roots-${session_id}-${agent_id}.txt` (or `-main.txt` if no agent_id)
-6. Runs `bunx tsc --incremental` in the project root
-7. On tsc failure, filters errors into two categories:
+6. Runs `bunx @typescript/native-preview --noEmit` (tsgo) in the project root
+7. On tsgo failure, filters errors into two categories:
    - **File errors**: lines starting with `${relative_path}(` — errors in the edited file
    - **Cascade errors**: remaining errors in other files
 8. Outputs structured JSON with error preview (first 10 lines of file errors) and cascade count
@@ -103,7 +103,7 @@ Handles both **Stop** and **SubagentStop** events. Determines which state file t
 4. For each root:
    - Skips if directory doesn't exist
    - Skips if no `tsconfig.json`
-   - Runs `bunx tsc` (full, no `--incremental`) and captures output
+   - Runs `bunx @typescript/native-preview --noEmit` (tsgo, full check) and captures output
    - Counts errors matching `): error TS`
    - Collects errors with `=== ${root} ===` header
 5. If any root failed: outputs JSON with first 60 lines of errors + total count, exits 2
@@ -178,7 +178,7 @@ Exit code 2 is a **blocking error** in Claude Code — the agent is forced to co
 2. **JSON output schema**: `hookSpecificOutput` structure must match exactly — Claude Code parses it
 3. **State file paths**: `/tmp/claude-typecheck-roots-${session_id}-${agent_id|main}.txt` — edit writes, stop reads+deletes
 4. **Session root detection**: `$HOME/.local/state/minsky/sessions/<uuid>/` prefix check
-5. **tsc modes**: `--incremental` for edit (fast feedback), full for stop (correctness gate)
+5. **tsgo modes**: `--noEmit` for edit (fast feedback), `--noEmit` full for stop (correctness gate)
 6. **Error filtering**: edit hook separates file-local vs cascade errors; stop hook aggregates all
 7. **Review gate**: checks both review existence AND spec verification in review body
 8. **Post-merge pull**: ff-only, warns only if src/ changed

--- a/.claude/hooks/SPEC.md
+++ b/.claude/hooks/SPEC.md
@@ -178,7 +178,7 @@ Exit code 2 is a **blocking error** in Claude Code — the agent is forced to co
 2. **JSON output schema**: `hookSpecificOutput` structure must match exactly — Claude Code parses it
 3. **State file paths**: `/tmp/claude-typecheck-roots-${session_id}-${agent_id|main}.txt` — edit writes, stop reads+deletes
 4. **Session root detection**: `$HOME/.local/state/minsky/sessions/<uuid>/` prefix check
-5. **tsgo modes**: `--noEmit` for edit (fast feedback), `--noEmit` full for stop (correctness gate)
+5. **tsgo**: `--noEmit` for both edit and stop; edit checks single root (fast feedback), stop checks all tracked roots (correctness gate)
 6. **Error filtering**: edit hook separates file-local vs cascade errors; stop hook aggregates all
 7. **Review gate**: checks both review existence AND spec verification in review body
 8. **Post-merge pull**: ff-only, warns only if src/ changed

--- a/.claude/hooks/typecheck-on-edit.ts
+++ b/.claude/hooks/typecheck-on-edit.ts
@@ -50,8 +50,8 @@ const stateFile = agentId
 
 appendFileSync(stateFile, `${projectRoot}\n`);
 
-// Run tsc with --incremental for fast feedback
-const result = execSync(["bunx", "tsc", "--incremental"], { cwd: projectRoot });
+// Run tsgo (native TypeScript compiler) with --noEmit for fast feedback
+const result = execSync(["bunx", "@typescript/native-preview", "--noEmit"], { cwd: projectRoot });
 
 if (result.exitCode !== 0) {
   const output = result.stdout || result.stderr;

--- a/.claude/hooks/typecheck-on-stop.ts
+++ b/.claude/hooks/typecheck-on-stop.ts
@@ -44,8 +44,8 @@ for (const root of roots) {
   if (!existsSync(root)) continue;
   if (!existsSync(`${root}/tsconfig.json`)) continue;
 
-  // Run full tsc (NO --incremental — correctness gate)
-  const result = execSync(["bunx", "tsc"], { cwd: root });
+  // Run full tsgo (native TypeScript compiler, NO --incremental — correctness gate)
+  const result = execSync(["bunx", "@typescript/native-preview", "--noEmit"], { cwd: root });
   if (result.exitCode !== 0) {
     const output = result.stdout || result.stderr;
     const count = output.split("\n").filter((line) => line.includes("): error TS")).length;

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@types/node": "^22.15.17",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260419.1",
         "@valibot/to-json-schema": "^1.3.0",
         "bun-types": "latest",
         "effect": "^3.16.12",
@@ -405,6 +406,22 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.34.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.34.1", "@typescript-eslint/types": "8.34.1", "@typescript-eslint/typescript-estree": "8.34.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.34.1", "", { "dependencies": { "@typescript-eslint/types": "8.34.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260419.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260419.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260419.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260419.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260419.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260419.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260419.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260419.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-PzN1nqNe0B4vqyUzZD0Da9LbbdOYhcjLVS0Rkd/lDZEuLuovZCdIpXg1hz2S7JnD4P5P+Uy1aAdO5ubv8vQVTw=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260419.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qgoZvmBsEE928tqDg7l27qciCrCWRU5bXdiWUykkt4+er3OaNYKUt+UtJvNiuNxiPaVwnRMEjnVyFiO/KNo3gA=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260419.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-3+bXF/Mi4u3jbtuPp0gO4bjk+uaDhQLWR/h7JRrmL6KgVJQ9uywEOorx+1SgbidH6a1neO/pUPAlCvJ7+9zUQA=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260419.1", "", { "os": "linux", "cpu": "arm" }, "sha512-e+BjeErUxpHb8FAYfCCrM9MvAl7yL4eYpYEW3jAaPle/K2+6BJPnUpytgB1fbrMWDmbnTWhC4m9NgTPfNHznxA=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260419.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-cxK8SJ0tLeAV67hKfPEkPyv6rDIeL8AyGFHJFMz+gz3mKNy6ZEPK+9B8fl/JFGPylOhspgm6+IqFepRJcw74eg=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260419.1", "", { "os": "linux", "cpu": "x64" }, "sha512-6cf/o48dN5px6mrW8Hq7duGpimoCFAlpEsgbjYWex8Vjv2EH+S1QcWUbh3L0cAhygnxnb4f2gwovBGJqKgf6jg=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260419.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-yz7AxGsNf1cueTUv0SF5Q1LvRGVHh+F4cSwmwucGVkHJGKdLCQO7cLs4MTFY0gcqsLNr7qKH7gMh5WCQqsPVXQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260419.1", "", { "os": "win32", "cpu": "x64" }, "sha512-3sXtVGB4dt/kNp/bQMj0H1q7WhFzVe//rTin9DWV9CpbPXY+Ue8aUIRNevneHBPp5zSsBkkJlg1BlMH1Z87mGA=="],
 
     "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.7.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg=="],
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/node": "^22.15.17",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260419.1",
     "@valibot/to-json-schema": "^1.3.0",
     "bun-types": "latest",
     "effect": "^3.16.12",

--- a/src/adapters/shared/commands/validate.ts
+++ b/src/adapters/shared/commands/validate.ts
@@ -144,7 +144,7 @@ export function registerValidateCommands(): void {
       execute: async (params): Promise<TypecheckResult> => {
         const workspacePath = (params.workspace as string | undefined) ?? process.cwd();
 
-        const proc = Bun.spawn(["bunx", "tsc", "--noEmit"], {
+        const proc = Bun.spawn(["bunx", "@typescript/native-preview", "--noEmit"], {
           cwd: workspacePath,
           stdout: "pipe",
           stderr: "pipe",
@@ -155,7 +155,7 @@ export function registerValidateCommands(): void {
         await new Response(proc.stderr).text();
         await proc.exited;
 
-        // Parse tsc output lines matching: file(line,col): error TSxxxx: message
+        // Parse tsgo output lines matching: file(line,col): error TSxxxx: message
         const errorPattern = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.+)$/;
         const errors: TypecheckError[] = [];
 

--- a/src/domain/task-status-bug-regression.test.ts
+++ b/src/domain/task-status-bug-regression.test.ts
@@ -4,6 +4,7 @@
  * prevents the "status is not defined" error from recurring.
  */
 
+import { describe, test, expect } from "bun:test";
 import { TASK_PARSING_UTILS, TaskStatus } from "./tasks/taskConstants";
 
 describe("Task Status Bug Regression Tests", () => {

--- a/src/domain/task-status-variables.test.ts
+++ b/src/domain/task-status-variables.test.ts
@@ -4,6 +4,7 @@
  * prevents the "status is not defined" error from recurring.
  */
 
+import { describe, test, expect } from "bun:test";
 import { TASK_PARSING_UTILS, TaskStatus } from "./tasks/taskConstants";
 
 describe("Task Status Variables Regression Tests", () => {

--- a/src/hooks/pre-commit.ts
+++ b/src/hooks/pre-commit.ts
@@ -367,7 +367,7 @@ export class PreCommitHook {
     log.cli("🔎 Running TypeScript type check...");
 
     try {
-      await execAsync("bunx tsc --noEmit", {
+      await execAsync("bunx @typescript/native-preview --noEmit", {
         cwd: this.projectRoot,
         timeout: 60000,
       });

--- a/tests/integration/ai-completion-service-error-handling.integration.test.ts
+++ b/tests/integration/ai-completion-service-error-handling.integration.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach } from "bun:test";
+
 beforeEach(() => {
   console.log("🔄 Setting up enhanced error handling test environment");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "typeRoots": ["./node_modules/@types", "./types"],
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": ["bun"]
   },
   "include": ["src", "types", "tests", ".eslintrc.cjs", ".prettierrc.cjs"],
   "exclude": [


### PR DESCRIPTION
## Summary

- Installs `@typescript/native-preview` (tsgo) as a dev dependency — the native Go-based TypeScript compiler that is 10-100x faster than `tsc`
- Updates both typecheck hooks (edit + stop) to use `bunx @typescript/native-preview --noEmit` instead of `bunx tsc`
- Adds `"types": ["bun"]` to `tsconfig.json` to resolve Bun global type errors that tsgo surfaces (tsgo is stricter about missing type declarations)
- Fixes missing `bun:test` imports in three test files that tsgo caught as errors
- Updates `SPEC.md` to document the tsgo-based behavior

## Changes

- `.claude/hooks/typecheck-on-edit.ts` — swap `["bunx", "tsc", "--incremental"]` → `["bunx", "@typescript/native-preview", "--noEmit"]`
- `.claude/hooks/typecheck-on-stop.ts` — swap `["bunx", "tsc"]` → `["bunx", "@typescript/native-preview", "--noEmit"]`
- `.claude/hooks/SPEC.md` — update behavioral documentation to reference tsgo
- `tsconfig.json` — add `"types": ["bun"]` compiler option
- `package.json` / `bun.lock` — add `@typescript/native-preview` dev dependency
- `src/domain/task-status-bug-regression.test.ts` — add missing `bun:test` imports
- `src/domain/task-status-variables.test.ts` — add missing `bun:test` imports
- `tests/integration/ai-completion-service-error-handling.integration.test.ts` — add missing `bun:test` import

## Verification

- `bunx @typescript/native-preview --noEmit` completes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude implement the tsgo adoption)