### PR TITLE
refactor(mt#814): convert PersistenceService from static singleton to injectable instance

### DIFF
--- a/src/adapters/shared/commands/tasks/similarity-commands.ts
+++ b/src/adapters/shared/commands/tasks/similarity-commands.ts
@@ -328,11 +328,13 @@ export async function createTaskSimilarityService(): Promise<TaskSimilarityServi
 
   const embedding = await createEmbeddingServiceFromConfig();
 
-  // Use PersistenceService (should already be initialized at application startup)
-  const { PersistenceService } = await import("../../../../domain/persistence/service");
+  // Use the default PersistenceService instance (initialized at application startup)
+  const { defaultInstance: persistenceService } = await import(
+    "../../../../domain/persistence/service"
+  );
 
-  // Get vector storage directly - throws if provider doesn't support it (now synchronous!)
-  const vectorStorage = PersistenceService.getVectorStorage(dimension);
+  // Get vector storage directly - throws if provider doesn't support it
+  const vectorStorage = persistenceService.getVectorStorage(dimension);
 
   // Minimal task resolvers reuse domain functions via dynamic import to avoid cycles
   const { createConfiguredTaskService } = await import("../../../../domain/tasks/taskService");

--- a/src/adapters/shared/commands/tasks/startup-embedding-sweep.ts
+++ b/src/adapters/shared/commands/tasks/startup-embedding-sweep.ts
@@ -11,9 +11,11 @@ export async function triggerStartupEmbeddingSweep(): Promise<void> {
 
   // Check if persistence supports SQL — use PersistenceService since this
   // runs at startup outside a command execution context (no container available)
-  const { PersistenceService } = await import("../../../../domain/persistence/service");
-  if (!PersistenceService.isInitialized()) return;
-  const provider = PersistenceService.getProvider();
+  const { defaultInstance: persistenceService } = await import(
+    "../../../../domain/persistence/service"
+  );
+  if (!persistenceService.isInitialized()) return;
+  const provider = persistenceService.getProvider();
   if (!provider.capabilities.sql) return;
 
   // Find tasks missing embeddings

--- a/src/composition/cli.ts
+++ b/src/composition/cli.ts
@@ -27,14 +27,17 @@ export async function createCliContainer(): Promise<AppContainerInterface> {
   container.register(
     "persistence",
     async () => {
-      const { PersistenceService } = await import("../domain/persistence/service");
-      await PersistenceService.initialize();
-      return PersistenceService.getProvider();
+      // Use the defaultInstance during migration — code that hasn't been
+      // migrated to container access still uses defaultInstance.getProvider().
+      // Once all callers use the container, this can create a fresh instance.
+      const { defaultInstance } = await import("../domain/persistence/service");
+      await defaultInstance.initialize();
+      return defaultInstance.getProvider();
     },
     {
       dispose: async () => {
-        const { PersistenceService } = await import("../domain/persistence/service");
-        await PersistenceService.close();
+        const { defaultInstance } = await import("../domain/persistence/service");
+        await defaultInstance.close();
       },
     }
   );

--- a/src/domain/persistence/architecture.test.ts
+++ b/src/domain/persistence/architecture.test.ts
@@ -58,19 +58,19 @@ describe("Cache-before-init detection", () => {
     const source = getSource(PATHS.persistenceService);
 
     const method = source.match(
-      /private static async performInitialization[\s\S]*?throw error;\s*\}/
+      /private async performInitialization[\s\S]*?throw error;\s*\}/
     )?.[0];
     expect(method).toBeDefined();
 
     const initIdx = method!.indexOf("await provider.initialize()");
-    const assignIdx = method!.indexOf("PersistenceService.provider = provider");
+    const assignIdx = method!.indexOf("this.provider = provider");
     expect(initIdx).toBeGreaterThan(-1);
     expect(assignIdx).toBeGreaterThan(-1);
     expect(assignIdx).toBeGreaterThan(initIdx);
 
     // Verify: catch block nulls provider
     const catchBlock = method!.match(/catch[\s\S]*?throw error/)?.[0];
-    expect(catchBlock).toContain("PersistenceService.provider = null");
+    expect(catchBlock).toContain("this.provider = null");
   });
 
   test("PostgresPersistenceProvider.initialize() assigns fields only after SELECT 1 verification", () => {

--- a/src/domain/persistence/service.test.ts
+++ b/src/domain/persistence/service.test.ts
@@ -7,31 +7,15 @@
  * - getProvider() throws
  * - retry re-attempts initialization
  */
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { PersistenceService } from "./service";
 
 const FAKE_CONNECTION_STRING = "postgresql://fake";
 const DB_UNAVAILABLE = "DB unavailable";
 
-// Save original state so we can restore it
-let originalProvider: unknown;
-
-beforeEach(async () => {
-  // Capture the current provider state
-  originalProvider = (PersistenceService as unknown as { provider: unknown }).provider;
-  // Reset to clean state
-  await PersistenceService.reset();
-});
-
-afterEach(async () => {
-  // Restore original state so we don't affect other tests
-  await PersistenceService.reset();
-  (PersistenceService as unknown as { provider: unknown }).provider = originalProvider;
-});
-
-describe("PersistenceService cache-before-init", () => {
+describe("PersistenceService (instance)", () => {
   test("isInitialized() returns false after failed initialization", async () => {
-    // Mock the factory to return a provider whose initialize() throws
+    const service = new PersistenceService();
     const { PersistenceProviderFactory } = await import("./factory");
     const origCreate = PersistenceProviderFactory.create;
 
@@ -44,19 +28,20 @@ describe("PersistenceService cache-before-init", () => {
 
     try {
       await expect(
-        PersistenceService.initialize({
+        service.initialize({
           backend: "postgres",
           postgres: { connectionString: FAKE_CONNECTION_STRING },
         })
       ).rejects.toThrow(DB_UNAVAILABLE);
 
-      expect(PersistenceService.isInitialized()).toBe(false);
+      expect(service.isInitialized()).toBe(false);
     } finally {
       PersistenceProviderFactory.create = origCreate;
     }
   });
 
   test("getProvider() throws after failed initialization", async () => {
+    const service = new PersistenceService();
     const { PersistenceProviderFactory } = await import("./factory");
     const origCreate = PersistenceProviderFactory.create;
 
@@ -69,19 +54,20 @@ describe("PersistenceService cache-before-init", () => {
 
     try {
       await expect(
-        PersistenceService.initialize({
+        service.initialize({
           backend: "postgres",
           postgres: { connectionString: FAKE_CONNECTION_STRING },
         })
       ).rejects.toThrow();
 
-      expect(() => PersistenceService.getProvider()).toThrow("PersistenceService not initialized");
+      expect(() => service.getProvider()).toThrow("not initialized");
     } finally {
       PersistenceProviderFactory.create = origCreate;
     }
   });
 
   test("initialization can be retried after failure", async () => {
+    const service = new PersistenceService();
     const { PersistenceProviderFactory } = await import("./factory");
     const origCreate = PersistenceProviderFactory.create;
 
@@ -107,22 +93,22 @@ describe("PersistenceService cache-before-init", () => {
     try {
       // First attempt fails
       await expect(
-        PersistenceService.initialize({
+        service.initialize({
           backend: "postgres",
           postgres: { connectionString: FAKE_CONNECTION_STRING },
         })
       ).rejects.toThrow();
 
-      expect(PersistenceService.isInitialized()).toBe(false);
+      expect(service.isInitialized()).toBe(false);
 
       // Second attempt succeeds
-      await PersistenceService.initialize({
+      await service.initialize({
         backend: "postgres",
         postgres: { connectionString: FAKE_CONNECTION_STRING },
       });
 
-      expect(PersistenceService.isInitialized()).toBe(true);
-      expect(PersistenceService.getProvider()).toBeDefined();
+      expect(service.isInitialized()).toBe(true);
+      expect(service.getProvider()).toBeDefined();
     } finally {
       PersistenceProviderFactory.create = origCreate;
     }

--- a/src/domain/persistence/service.ts
+++ b/src/domain/persistence/service.ts
@@ -1,8 +1,11 @@
 /**
  * Persistence Service
  *
- * Singleton service for managing persistence provider lifecycle.
- * Combines factory and singleton patterns for production use and testing flexibility.
+ * Injectable service for managing persistence provider lifecycle.
+ * Created by the DI container in composition roots — domain code
+ * receives it via constructor injection or typed deps interfaces.
+ *
+ * @see mt#814 — converted from static singleton to injectable instance
  */
 
 import {
@@ -17,49 +20,42 @@ import { log } from "../../utils/logger";
 import type { VectorStorage } from "../storage/vector/types";
 
 /**
- * Persistence service singleton
+ * Persistence service — injectable instance.
+ *
+ * Manages the lifecycle of a PersistenceProvider (database connection).
+ * Created once per application context (CLI, MCP, test) via the DI container.
  */
 export class PersistenceService {
-  private static provider: PersistenceProvider | null = null;
-  private static initPromise: Promise<void> | null = null;
+  private provider: PersistenceProvider | null = null;
+  private initPromise: Promise<void> | null = null;
 
   /**
-   * Initialize the persistence service with configuration
+   * Initialize the persistence service with configuration.
+   * Safe to call multiple times — concurrent calls are coalesced.
    */
-  static async initialize(config?: PersistenceConfig): Promise<void> {
-    // Prevent concurrent initialization
-    if (PersistenceService.initPromise) {
-      return PersistenceService.initPromise;
+  async initialize(config?: PersistenceConfig): Promise<void> {
+    if (this.initPromise) {
+      return this.initPromise;
     }
 
-    PersistenceService.initPromise = PersistenceService.performInitialization(config);
+    this.initPromise = this.performInitialization(config);
 
     try {
-      await PersistenceService.initPromise;
+      await this.initPromise;
     } finally {
-      PersistenceService.initPromise = null;
+      this.initPromise = null;
     }
   }
 
-  /**
-   * Perform actual initialization
-   */
-  private static async performInitialization(config?: PersistenceConfig): Promise<void> {
+  private async performInitialization(config?: PersistenceConfig): Promise<void> {
     try {
-      // Use provided config or load from configuration
       const persistenceConfig = config || PersistenceService.loadConfiguration();
-
-      // Create provider using factory (now async for runtime capability detection)
       const provider = await PersistenceProviderFactory.create(persistenceConfig);
-
-      // Initialize before caching — if init fails, provider stays null so
-      // isInitialized() returns false and getProvider() throws correctly
       await provider.initialize();
-
-      PersistenceService.provider = provider;
+      this.provider = provider;
       log.info("PersistenceService initialized successfully");
     } catch (error) {
-      PersistenceService.provider = null;
+      this.provider = null;
       log.error(
         "Failed to initialize PersistenceService:",
         error instanceof Error ? error : { error: String(error) }
@@ -69,53 +65,44 @@ export class PersistenceService {
   }
 
   /**
-   * Load configuration from runtime config
+   * Load configuration from runtime config.
+   * Static because it doesn't depend on instance state.
    */
   private static loadConfiguration(): PersistenceConfig {
     const runtimeConfig = getConfiguration();
-
-    // Check for persistence config structure
     if (runtimeConfig.persistence) {
       return runtimeConfig.persistence;
     }
-
     throw new Error(
       "No persistence configuration found. Please configure 'persistence:' in your configuration."
     );
   }
 
   /**
-   * Get the persistence provider instance
+   * Get the persistence provider instance.
+   * Throws if not initialized.
    */
-  static getProvider(): PersistenceProvider {
-    if (!PersistenceService.provider) {
-      throw new Error(
-        "PersistenceService not initialized. Call PersistenceService.initialize() first."
-      );
+  getProvider(): PersistenceProvider {
+    if (!this.provider) {
+      throw new Error("PersistenceService not initialized. Call initialize() first.");
     }
-    return PersistenceService.provider;
+    return this.provider;
   }
 
   /**
-   * Get vector storage directly - type-safe approach using interface checking
-   * This eliminates runtime capability checking by using TypeScript type guards
+   * Get vector storage — type-safe approach using interface checking.
    */
-  static getVectorStorage(dimension: number): VectorStorage {
-    const provider = PersistenceService.getProvider();
+  getVectorStorage(dimension: number): VectorStorage {
+    const provider = this.getProvider();
 
-    // Type guard: check if provider implements VectorCapablePersistenceProvider
-    if (!PersistenceService.isVectorCapable(provider)) {
+    if (!this.isVectorCapable(provider)) {
       throw new CapabilityNotSupportedError("vectorStorage", provider.constructor.name);
     }
 
-    // TypeScript now knows provider has getVectorStorage method
     return provider.getVectorStorage(dimension);
   }
 
-  /**
-   * Type guard to check if provider supports vector storage
-   */
-  private static isVectorCapable(
+  private isVectorCapable(
     provider: PersistenceProvider
   ): provider is VectorCapablePersistenceProvider {
     return (
@@ -126,41 +113,33 @@ export class PersistenceService {
   }
 
   /**
-   * Check if service is initialized
+   * Check if service is initialized.
    */
-  static isInitialized(): boolean {
-    return PersistenceService.provider !== null;
+  isInitialized(): boolean {
+    return this.provider !== null;
   }
 
   /**
-   * Close the persistence service
+   * Close the persistence service and release resources.
    */
-  static async close(): Promise<void> {
-    if (PersistenceService.provider) {
-      await PersistenceService.provider.close();
-      PersistenceService.provider = null;
+  async close(): Promise<void> {
+    if (this.provider) {
+      await this.provider.close();
+      this.provider = null;
     }
-  }
-
-  /**
-   * Reset the service (alias for close, mainly for testing)
-   */
-  static async reset(): Promise<void> {
-    return PersistenceService.close();
-  }
-
-  /**
-   * Set a mock provider for testing
-   */
-  static setMockProvider(provider: PersistenceProvider): void {
-    PersistenceService.provider = provider;
   }
 }
 
 /**
- * Convenience function to get persistence provider
- * Assumes service is already initialized at application startup
+ * Convenience function to get persistence provider from the default instance.
+ * @deprecated Use container.get("persistence") instead.
  */
 export function getPersistenceProvider(): PersistenceProvider {
-  return PersistenceService.getProvider();
+  return defaultInstance.getProvider();
 }
+
+/**
+ * Default instance — used during migration period while callers
+ * transition to container-based injection. Will be removed in Phase E.
+ */
+export const defaultInstance = new PersistenceService();

--- a/src/domain/session/session-db-adapter.ts
+++ b/src/domain/session/session-db-adapter.ts
@@ -11,7 +11,7 @@ import { createSessionProviderWithAutoRepair } from "./session-auto-repair-provi
 // Re-export the interface for use in extracted modules
 export type { SessionProviderInterface };
 import type { PersistenceProvider } from "../persistence/types";
-import { PersistenceService } from "../persistence/service";
+import { defaultInstance } from "../persistence/service";
 import type { DatabaseStorage } from "../storage/database-storage";
 import type { SessionDbState } from "./session-db";
 import {
@@ -306,7 +306,7 @@ export interface CreateSessionProviderDeps {
 }
 
 const defaultCreateSessionProviderDeps: CreateSessionProviderDeps = {
-  persistenceService: PersistenceService,
+  persistenceService: defaultInstance,
 };
 
 /**

--- a/src/domain/storage/vector/vector-storage-factory.ts
+++ b/src/domain/storage/vector/vector-storage-factory.ts
@@ -22,8 +22,8 @@ export async function createVectorStorageFromConfig(
   if (persistenceProvider) {
     provider = persistenceProvider;
   } else {
-    const { PersistenceService } = await import("../../persistence/service");
-    provider = PersistenceService.getProvider();
+    const { defaultInstance: persistenceService } = await import("../../persistence/service");
+    provider = persistenceService.getProvider();
   }
 
   // Check if provider supports vector storage

--- a/src/domain/tasks/taskCommands.db-wiring.test.ts
+++ b/src/domain/tasks/taskCommands.db-wiring.test.ts
@@ -4,11 +4,12 @@ import { listTasksFromParams } from "./taskCommands";
 describe("DB wiring for minsky backend", () => {
   beforeAll(async () => {
     // Set up mock persistence provider before any tests run
-    const { PersistenceService } = await import("../persistence/service");
+    const { defaultInstance: persistenceService } = await import("../persistence/service");
     const { FakePersistenceProvider } = await import("../persistence/fake-persistence-provider");
 
     const fakeProvider = new FakePersistenceProvider();
-    PersistenceService.setMockProvider(fakeProvider);
+    // Set provider directly on the default instance for testing
+    (persistenceService as any).provider = fakeProvider;
 
     // Initialize configuration for persistence tests
     const { initializeConfiguration, CustomConfigFactory } = await import("../configuration/index");

--- a/src/domain/tasks/taskCommands.test.ts
+++ b/src/domain/tasks/taskCommands.test.ts
@@ -21,12 +21,12 @@ import path from "path";
 
 describe("Interface-Agnostic Task Command Functions", () => {
   beforeAll(async () => {
-    const { PersistenceService } = await import("../persistence/service");
+    const { defaultInstance: persistenceService } = await import("../persistence/service");
     const { FakePersistenceProvider } = await import("../persistence/fake-persistence-provider");
     const { FakeSessionProvider } = await import("../session/fake-session-provider");
     const { setSharedSessionProvider } = await import("../session/session-provider-cache-seams");
 
-    PersistenceService.setMockProvider(new FakePersistenceProvider());
+    (persistenceService as any).provider = new FakePersistenceProvider();
     setSharedSessionProvider(new FakeSessionProvider());
 
     // Initialize configuration too — some downstream code paths require it


### PR DESCRIPTION
## Summary

Phase A of mt#811 (service consolidation for full DI). Converts `PersistenceService` from a static singleton class to an injectable instance class. This is the root blocker — every other service depends on persistence, and as long as it's static, nothing downstream can be properly injected.

### What changed

**`src/domain/persistence/service.ts`** — All methods converted from `static` to instance. Constructor creates an empty service; `initialize()` connects to the database. Exported `defaultInstance` for backward compatibility during migration.

**`src/composition/cli.ts`** — Uses `defaultInstance` (shared during migration) instead of creating a fresh instance.

**Production callers** (3 files) — Updated to use `defaultInstance` instead of static `PersistenceService`:
- `similarity-commands.ts` — `defaultInstance.getVectorStorage()`
- `startup-embedding-sweep.ts` — `defaultInstance.isInitialized()`, `.getProvider()`
- `vector-storage-factory.ts` — `defaultInstance.getProvider()`

**`session-db-adapter.ts`** — Default deps use `defaultInstance` instead of static class.

**Tests** (3 files) — Updated to create `new PersistenceService()` instances or use `defaultInstance`. Architecture test updated to match instance method patterns.

### Migration note

The `defaultInstance` export is a transitional bridge. Code that hasn't been fully migrated to container access still uses it. Once all callers resolve persistence from the container, `defaultInstance` will be removed (Phase C/E).

## Test plan

- [x] TypeScript typecheck passes
- [x] 1617 tests pass, 0 failures (1 architecture test updated)
- [x] ESLint: 0 errors, 0 warnings
- [x] CLI functional: session --help, tasks list work correctly