### PR TITLE
refactor(mt#818): Standardize storage classes to constructor injection (Phase B4 of mt#818)

### DIFF
--- a/src/domain/similarity/create-rule-similarity-core.ts
+++ b/src/domain/similarity/create-rule-similarity-core.ts
@@ -6,6 +6,7 @@ import { createEmbeddingServiceFromConfig } from "../ai/embedding-service-factor
 import { createRulesVectorStorageFromConfig } from "../storage/vector/vector-storage-factory";
 import { RuleService } from "../rules";
 import { getConfiguration } from "../configuration";
+import { defaultInstance } from "../persistence/service";
 
 export interface RuleSimilarityCoreOptions {
   disableEmbeddings?: boolean;
@@ -23,7 +24,10 @@ export async function createRuleSimilarityCore(
   if (!options.disableEmbeddings) {
     try {
       const embedding = await createEmbeddingServiceFromConfig();
-      const storage = await createRulesVectorStorageFromConfig(dimension);
+      const storage = await createRulesVectorStorageFromConfig(
+        dimension,
+        defaultInstance.getProvider()
+      );
       embeddings = new EmbeddingsSimilarityBackend(embedding, storage);
     } catch {
       embeddings = null;

--- a/src/domain/storage/backends/postgres-storage-error-propagation.test.ts
+++ b/src/domain/storage/backends/postgres-storage-error-propagation.test.ts
@@ -20,17 +20,53 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { PostgresStorage } from "./postgres-storage";
+import type { PersistenceProvider } from "../../persistence/types";
+
+// Minimal mock provider that simulates a connection failure
+function makeFailingProvider(): PersistenceProvider {
+  return {
+    capabilities: {
+      sql: true,
+      transactions: false,
+      jsonb: false,
+      vectorStorage: false,
+      migrations: false,
+    },
+    getCapabilities: () => ({
+      sql: true,
+      transactions: false,
+      jsonb: false,
+      vectorStorage: false,
+      migrations: false,
+    }),
+    getStorage: () => {
+      throw new Error("not implemented");
+    },
+    initialize: async () => {},
+    close: async () => {},
+    getConnectionInfo: () => "mock-failing",
+    getDatabaseConnection: async () => {
+      throw new Error("simulated connection failure");
+    },
+    getRawSqlConnection: async () => {
+      throw new Error("simulated connection failure");
+    },
+  } as unknown as PersistenceProvider;
+}
 
 // We test through the public API with a mock that simulates connection failures
 describe("PostgresStorage error propagation (mt#722)", () => {
   let storage: PostgresStorage;
 
   beforeEach(() => {
-    storage = new PostgresStorage({
-      connectionString: "postgresql://x:x@invalid:0/x",
-      maxConnections: 1,
-      connectTimeout: 1,
-    });
+    storage = new PostgresStorage(
+      {
+        connectionString: "postgresql://x:x@invalid:0/x",
+        maxConnections: 1,
+        connectTimeout: 1,
+      },
+      makeFailingProvider()
+    );
   });
 
   describe("getEntity", () => {

--- a/src/domain/storage/backends/postgres-storage.ts
+++ b/src/domain/storage/backends/postgres-storage.ts
@@ -55,9 +55,9 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
   private sql: ReturnType<typeof postgres> | null = null;
   private drizzle: ReturnType<typeof drizzle> | null = null;
   private readonly connectionString: string;
-  private readonly persistenceProvider?: PersistenceProvider;
+  private readonly persistenceProvider: PersistenceProvider;
 
-  constructor(config: PostgresStorageConfig, persistenceProvider?: PersistenceProvider) {
+  constructor(config: PostgresStorageConfig, persistenceProvider: PersistenceProvider) {
     this.connectionString = config.connectionString;
     this.persistenceProvider = persistenceProvider;
   }
@@ -70,11 +70,6 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
       return; // Already initialized
     }
 
-    if (!this.persistenceProvider) {
-      throw new Error(
-        "PostgresStorage requires a PersistenceProvider to be injected via constructor"
-      );
-    }
     const provider: PersistenceProvider = this.persistenceProvider;
 
     const capabilities = provider.getCapabilities();
@@ -442,13 +437,4 @@ export class PostgresStorage implements DatabaseStorage<SessionRecord, SessionDb
     this.sql = null;
     this.drizzle = null;
   }
-}
-
-/**
- * Create a new PostgreSQL storage instance
- */
-export function createPostgresStorage(
-  config: PostgresStorageConfig
-): DatabaseStorage<SessionRecord, SessionDbState> {
-  return new PostgresStorage(config);
 }

--- a/src/domain/storage/postgres-storage-interface-bug.test.ts
+++ b/src/domain/storage/postgres-storage-interface-bug.test.ts
@@ -7,6 +7,7 @@
  * - This caused all session lookups by name to fail
  */
 import { describe, test, expect, mock } from "bun:test";
+import type { PersistenceProvider } from "../persistence/types";
 
 describe("PostgresStorage Interface Completeness", () => {
   test("PostgresStorage must implement both getEntity() and get() methods", async () => {
@@ -20,7 +21,31 @@ describe("PostgresStorage Interface Completeness", () => {
       connectTimeout: 30,
     };
 
-    const storage = new PostgresStorage(mockConfig); // Mock sql connection
+    // Minimal mock provider — never actually used (test only checks method existence)
+    const mockProvider = {
+      capabilities: {
+        sql: true,
+        transactions: false,
+        jsonb: false,
+        vectorStorage: false,
+        migrations: false,
+      },
+      getCapabilities: () => mockProvider.capabilities,
+      getStorage: () => {
+        throw new Error("not implemented");
+      },
+      initialize: async () => {},
+      close: async () => {},
+      getConnectionInfo: () => "mock",
+      getDatabaseConnection: async () => {
+        throw new Error("no connection");
+      },
+      getRawSqlConnection: async () => {
+        throw new Error("no connection");
+      },
+    } as unknown as PersistenceProvider;
+
+    const storage = new PostgresStorage(mockConfig, mockProvider);
 
     // Verify both methods exist on the interface
     expect(typeof storage.getEntity).toBe("function");

--- a/src/domain/storage/vector/postgres-vector-storage.ts
+++ b/src/domain/storage/vector/postgres-vector-storage.ts
@@ -27,40 +27,6 @@ export class PostgresVectorStorage implements VectorStorage {
     this.db = db;
   }
 
-  static async fromPersistenceProvider(
-    dimension: number,
-    config: PostgresVectorStorageConfig,
-    persistenceProvider: import("../../persistence/types").PersistenceProvider
-  ): Promise<PostgresVectorStorage> {
-    const provider = persistenceProvider;
-
-    if (!provider.capabilities.sql || !provider.capabilities.vectorStorage) {
-      throw new Error("Current persistence provider does not support SQL or vector storage");
-    }
-
-    const sql = (await provider.getRawSqlConnection?.()) as ReturnType<typeof postgres> | undefined;
-    const db = (await provider.getDatabaseConnection?.()) as PostgresJsDatabase | undefined;
-
-    if (!sql || !db) {
-      throw new Error("Failed to get database connections from persistence provider");
-    }
-
-    const storage = new PostgresVectorStorage(sql, db, dimension, config);
-    await storage.initialize();
-    return storage;
-  }
-
-  /**
-   * @deprecated Use fromPersistenceProvider() instead
-   */
-  static async fromSessionDbConfig(
-    dimension: number,
-    config: PostgresVectorStorageConfig,
-    persistenceProvider: import("../../persistence/types").PersistenceProvider
-  ): Promise<PostgresVectorStorage> {
-    return PostgresVectorStorage.fromPersistenceProvider(dimension, config, persistenceProvider);
-  }
-
   async initialize(): Promise<void> {
     await this.sql.unsafe("CREATE EXTENSION IF NOT EXISTS vector");
     // Tables are managed by Drizzle migrations. No-op here to avoid drift.

--- a/src/domain/storage/vector/vector-storage-factory.ts
+++ b/src/domain/storage/vector/vector-storage-factory.ts
@@ -2,7 +2,7 @@
  * Vector Storage Factory
  *
  * Creates vector storage instances using the persistence provider.
- * Updated to use dependency injection pattern with PersistenceProvider.
+ * Uses dependency injection pattern with PersistenceProvider (required).
  */
 
 import type { VectorStorage } from "./types";
@@ -15,16 +15,9 @@ import { log } from "../../../utils/logger";
  */
 export async function createVectorStorageFromConfig(
   dimension: number,
-  persistenceProvider?: PersistenceProvider
+  persistenceProvider: PersistenceProvider
 ): Promise<VectorStorage> {
-  // Resolve provider: use injected or fall back to PersistenceService (composition boundary)
-  let provider: PersistenceProvider;
-  if (persistenceProvider) {
-    provider = persistenceProvider;
-  } else {
-    const { defaultInstance: persistenceService } = await import("../../persistence/service");
-    provider = persistenceService.getProvider();
-  }
+  const provider = persistenceProvider;
 
   // Check if provider supports vector storage
   if (!provider.capabilities.vectorStorage) {
@@ -49,7 +42,7 @@ export async function createVectorStorageFromConfig(
  */
 export async function createRulesVectorStorageFromConfig(
   dimension: number,
-  persistenceProvider?: PersistenceProvider
+  persistenceProvider: PersistenceProvider
 ): Promise<VectorStorage> {
   // For now, use the same implementation as tasks
   // In the future, this could create a separate vector storage instance
@@ -63,7 +56,7 @@ export async function createRulesVectorStorageFromConfig(
  */
 export async function createToolsVectorStorageFromConfig(
   dimension: number,
-  persistenceProvider?: PersistenceProvider
+  persistenceProvider: PersistenceProvider
 ): Promise<VectorStorage> {
   // For now, use the same implementation as tasks
   // In the future, this could create a separate vector storage instance

--- a/src/domain/tools/similarity/create-tool-similarity-core.ts
+++ b/src/domain/tools/similarity/create-tool-similarity-core.ts
@@ -7,6 +7,7 @@ import { createToolsVectorStorageFromConfig } from "../../storage/vector/vector-
 import { getEmbeddingDimension } from "../../ai/embedding-models";
 import { getConfiguration } from "../../configuration";
 import { sharedCommandRegistry } from "../../../adapters/shared/command-registry";
+import { defaultInstance } from "../../persistence/service";
 
 export interface ToolSimilarityCoreOptions {
   disableEmbeddings?: boolean;
@@ -21,7 +22,10 @@ export async function createToolSimilarityCore(options: ToolSimilarityCoreOption
   if (!options.disableEmbeddings) {
     try {
       const embedding = await createEmbeddingServiceFromConfig();
-      const storage = await createToolsVectorStorageFromConfig(dimension);
+      const storage = await createToolsVectorStorageFromConfig(
+        dimension,
+        defaultInstance.getProvider()
+      );
       embeddings = new EmbeddingsSimilarityBackend(embedding, storage);
     } catch {
       embeddings = null; // Treat embeddings as unavailable when misconfigured in tests

--- a/src/domain/tools/tool-embedding-service.ts
+++ b/src/domain/tools/tool-embedding-service.ts
@@ -5,6 +5,7 @@ import { createToolsVectorStorageFromConfig } from "../storage/vector/vector-sto
 import { getConfiguration } from "../configuration";
 import { getEmbeddingDimension } from "../ai/embedding-models";
 import { sharedCommandRegistry, type SharedCommand } from "../../adapters/shared/command-registry";
+import { defaultInstance } from "../persistence/service";
 
 const log = createLogger();
 
@@ -37,7 +38,10 @@ export class ToolEmbeddingService {
       ((cfg?.["embeddings"] as Record<string, unknown> | undefined)?.["model"] as string) ||
       "text-embedding-3-small";
     const dimension = getEmbeddingDimension(model, 1536);
-    const storage = await createToolsVectorStorageFromConfig(dimension);
+    const storage = await createToolsVectorStorageFromConfig(
+      dimension,
+      defaultInstance.getProvider()
+    );
 
     // Extract tool content for embedding
     const content = this.extractToolContent(tool);
@@ -137,7 +141,10 @@ export class ToolEmbeddingService {
         ((cfg?.["embeddings"] as Record<string, unknown> | undefined)?.["model"] as string) ||
         "text-embedding-3-small";
       const dimension = getEmbeddingDimension(model, 1536);
-      const storage = await createToolsVectorStorageFromConfig(dimension);
+      const storage = await createToolsVectorStorageFromConfig(
+        dimension,
+        defaultInstance.getProvider()
+      );
 
       if (typeof storage.getMetadata === "function") {
         return await storage.getMetadata(toolId);


### PR DESCRIPTION
## Summary

- Remove static factory methods `fromPersistenceProvider()` and `fromSessionDbConfig()` from `PostgresVectorStorage` — no external callers existed
- Make `persistenceProvider` required (not optional) in `createVectorStorageFromConfig()`, `createRulesVectorStorageFromConfig()`, and `createToolsVectorStorageFromConfig()` — removes the hidden fallback to `defaultInstance.getProvider()`
- Make `persistenceProvider` required in `PostgresStorage` constructor — removes the optional guard and the error that guarded against a missing provider at runtime
- Remove the dead `createPostgresStorage()` export (no callers, created storage without a provider which always threw)
- Update callers (`create-rule-similarity-core`, `create-tool-similarity-core`, `tool-embedding-service`) to pass `defaultInstance.getProvider()` explicitly — making the dependency visible at the call site
- Update test files to pass a mock `PersistenceProvider` to `PostgresStorage` so they compile and retain their behavioral intent

## Coherence Verification

**Files re-read**: 
- `src/domain/storage/vector/postgres-vector-storage.ts`
- `src/domain/storage/vector/vector-storage-factory.ts`
- `src/domain/storage/backends/postgres-storage.ts`
- `src/domain/similarity/create-rule-similarity-core.ts`
- `src/domain/tools/similarity/create-tool-similarity-core.ts`
- `src/domain/tools/tool-embedding-service.ts`
- `src/domain/storage/postgres-storage-interface-bug.test.ts`
- `src/domain/storage/backends/postgres-storage-error-propagation.test.ts`

**Q1 single purpose**: pass — each file remains focused; `postgres-vector-storage.ts` is now a clean implementation class without factory methods, `vector-storage-factory.ts` is a pure factory with required deps

**Q2 comment honesty**: pass — updated the module header comment in `vector-storage-factory.ts` from "Updated to use dependency injection pattern" to "Uses dependency injection pattern (required)" to reflect the now-required parameter

**Q3 naming honesty**: pass — no names changed, all naming remains accurate

**Q4 redundant siblings**: pass — no new duplication introduced; `createVectorStorage()` (for testing) and `createVectorStorageFromConfig()` (for production) serve distinct purposes

**Q5 dead exports**: pass — grepped for `fromPersistenceProvider`, `fromSessionDbConfig`, `forTasksEmbeddingsFromConfig`, `createPostgresStorage` → zero results. The removed factory methods had no external callers; `createVectorStorage()` still has callers (kept).

**Q6 orphan code**: pass — no helpers existed solely for the removed factory methods; the `VectorCapableProvider` interface in the factory file still serves `createVectorStorage()`

**Q7 stray artifacts**: pass — no `.backup`, `.bak`, `.old`, `.tmp` files; no leftover TODOs from this refactor

**Items fixed in this PR (beyond original scope)**: none
**Items deferred (with justification)**: none

🤖 Generated with Claude Code (refactor subagent)