### PR TITLE
fix(gh#491): preserve this binding in task command auto-registration

### DIFF
--- a/src/adapters/shared/commands/tasks-modular.ts
+++ b/src/adapters/shared/commands/tasks-modular.ts
@@ -38,7 +38,7 @@ export class ModularTasksCommandManager {
           name: command.name,
           description: command.description,
           parameters: command.parameters,
-          execute: command.execute,
+          execute: (params, ctx) => command.execute(params, ctx),
         });
       }
 


### PR DESCRIPTION
## Summary

Follow-up fix to PR #492. The auto-registration loop passed `command.execute` directly, detaching it from the command instance. `BaseTaskCommand` methods like `this.debug()` failed with `this.debug is not a function` when called via MCP.

Fix: wrap in arrow function `(params, ctx) => command.execute(params, ctx)` to preserve call context.

## Spec verification

| Criterion | Status | Evidence |
|---|---|---|
| tasks.get works via MCP | Met | Arrow wrapper preserves this binding |
| All existing commands still work | Met | 1617 tests pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)