### PR TITLE
feat(mt#815): Add commit, createPr, mergePr, scanConflicts, cleanup methods to SessionService (mt#815)

### DIFF
--- a/src/domain/session/session-service.ts
+++ b/src/domain/session/session-service.ts
@@ -25,6 +25,7 @@ import {
   deleteSessionImpl,
   getSessionDirImpl,
   inspectSessionImpl,
+  cleanupSessionImpl,
   type DeleteSessionResult,
 } from "./session-lifecycle-operations";
 import { startSessionImpl } from "./start-session-operations";
@@ -33,6 +34,17 @@ import { sessionReviewImpl } from "./session-review-operations";
 import type { SessionReviewParams, SessionReviewResult } from "./session-review-operations";
 import { approveSessionPr } from "./session-approval-operations";
 import type { ApprovalInfo } from "../repository/approval-types";
+import { sessionCommit } from "./session-commands";
+import { sessionPrImpl } from "./session-pr-operations";
+import type { SessionPrDependencies } from "./session-pr-operations";
+import { mergeSessionPr } from "./session-merge-operations";
+import type { SessionMergeParams, SessionMergeResult } from "./session-merge-operations";
+import { scanSessionConflicts } from "./session-conflicts-operations";
+import type {
+  SessionConflictParams,
+  SessionConflictScanOptions,
+  SessionConflictScanResult,
+} from "./session-conflicts-operations";
 
 import type { Session } from "./types";
 import type {
@@ -44,6 +56,7 @@ import type {
   SessionUpdateParams,
 } from "../../schemas/session";
 import type { SessionStartParameters, SessionUpdateParameters } from "../schemas";
+import type { SessionPRParameters } from "../schemas";
 
 /**
  * The superset of all dependencies needed by any session operation.
@@ -242,6 +255,92 @@ export class SessionService {
       approvalInfo: result.approvalInfo,
       wasAlreadyApproved: result.wasAlreadyApproved,
     };
+  }
+
+  /**
+   * Commit and push changes within a session workspace.
+   */
+  async commit(params: {
+    session: string;
+    message: string;
+    all?: boolean;
+    amend?: boolean;
+    noStage?: boolean;
+  }): Promise<{
+    success: boolean;
+    nothingToCommit?: boolean;
+    commitHash: string | null;
+    shortHash?: string;
+    subject?: string;
+    branch?: string;
+    authorName?: string;
+    authorEmail?: string;
+    timestamp?: string;
+    message: string;
+    filesChanged?: number;
+    insertions?: number;
+    deletions?: number;
+    files?: Array<{ path: string; status: string }>;
+    pushed: boolean;
+  }> {
+    return sessionCommit(params, this.deps.sessionProvider);
+  }
+
+  /**
+   * Create a pull request for a session.
+   */
+  async createPr(
+    params: SessionPRParameters,
+    options?: { interface?: "cli" | "mcp"; workingDirectory?: string }
+  ): Promise<{
+    prBranch: string;
+    baseBranch: string;
+    title?: string;
+    body?: string;
+    url?: string;
+  }> {
+    const deps: SessionPrDependencies = {
+      sessionDB: this.deps.sessionProvider,
+      gitService: this.deps.gitService,
+    };
+    return sessionPrImpl(params, deps, options);
+  }
+
+  /**
+   * Merge an approved session pull request.
+   */
+  async mergePr(params: SessionMergeParams): Promise<SessionMergeResult> {
+    return mergeSessionPr(params, {
+      sessionDB: this.deps.sessionProvider,
+      taskService: this.deps.taskService,
+      gitService: this.deps.gitService,
+    });
+  }
+
+  /**
+   * Scan a session workspace for git conflict markers.
+   */
+  async scanConflicts(
+    params: SessionConflictParams,
+    options?: SessionConflictScanOptions
+  ): Promise<SessionConflictScanResult> {
+    return scanSessionConflicts(params, options ?? {}, this.deps.sessionProvider);
+  }
+
+  /**
+   * Clean up a session — removes workspace directories and database record.
+   */
+  async cleanup(params: {
+    sessionId: string;
+    taskId?: string;
+    force?: boolean;
+    dryRun?: boolean;
+  }): Promise<{
+    sessionDeleted: boolean;
+    directoriesRemoved: string[];
+    errors: string[];
+  }> {
+    return cleanupSessionImpl(params, { sessionDB: this.deps.sessionProvider });
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `commit()` method delegating to `sessionCommit()` from `session-commands.ts`
- Adds `createPr()` method delegating to `sessionPrImpl()` from `session-pr-operations.ts`
- Adds `mergePr()` method delegating to `mergeSessionPr()` from `session-merge-operations.ts`
- Adds `scanConflicts()` method delegating to `scanSessionConflicts()` from `session-conflicts-operations.ts`
- Adds `cleanup()` method delegating to `cleanupSessionImpl()` from `session-lifecycle-operations.ts`
- Consolidates `cleanupSessionImpl` into the existing `session-lifecycle-operations` import block (removed duplicate import)
- Adds `SessionPRParameters` import from `../schemas`

All 5 methods follow the existing pattern: accept typed params, delegate to the `*Impl` function, pass the relevant `this.deps` subset.

## Test plan

- [ ] `bun run tsc --noEmit` passes (verified locally — zero errors)
- [ ] `bun run format:all` passes (verified locally — no changes)
- [ ] Pre-commit hooks pass on CI

## Coherence Verification

**Files re-read**: `src/domain/session/session-service.ts`

**Q1 single purpose**: pass — `SessionService` remains the single unified service class; each new method is a thin delegation to an existing impl function.

**Q2 comment honesty**: pass — all docstrings are accurate; new methods have concise, truthful JSDoc.

**Q3 naming honesty**: pass — method names (`commit`, `createPr`, `mergePr`, `scanConflicts`, `cleanup`) directly match the operations they perform.

**Q4 redundant siblings**: pass — no new files created; this is purely additive to the existing class.

**Q5 dead exports**: pass — `SessionService`, `createSessionDeps`, `createSessionService`, `SessionDeps`, `ApproveResult` are all consumed by callers in `src/domain/session.ts`, `src/adapters/shared/commands/session/*`. Grepped for `SessionService` across the codebase — all exports are actively used.

**Q6 orphan code**: pass — no orphan code introduced. The duplicate `import { cleanupSessionImpl } from "./session-lifecycle-operations"` was consolidated into the existing import block.

**Q7 stray artifacts**: pass — no `.backup`, `.bak`, or `TODO: remove` artifacts introduced.

**Items fixed in this PR (beyond original scope)**: Consolidated duplicate import of `cleanupSessionImpl` into existing `session-lifecycle-operations` import block.

**Items deferred**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)