### PR TITLE
fix(gh#491): auto-register task commands for MCP from single source

### DIFF
--- a/src/adapters/shared/commands/tasks-modular.ts
+++ b/src/adapters/shared/commands/tasks-modular.ts
@@ -1,384 +1,48 @@
 /**
  * Modular Tasks Commands
  *
- * Lightweight replacement for the original tasks commands using the Command Pattern.
- * This reduces duplication and improves maintainability by creating commands on-demand.
+ * Registers task commands in the shared command registry for MCP exposure.
+ * Uses createAllTaskCommands() from registry-setup as the single source of truth,
+ * eliminating dual-registration bugs where a command is added to CLI but not MCP.
  */
-import { sharedCommandRegistry, defineCommand } from "../command-registry";
+import { sharedCommandRegistry } from "../command-registry";
 import { CommandCategory } from "../command-registry";
 import { log } from "../../../utils/logger";
 import type { AppContainerInterface } from "../../../composition/types";
-// PersistenceService is lazy-imported inside the closure to avoid loading
-// the persistence module (~95ms) during command registration.
-import {
-  createTasksListCommand,
-  createTasksGetCommand,
-  createTasksCreateCommand,
-  createTasksDeleteCommand,
-} from "./tasks/crud-commands";
-import { createTasksSpecCommand } from "./tasks/spec-command";
-import { createTasksStatusGetCommand, createTasksStatusSetCommand } from "./tasks/status-commands";
-import { createTasksEditCommand } from "./tasks/edit-commands";
-import { createTasksMigrateBackendCommand } from "./tasks/migrate-backend-command";
-import { TasksSimilarCommand, TasksSearchCommand } from "./tasks/similarity-commands";
-import { TasksIndexEmbeddingsCommand } from "./tasks/index-embeddings-command";
-import { TasksEmbeddingsStatusCommand } from "./tasks/embeddings-status-command";
-import { TasksEmbeddingsRepairCommand } from "./tasks/embeddings-repair-command";
-import {
-  createTasksDepsAddCommand,
-  createTasksDepsRmCommand,
-  createTasksDepsListCommand,
-} from "./tasks/deps-commands";
-import {
-  createTasksDepsTreeCommand,
-  createTasksDepsGraphCommand,
-} from "./tasks/deps-visualization-commands";
-import { createTasksAvailableCommand, createTasksRouteCommand } from "./tasks/routing-commands";
+import { createAllTaskCommands } from "./tasks/registry-setup";
 
 /**
  * Modular Tasks Command Manager
  *
- * Manages task commands using the Command Pattern with lazy loading.
- * Commands are created on-demand to avoid circular dependencies.
+ * Registers all task commands from the canonical createAllTaskCommands() source.
+ * Adding a command to registry-setup.ts automatically makes it available via MCP.
  */
 export class ModularTasksCommandManager {
   /**
-   * Register all task commands in the shared command registry
+   * Register all task commands in the shared command registry.
+   *
+   * Uses createAllTaskCommands() as the single source of truth.
+   * Each command is wrapped with category: CommandCategory.TASKS
+   * so the MCP bridge can discover it.
    */
   registerAllCommands(container?: AppContainerInterface): void {
-    // Register all tasks commands using static imports
     try {
-      log.debug("[ModularTasksCommandManager] Starting registerAllCommands");
+      log.debug("[ModularTasksCommandManager] Auto-registering all task commands");
 
-      // Create command instances to get their parameter definitions
-      log.debug("[ModularTasksCommandManager] Creating command instances");
-      // Lazy: PersistenceService is imported on first call, not at registration.
-      // By command execution time, the preAction hook in cli.ts has already
-      // initialized PersistenceService, so getProvider() is safe to call sync.
-      let cachedPersistence: {
-        getProvider: () => import("../../../domain/persistence/types").PersistenceProvider;
-      } | null = null;
-      const getPersistenceProvider = () => {
-        if (container?.has("persistence")) {
-          return container.get("persistence");
-        }
-        if (!cachedPersistence) {
-          cachedPersistence = require("../../../domain/persistence/service").PersistenceService;
-        }
-        return cachedPersistence!.getProvider();
-      };
-      const listCommand = createTasksListCommand();
-      const getCommand = createTasksGetCommand();
-      const createCommand = createTasksCreateCommand(getPersistenceProvider);
-      const editCommand = createTasksEditCommand();
-      const deleteCommand = createTasksDeleteCommand();
-      const specCommand = createTasksSpecCommand();
-      const statusGetCommand = createTasksStatusGetCommand();
-      const statusSetCommand = createTasksStatusSetCommand();
-      const migrateBackendCommand = createTasksMigrateBackendCommand();
+      const commands = createAllTaskCommands(container);
 
-      const similarCommand = new TasksSimilarCommand();
-      const searchCommand = new TasksSearchCommand();
-      const indexEmbeddingsCommand = new TasksIndexEmbeddingsCommand();
-      const embeddingsStatusCommand = new TasksEmbeddingsStatusCommand();
-      const embeddingsRepairCommand = new TasksEmbeddingsRepairCommand();
-      const depsAddCommand = createTasksDepsAddCommand(getPersistenceProvider);
-      const depsRmCommand = createTasksDepsRmCommand(getPersistenceProvider);
-      const depsListCommand = createTasksDepsListCommand(getPersistenceProvider);
-      const depsTreeCommand = createTasksDepsTreeCommand(getPersistenceProvider);
-      const depsGraphCommand = createTasksDepsGraphCommand(getPersistenceProvider);
-
-      const availableCommand = createTasksAvailableCommand(getPersistenceProvider);
-      const routeCommand = createTasksRouteCommand(getPersistenceProvider);
-
-      // Register list command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.list",
+      for (const command of commands) {
+        sharedCommandRegistry.registerCommand({
+          id: command.id,
           category: CommandCategory.TASKS,
-          name: "list",
-          description: "List tasks",
-          parameters: listCommand.parameters,
-          execute: async (params, context) => {
-            return await listCommand.execute(params, context);
-          },
-        })
-      );
+          name: command.name,
+          description: command.description,
+          parameters: command.parameters,
+          execute: command.execute,
+        });
+      }
 
-      // Register get command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.get",
-          category: CommandCategory.TASKS,
-          name: "get",
-          description: "Get task details",
-          parameters: getCommand.parameters,
-          execute: async (params, context) => {
-            return await getCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register create command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.create",
-          category: CommandCategory.TASKS,
-          name: "create",
-          description: "Create a new task",
-          parameters: createCommand.parameters,
-          execute: async (params, context) => {
-            return await createCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register edit command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.edit",
-          category: CommandCategory.TASKS,
-          name: "edit",
-          description: "Edit task title and/or specification content",
-          parameters: editCommand.parameters,
-          execute: async (params, context) => {
-            return await editCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register delete command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.delete",
-          category: CommandCategory.TASKS,
-          name: "delete",
-          description: "Delete a task",
-          parameters: deleteCommand.parameters,
-          execute: async (params, context) => {
-            return await deleteCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register spec get command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.spec.get",
-          category: CommandCategory.TASKS,
-          name: "get",
-          description: "Get task specification content",
-          parameters: specCommand.parameters,
-          execute: async (params, context) => {
-            return await specCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register spec edit command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.spec.edit",
-          category: CommandCategory.TASKS,
-          name: "edit",
-          description: "Edit task specification content",
-          parameters: editCommand.parameters,
-          execute: async (params, context) => {
-            // For spec edit, we only allow spec-related parameters
-            const specParams = {
-              ...params,
-              title: undefined, // Don't allow title editing in spec edit
-            };
-            return await editCommand.execute(specParams, context);
-          },
-        })
-      );
-
-      // Register status get command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.status.get",
-          category: CommandCategory.TASKS,
-          name: "get",
-          description: "Get the status of a task",
-          parameters: statusGetCommand.parameters,
-          execute: async (params, context) => {
-            return await statusGetCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register status set command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.status.set",
-          category: CommandCategory.TASKS,
-          name: "set",
-          description: "Set the status of a task",
-          parameters: statusSetCommand.parameters,
-          execute: async (params, context) => {
-            return await statusSetCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register migrate-backend command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: "tasks.migrate-backend",
-          category: CommandCategory.TASKS,
-          name: "migrate-backend",
-          description: "Migrate tasks between different backends (minsky, github)",
-          parameters: migrateBackendCommand.parameters,
-          execute: async (params, context) => {
-            return await migrateBackendCommand.execute(params, context);
-          },
-        })
-      );
-
-      // Register similarity commands
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: similarCommand.id,
-          category: CommandCategory.TASKS,
-          name: similarCommand.name,
-          description: similarCommand.description,
-          parameters: similarCommand.parameters,
-          execute: (params, ctx) =>
-            similarCommand.execute(
-              params as Parameters<typeof similarCommand.execute>[0],
-              ctx as Parameters<typeof similarCommand.execute>[1]
-            ),
-        })
-      );
-
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: searchCommand.id,
-          category: CommandCategory.TASKS,
-          name: searchCommand.name,
-          description: searchCommand.description,
-          parameters: searchCommand.parameters,
-          execute: (params, ctx) =>
-            searchCommand.execute(
-              params as Parameters<typeof searchCommand.execute>[0],
-              ctx as Parameters<typeof searchCommand.execute>[1]
-            ),
-        })
-      );
-
-      // Register index embeddings command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: indexEmbeddingsCommand.id,
-          category: CommandCategory.TASKS,
-          name: indexEmbeddingsCommand.name,
-          description: indexEmbeddingsCommand.description,
-          parameters: indexEmbeddingsCommand.parameters,
-          execute: (params, ctx) =>
-            indexEmbeddingsCommand.execute(
-              params as Parameters<typeof indexEmbeddingsCommand.execute>[0],
-              ctx as Parameters<typeof indexEmbeddingsCommand.execute>[1]
-            ),
-        })
-      );
-
-      // Register embeddings status command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: embeddingsStatusCommand.id,
-          category: CommandCategory.TASKS,
-          name: embeddingsStatusCommand.name,
-          description: embeddingsStatusCommand.description,
-          parameters: embeddingsStatusCommand.parameters,
-          execute: (params, ctx) =>
-            embeddingsStatusCommand.execute(
-              params as Parameters<typeof embeddingsStatusCommand.execute>[0],
-              ctx as Parameters<typeof embeddingsStatusCommand.execute>[1]
-            ),
-        })
-      );
-
-      // Register embeddings repair command
-      sharedCommandRegistry.registerCommand(
-        defineCommand({
-          id: embeddingsRepairCommand.id,
-          category: CommandCategory.TASKS,
-          name: embeddingsRepairCommand.name,
-          description: embeddingsRepairCommand.description,
-          parameters: embeddingsRepairCommand.parameters,
-          execute: (params, ctx) =>
-            embeddingsRepairCommand.execute(
-              params as Parameters<typeof embeddingsRepairCommand.execute>[0],
-              ctx as Parameters<typeof embeddingsRepairCommand.execute>[1]
-            ),
-        })
-      );
-
-      // Register deps commands using the command objects directly
-      sharedCommandRegistry.registerCommand({
-        id: depsAddCommand.id,
-        category: CommandCategory.TASKS,
-        name: depsAddCommand.name,
-        description: depsAddCommand.description,
-        parameters: depsAddCommand.parameters,
-        execute: depsAddCommand.execute,
-      });
-
-      sharedCommandRegistry.registerCommand({
-        id: depsRmCommand.id,
-        category: CommandCategory.TASKS,
-        name: depsRmCommand.name,
-        description: depsRmCommand.description,
-        parameters: depsRmCommand.parameters,
-        execute: depsRmCommand.execute,
-      });
-
-      sharedCommandRegistry.registerCommand({
-        id: depsListCommand.id,
-        category: CommandCategory.TASKS,
-        name: depsListCommand.name,
-        description: depsListCommand.description,
-        parameters: depsListCommand.parameters,
-        execute: depsListCommand.execute,
-      });
-
-      sharedCommandRegistry.registerCommand({
-        id: depsTreeCommand.id,
-        category: CommandCategory.TASKS,
-        name: depsTreeCommand.name,
-        description: depsTreeCommand.description,
-        parameters: depsTreeCommand.parameters,
-        execute: depsTreeCommand.execute,
-      });
-
-      sharedCommandRegistry.registerCommand({
-        id: depsGraphCommand.id,
-        category: CommandCategory.TASKS,
-        name: depsGraphCommand.name,
-        description: depsGraphCommand.description,
-        parameters: depsGraphCommand.parameters,
-        execute: depsGraphCommand.execute,
-      });
-
-      // Register routing commands
-      sharedCommandRegistry.registerCommand({
-        id: availableCommand.id,
-        category: CommandCategory.TASKS,
-        name: availableCommand.name,
-        description: availableCommand.description,
-        parameters: availableCommand.parameters,
-        execute: availableCommand.execute,
-      });
-
-      sharedCommandRegistry.registerCommand({
-        id: routeCommand.id,
-        category: CommandCategory.TASKS,
-        name: routeCommand.name,
-        description: routeCommand.description,
-        parameters: routeCommand.parameters,
-        execute: routeCommand.execute,
-      });
+      log.debug(`[ModularTasksCommandManager] Registered ${commands.length} task commands`);
     } catch (error) {
       log.warn(
         `Failed to register task commands: ${error instanceof Error ? error.message : String(error)}`


### PR DESCRIPTION
## Summary

**Bug fix:** `tasks.children`, `tasks.parent`, and `tasks.dispatch` were added to `registry-setup.ts` (CLI) but not `tasks-modular.ts` (MCP). They worked in CLI but were invisible as MCP tools.

**Structural fix:** Replaced ~360 lines of manual per-command registration in `tasks-modular.ts` with a 10-line loop over `createAllTaskCommands()`. Now the CLI registry and MCP registry use the **same source of truth** — adding a command to `registry-setup.ts` automatically makes it available via MCP.

### Before (dual registration, error-prone)
```
// registry-setup.ts — CLI
createTasksChildrenCommand(getPersistenceProvider),
// tasks-modular.ts — MCP (MANUALLY, SEPARATELY)
sharedCommandRegistry.registerCommand({
  id: childrenCommand.id,
  category: CommandCategory.TASKS,
  ...
});
```

### After (single source)
```
// registry-setup.ts — single source
createTasksChildrenCommand(getPersistenceProvider),
// tasks-modular.ts — auto-registers ALL commands
for (const command of createAllTaskCommands(container)) {
  sharedCommandRegistry.registerCommand({ ...command, category: CommandCategory.TASKS });
}
```

## Spec verification

**Task:** gh#491

| Criterion | Status | Evidence |
|---|---|---|
| tasks.children/parent/dispatch appear as MCP tools | Met | Auto-registered from createAllTaskCommands |
| tasks-modular.ts auto-registers from single source | Met | Loop replaces 360 lines of manual registration |
| New commands automatically available via MCP | Met | No second registration step needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)