### PR TITLE
fix(gh#505): Enforce review freshness, scope gate, and retrospective protocol

### DIFF
--- a/.claude/hooks/require-review-before-merge.ts
+++ b/.claude/hooks/require-review-before-merge.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
-// PreToolUse hook: block session_pr_merge if no review exists on the PR
-// or if the review lacks a spec verification section.
-// Ensures code review AND spec verification are complete before merging.
+// PreToolUse hook: block session_pr_merge if no review exists on the PR,
+// the review lacks a spec verification section, or the review is stale
+// (covers an older commit than PR HEAD).
+// Ensures code review, spec verification, AND review freshness before merging.
 
 import { readInput, writeOutput, execSync } from "./types";
 import type { ToolHookInput } from "./types";
@@ -13,7 +14,7 @@ if (!task) process.exit(0);
 
 const branch = `task/${task.replace("#", "-")}`;
 
-// Get PR number for this branch
+// Get PR number and head SHA for this branch
 const prResult = execSync([
   "gh",
   "pr",
@@ -23,23 +24,26 @@ const prResult = execSync([
   "--head",
   branch,
   "--json",
-  "number",
+  "number,headRefOid",
   "--jq",
-  ".[0].number",
+  ".[0] | [.number, .headRefOid] | @tsv",
 ]);
-const pr = prResult.stdout.trim();
+const prParts = prResult.stdout.trim().split("\t");
+const pr = prParts[0];
+const headSha = prParts[1];
 if (!pr) process.exit(0);
 
+// Get all reviews
+const reviewsJson = execSync(["gh", "api", `repos/edobry/minsky/pulls/${pr}/reviews`]);
+let reviews: Array<{ body: string; commit_id: string; submitted_at: string }>;
+try {
+  reviews = JSON.parse(reviewsJson.stdout.trim());
+} catch {
+  reviews = [];
+}
+
 // Check that at least one review exists
-const reviewsResult = execSync([
-  "gh",
-  "api",
-  `repos/edobry/minsky/pulls/${pr}/reviews`,
-  "--jq",
-  "length",
-]);
-const reviews = reviewsResult.stdout.trim();
-if (reviews === "0" || !reviews) {
+if (reviews.length === 0) {
   writeOutput({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -51,15 +55,8 @@ if (reviews === "0" || !reviews) {
 }
 
 // Check that at least one review contains spec verification
-const hasSpecResult = execSync([
-  "gh",
-  "api",
-  `repos/edobry/minsky/pulls/${pr}/reviews`,
-  "--jq",
-  '[.[].body] | any(test("Spec verification|spec verification|SPEC VERIFICATION"))',
-]);
-const hasSpec = hasSpecResult.stdout.trim();
-if (hasSpec !== "true") {
+const hasSpec = reviews.some((r) => r.body && /spec verification/i.test(r.body));
+if (!hasSpec) {
   writeOutput({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -68,4 +65,24 @@ if (hasSpec !== "true") {
     },
   });
   process.exit(0);
+}
+
+// Check that the most recent review with spec verification covers the current HEAD
+if (headSha) {
+  const specReviews = reviews
+    .filter((r) => r.body && /spec verification/i.test(r.body))
+    .sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime());
+  const latestReview = specReviews[0];
+  if (latestReview && latestReview.commit_id !== headSha) {
+    writeOutput({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason:
+          `Review on PR #${pr} is stale — covers commit ${latestReview.commit_id.slice(0, 7)} ` +
+          `but PR HEAD is ${headSha.slice(0, 7)}. Re-run /review-pr to review the latest changes.`,
+      },
+    });
+    process.exit(0);
+  }
 }

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -50,9 +50,11 @@ For each file changed, understand:
 - If behavior looks changed, read the surrounding code to understand the full context.
 - Classify each finding with evidence:
   - **Blocking** — verified real issue introduced by this PR, with file:line evidence
-  - **Non-blocking** — real concern but low risk or stylistic
+  - **Non-blocking** — real concern but low risk or stylistic, AND genuinely out of scope or requiring separate investigation
   - **Pre-existing** — real issue but not introduced by this PR (note for follow-up)
   - **False positive** — concern was disproven by reading the source (do not include in review)
+
+**Decision gate for non-blocking findings:** If a finding is (a) in-scope for the current task AND (b) the fix is known and actionable, it is **BLOCKING**, not non-blocking. "Non-blocking" means the issue is genuinely out of scope, requires separate investigation, or is a stylistic preference — not "I know the fix but want to defer it." In-scope actionable work must be fixed before merge.
 
 Only include verified findings in the GitHub review. Drop false positives entirely rather than padding the review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ The `/review-pr` skill requires a **Spec verification** section in every review.
 - **Artifact creation is not progress.** Creating tasks, updating specs, writing rules, and process discussion are not substitutes for doing the work. If you can describe exactly what needs to be done, do it.
 - **Before proposing to ship**, check the task spec's success criteria. If items are unmet and actionable, keep working.
 - **Never notice an issue without acting on it.** If you discover a problem, duplication, or architectural concern that's out of scope to fix now, immediately file a task with `mcp__minsky__tasks_create`. Mentioning it in chat is not action — it must become a trackable artifact (task, spec update, or memory). There is no "worth noting for a follow-up" without creating the follow-up.
+- **Process corrections require structural fixes, not memories.** When corrected on a process failure, invoke `/retrospective` to analyze the root cause and produce durable fixes (hooks, skill updates, CLAUDE.md changes). Saving a memory is not enforcement — memories are behavioral guidance that can be ignored. Hooks and skill steps are structural and cannot be bypassed.
 
 ## Task Creation
 


### PR DESCRIPTION
## Summary

Three structural fixes from the gh#499 retrospective to prevent recurring process failures:

1. **Review freshness enforcement (hook):** `require-review-before-merge.ts` now checks that the latest spec-verification review covers the PR's current HEAD SHA. Stale reviews (posted against older commits) block the merge with a clear message.

2. **Non-blocking scope gate (skill):** `/review-pr` step 5 now includes a decision gate — if a finding is in-scope for the task AND the fix is known/actionable, it must be classified as BLOCKING. "Non-blocking" is reserved for genuinely out-of-scope or investigation-required items.

3. **Retrospective protocol (CLAUDE.md):** Work Completion section now states that process corrections require `/retrospective` invocation for structural fixes (hooks, skills, CLAUDE.md). Saving a memory is not enforcement.