### PR TITLE
fix(mt#823): Fix spec_get single-backend mode and migrate-backend error details

### DIFF
--- a/src/adapters/shared/commands/tasks/migrate-backend-command.ts
+++ b/src/adapters/shared/commands/tasks/migrate-backend-command.ts
@@ -218,9 +218,10 @@ export class TasksMigrateBackendCommand extends BaseTaskCommand<MigrateBackendPa
         migrated: result.migrated,
         skipped: result.skipped,
         errors: result.errors,
-        validated: validationResult?.passed.length || 0,
-        validationFailed: validationResult?.failed.length || 0,
+        validated: validationResult?.passed?.length ?? 0,
+        validationFailed: validationResult?.failed?.length ?? 0,
       },
+      errorDetails: result.details?.filter((d: MigrationDetail) => d.error) ?? [],
     };
   }
 

--- a/src/domain/tasks.ts
+++ b/src/domain/tasks.ts
@@ -243,35 +243,14 @@ export async function getTaskSpecContentFromParams(
   const workspacePath = process.cwd();
   log.debug("tasks.spec params", { backend: validParams.backend });
 
-  // Determine backend (prefer CLI param, else config)
-  let backend = validParams.backend;
-  if (!backend) {
-    try {
-      const { ConfigurationLoader } = await import("./configuration/loader");
-      const configLoader = new ConfigurationLoader();
-      const configResult = await configLoader.load();
-      if (configResult.config.tasks?.backend) {
-        backend = configResult.config.tasks.backend;
-        log.debug("tasks.spec backend from configuration", { backend });
-      } else if (configResult.config.backend) {
-        // Fallback to deprecated root backend property for backward compatibility
-        backend = configResult.config.backend as string;
-        log.warn("Using deprecated root 'backend' property. Please use 'tasks.backend' instead.", {
-          backend,
-        });
-      }
-    } catch (error) {
-      log.debug("tasks.spec failed to load configuration", { error });
-    }
-  }
-
   const taskService = await createConfiguredTaskService({
     workspacePath,
-    backend,
+    backend: validParams.backend,
     persistenceProvider: deps?.persistenceProvider,
   });
   log.debug("tasks.spec created TaskService", {
-    backend: taskService.listBackends!().find((b) => b.prefix === backend)?.name || "default",
+    backend:
+      taskService.listBackends!().find((b) => b.prefix === validParams.backend)?.name || "default",
   });
   return await taskService.getTaskSpecContent(validParams.taskId);
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: `getTaskSpecContentFromParams` was loading config and explicitly setting `backend` from it, forcing single-backend mode. This meant `gh#` tasks couldn't be found via `spec_get`. Fixed by removing the config-loading block — `validParams.backend` (undefined if not provided) is now passed directly to `createConfiguredTaskService`, enabling multi-backend mode like all other `*FromParams` functions.

- **Bug 2**: The non-JSON return path of `migrate-backend-command` only returned summary counts, omitting error details. Fixed by adding `errorDetails: result.details?.filter((d) => d.error) ?? []` to the non-JSON return so callers can see what failed without needing `--json`.

## Test plan
- [ ] `minsky tasks spec-get gh#<id>` now works without specifying `--backend github` explicitly
- [ ] `minsky tasks migrate-backend` non-JSON output (without `--json`) now includes error detail entries when migrations fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)