### PR TITLE
refactor(mt#816): Add constructor DI to GitService and remove singleton fallbacks (mt#816)

### DIFF
--- a/src/composition/cli.ts
+++ b/src/composition/cli.ts
@@ -57,9 +57,9 @@ export async function createCliContainer(): Promise<AppContainerInterface> {
 
   // --- Domain services ---
 
-  container.register("gitService", async () => {
+  container.register("gitService", async (c) => {
     const { createGitService } = await import("../domain/git/git-service-factory");
-    return createGitService();
+    return createGitService({ sessionProvider: c.get("sessionProvider") });
   });
 
   container.register("taskService", async (c) => {

--- a/src/domain/git.ts
+++ b/src/domain/git.ts
@@ -89,12 +89,29 @@ export {
   rebaseFromParams,
 } from "./git/git-params-facade";
 
+/**
+ * Dependencies that can be injected into GitService at construction time.
+ */
+export interface GitServiceDeps {
+  baseDir?: string;
+  sessionProvider?: SessionProviderInterface;
+}
+
 export class GitService implements GitServiceInterface {
   private readonly baseDir: string;
   private sessionDb: SessionProviderInterface | null = null;
 
-  constructor(baseDir?: string) {
-    this.baseDir = baseDir || getMinskyStateDir();
+  constructor(baseDirOrDeps?: string | GitServiceDeps | null) {
+    if (typeof baseDirOrDeps === "string") {
+      this.baseDir = baseDirOrDeps || getMinskyStateDir();
+    } else if (baseDirOrDeps != null) {
+      this.baseDir = baseDirOrDeps.baseDir || getMinskyStateDir();
+      if (baseDirOrDeps.sessionProvider) {
+        this.sessionDb = baseDirOrDeps.sessionProvider;
+      }
+    } else {
+      this.baseDir = getMinskyStateDir();
+    }
   }
 
   private async getSessionDb(): Promise<SessionProviderInterface> {
@@ -386,6 +403,6 @@ export class GitService implements GitServiceInterface {
 /**
  * Creates a default GitService implementation
  */
-export function createGitService(options?: { baseDir?: string }): GitServiceInterface {
-  return new GitService(options?.baseDir);
+export function createGitService(options?: GitServiceDeps): GitServiceInterface {
+  return new GitService(options);
 }

--- a/src/domain/git/git-service-factory.ts
+++ b/src/domain/git/git-service-factory.ts
@@ -5,6 +5,7 @@
  * Extracted from git.ts to support modular architecture.
  */
 import { type GitServiceInterface } from "./types";
+import type { GitServiceDeps } from "../git";
 
 /**
  * Creates a default GitService implementation
@@ -13,7 +14,7 @@ import { type GitServiceInterface } from "./types";
  * @param options Optional configuration options for the git service
  * @returns A GitServiceInterface implementation
  */
-export function createGitService(options?: { baseDir?: string }): GitServiceInterface {
+export function createGitService(options?: GitServiceDeps): GitServiceInterface {
   // Use lazy static import to avoid circular dependency and hanging during MCP startup
   try {
     const { GitService } = require("../git");
@@ -22,7 +23,7 @@ export function createGitService(options?: { baseDir?: string }): GitServiceInte
       throw new Error("GitService class not found - check git.ts exports");
     }
 
-    return new GitService(options?.baseDir);
+    return new GitService(options);
   } catch (error) {
     // If require fails during MCP startup, provide a minimal fallback
     throw new Error(

--- a/src/domain/git/operations/base-git-operation.ts
+++ b/src/domain/git/operations/base-git-operation.ts
@@ -67,8 +67,9 @@ export abstract class BaseGitOperation<TParams, TResult> {
       const baseParams = validParams as BaseGitOperationParams;
       if (baseParams.session && !baseParams.repo) {
         if (!this.deps.sessionProvider) {
-          const { getSharedSessionProvider } = await import("../../session/session-provider-cache");
-          this.deps.sessionProvider = await getSharedSessionProvider();
+          throw new Error(
+            `sessionProvider is required to resolve session '${baseParams.session}' but was not provided to ${this.getOperationName()}`
+          );
         }
         const workdir = await resolveSessionDirectory(
           baseParams.session,

--- a/src/domain/session-pr-no-branch-switch.test.ts
+++ b/src/domain/session-pr-no-branch-switch.test.ts
@@ -1,12 +1,8 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import { preparePrFromParams } from "./git/git-commands-modular";
 import { preparePrImpl } from "./git/prepare-pr-operations";
 import { FakeGitService } from "./git/fake-git-service";
 import { FakeSessionProvider } from "./session/fake-session-provider";
-import {
-  setSharedSessionProvider,
-  resetSharedSessionProvider,
-} from "./session/session-provider-cache-seams";
 import type { GitServiceInterface } from "./git/types";
 import { initializeConfiguration, CustomConfigFactory } from "./configuration";
 
@@ -71,13 +67,8 @@ describe("Session PR Command Branch Behavior", () => {
       repoPath: WORKDIR,
       sessionWorkdir: WORKDIR,
     });
-    setSharedSessionProvider(fakeSessionProvider);
 
     fakeGitService = buildFakeGitService(fakeSessionProvider);
-  });
-
-  afterEach(() => {
-    resetSharedSessionProvider();
   });
 
   test("should never switch user to PR branch (recovery path: PR branch already exists)", async () => {
@@ -88,7 +79,7 @@ describe("Session PR Command Branch Behavior", () => {
         body: "Test body",
         baseBranch: "main",
       },
-      { createGitService: () => fakeGitService }
+      { createGitService: () => fakeGitService, sessionProvider: fakeSessionProvider }
     );
 
     const gitCommands = fakeGitService.recordedCommands.map((entry) => entry.command);
@@ -145,7 +136,7 @@ describe("Session PR Command Branch Behavior", () => {
         body: "Test body",
         baseBranch: "main",
       },
-      { createGitService: () => fakeGitService }
+      { createGitService: () => fakeGitService, sessionProvider: fakeSessionProvider }
     );
 
     const gitCommands = fakeGitService.recordedCommands.map((entry) => entry.command);
@@ -197,7 +188,7 @@ describe("Session PR Command Branch Behavior", () => {
           body: "Test body",
           baseBranch: "main",
         },
-        { createGitService: () => fakeGitService }
+        { createGitService: () => fakeGitService, sessionProvider: fakeSessionProvider }
       )
     ).rejects.toThrow(/Failed to switch back to session branch/i);
 

--- a/tests/unit/domain/changeset/local-git-adapter.test.ts
+++ b/tests/unit/domain/changeset/local-git-adapter.test.ts
@@ -218,7 +218,10 @@ describe("LocalGitChangesetAdapterFactory", () => {
   });
 
   test("creates adapter instance", async () => {
-    const adapter = await factory.createAdapter("/test/repo");
+    const adapter = await factory.createAdapter("/test/repo", {
+      repositoryUrl: "/test/repo",
+      deps: mockDeps as unknown as Record<string, unknown>,
+    });
 
     expect(adapter).toBeInstanceOf(LocalGitChangesetAdapter);
     expect(adapter.platform).toBe("local-git");


### PR DESCRIPTION
## Summary

Phase B2 of mt#816: wire dependency injection through GitService and BaseGitOperation.

- **`GitServiceDeps` interface** added to `src/domain/git.ts`: optional `baseDir` and `sessionProvider` fields
- **`GitService` constructor** updated to accept `string | GitServiceDeps | null` (fully backward-compatible union)
- When `sessionProvider` is injected at construction time, it pre-populates `this.sessionDb`, bypassing the lazy `createSessionProvider()` call
- **`createGitService()`** in both `git.ts` and `git-service-factory.ts` updated to accept `GitServiceDeps`
- **`src/composition/cli.ts`** updated: `gitService` registration now depends on `sessionProvider` and passes it through
- **`BaseGitOperation.execute()`** no longer imports `getSharedSessionProvider()` as a fallback; instead throws a clear error if `sessionProvider` is absent when resolving a session
- **Test cleanup**: `session-pr-no-branch-switch.test.ts` passes `sessionProvider` explicitly in deps (removes reliance on `setSharedSessionProvider` seam); pre-existing broken test in `local-git-adapter.test.ts` fixed to supply required deps

## Coherence Verification

**Files re-read**: `src/domain/git.ts`, `src/domain/git/git-service-factory.ts`, `src/domain/git/operations/base-git-operation.ts`, `src/composition/cli.ts`, `src/domain/session-pr-no-branch-switch.test.ts`, `tests/unit/domain/changeset/local-git-adapter.test.ts`

**Q1 single purpose**: pass — each file still has one clear reason to exist; no new thin wrapper created

**Q2 comment honesty**: pass — the `base-git-operation.ts` header references "modularization effort" which remains accurate; no stale comments introduced

**Q3 naming honesty**: pass — `GitServiceDeps` accurately describes what it carries; no renames needed

**Q4 redundant siblings**: pass — `createGitService` in `git.ts` and `git-service-factory.ts` remain distinct (factory uses `require()` for circular-dep avoidance); they share the same `GitServiceDeps` type via type import

**Q5 dead exports**: pass — `GitServiceDeps` is exported from `git.ts` and imported by `git-service-factory.ts`; `createGitService` is consumed by `cli.ts` and many command files (unchanged callers still work because `GitServiceDeps` is a superset of `{ baseDir?: string }`)

**Q6 orphan code**: pass — removed `setSharedSessionProvider`/`resetSharedSessionProvider` calls from the test that no longer needs them; the seam module itself may have other users and was not deleted

**Q7 stray artifacts**: pass — no `.backup`, `.bak`, `.old`, `.tmp` files; no leftover `// TODO: remove` comments

**Items fixed in this PR (beyond original scope)**:
- Pre-existing broken test in `local-git-adapter.test.ts`: `LocalGitChangesetAdapterFactory.creates adapter instance` was calling `factory.createAdapter` without providing `sessionProvider` in deps, causing the constructor to throw. Fixed by supplying `mockDeps` (already defined in the file) via the `config.deps` parameter.

**Items deferred**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)