### PR TITLE
chore(mt#675): Clean up remaining tsc references after tsgo adoption

### DIFF
--- a/.claude/agents/refactor.md
+++ b/.claude/agents/refactor.md
@@ -20,7 +20,7 @@ The parent agent will give you:
 - ALL file operations use ABSOLUTE paths
 - Use MCP tools for git operations: `mcp__minsky__session_commit`, `mcp__minsky__session_pr_create`. NEVER use bare `git` commands.
 - Use the parent's specified session directory; do not start your own session
-- Trust the pre-commit hook for tsc/lint/test verification — do not manually run them before committing
+- Trust the pre-commit hook for type-check/lint/test verification — do not manually run them before committing
 - Read files BEFORE editing them
 
 # Coherence verification protocol — MANDATORY
@@ -68,7 +68,7 @@ Your final summary MUST include this structured section, not buried in prose:
 - _"I'll keep the comments for context"_ → stale comments that mislead future readers. **Fix**: rewrite or delete them.
 - _"I'll mark this with TODO"_ → deferring a 30-second cleanup that the next person will pay 30 minutes to understand. **Fix**: do it now.
 - _"The original file name is fine"_ → after a refactor, names often become misleading. **Fix**: rename when the meaning shifts.
-- _"Tests pass so it's done"_ → tsc and tests pass even when the structure is incoherent. **Fix**: structural coherence is a separate gate from test correctness.
+- _"Tests pass so it's done"_ → type checker and tests pass even when the structure is incoherent. **Fix**: structural coherence is a separate gate from test correctness.
 - _"That's out of scope for this PR"_ → the cleanup directly caused by your change is _in_ scope. Filing follow-up tasks for trivial cleanup is a tax on the next reader.
 
 # Incremental commits — MANDATORY for large changes

--- a/.claude/hooks/typecheck-on-edit.ts
+++ b/.claude/hooks/typecheck-on-edit.ts
@@ -3,7 +3,7 @@
 //
 // Two responsibilities:
 //   1. Track which project root was edited (state file for Stop/SubagentStop hooks)
-//   2. Run incremental tsc in that root, show smart-filtered errors as context
+//   2. Run incremental tsgo in that root, show smart-filtered errors as context
 //
 // Does NOT block — Stop/SubagentStop hooks enforce correctness at turn end.
 
@@ -28,7 +28,7 @@ if (!/\.tsx?$/.test(filePath)) {
   process.exit(0);
 }
 
-// Determine the right project root to run tsc from.
+// Determine the right project root to run tsgo from.
 // If the file is in a Minsky session dir, use that session's root.
 // Otherwise, use the main project dir.
 const sessionsDir = `${os.homedir()}/.local/state/minsky/sessions/`;
@@ -55,7 +55,7 @@ const result = execSync(["bunx", "@typescript/native-preview", "--noEmit"], { cw
 
 if (result.exitCode !== 0) {
   const output = result.stdout || result.stderr;
-  // Compute relative path from project root for matching tsc output
+  // Compute relative path from project root for matching tsgo output
   const relPath = filePath.startsWith(`${projectRoot}/`)
     ? filePath.slice(projectRoot.length + 1)
     : filePath;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Run the formatter and linter:
 bun run format:check   # check formatting (Prettier)
 bun run format:all     # format and auto-fix lint issues
 bun run lint           # ESLint only
-bun run typecheck      # tsc --noEmit
+bun run typecheck      # tsgo --noEmit
 bun run validate-all   # run all checks (format + lint + typecheck + tests)
 ```
 
@@ -207,7 +207,7 @@ quality gates in order from fastest to slowest:
 1. **Code formatting** — Prettier via lint-staged (staged files only, ~1s)
 2. **Console usage validation** — catches bare `console.log` in non-test code (~1s)
 3. **Variable naming check** — underscore prefix mismatch detection (~1s)
-4. **TypeScript type checking** — `tsc --noEmit` (~5s)
+4. **TypeScript type checking** — `tsgo --noEmit` (~1.5s)
 5. **ESLint** — full lint with zero-error gate (~5–10s)
 6. **Secret scanning** — gitleaks (~2–3s)
 7. **Unit tests** — full test suite (~15–30s)

--- a/docs/architecture/agent-guidance-mechanisms.md
+++ b/docs/architecture/agent-guidance-mechanisms.md
@@ -50,7 +50,7 @@ Minsky's hook architecture:
 | `check-prompt-watermark.ts`      | PreToolUse (merge) | Validates prompt watermark before merge          | Yes     |
 | `validate-task-spec.ts`          | PreToolUse         | Validates task spec structure                    | Yes     |
 
-Hooks can't detect semantic coherence (that requires understanding, not pattern matching), but they can enforce mechanical correctness (tsc, lint) and workflow invariants (review required).
+Hooks can't detect semantic coherence (that requires understanding, not pattern matching), but they can enforce mechanical correctness (type checking, lint) and workflow invariants (review required).
 
 ## The strength ordering
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:console": "bun scripts/lint-console-usage.ts",
     "lint:console:strict": "bun scripts/lint-console-usage.ts --fail-on-error",
     "validate-commit": "bun scripts/validate-commit-message.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bunx @typescript/native-preview --noEmit",
     "validate-all": "bun run format:check && bun run lint && bun run lint:console:strict && bun run typecheck && bun run test",
     "secrets:gitleaks": "gitleaks detect --source . --verbose",
     "secrets:scan": "gitleaks detect --source . --verbose",

--- a/src/domain/context/components/error-context.ts
+++ b/src/domain/context/components/error-context.ts
@@ -310,7 +310,7 @@ export const ErrorContextComponent: ContextComponent = {
         content += `4. **Fix import errors** - ${errorInputs.errorsByCategory["import-error"].length} module resolution issues\n`;
       }
 
-      content += `5. **Run type checker**: Use \`tsc --noEmit\` for full error detection\n`;
+      content += `5. **Run type checker**: Run the project's type checker (e.g. \`bun run typecheck\`) for full error detection\n`;
       content += `6. **Run linter**: Use \`eslint --fix\` for automated fixes\n`;
     }
 


### PR DESCRIPTION
## Summary

- Updates `package.json` typecheck script to use tsgo instead of tsc
- Updates `CONTRIBUTING.md` docs and timing (~5s → ~1.5s)
- Makes `error-context.ts` type checker guidance generic instead of hardcoding `tsc --noEmit`
- Updates comments in `typecheck-on-edit.ts` from tsc to tsgo
- Genericizes tsc references in `refactor.md` and `agent-guidance-mechanisms.md`

Follow-up to PR #489 which did the core tsgo adoption.

## Test plan

- [ ] `bun run typecheck` invokes tsgo and passes
- [ ] No remaining functional references to `tsc` in hooks or scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude do the cleanup)