### PR TITLE
fix(mt#829): Fix GitHubIssuesTaskBackend.getTask excluding closed issues

### DIFF
--- a/src/domain/tasks/githubIssuesTaskBackend.ts
+++ b/src/domain/tasks/githubIssuesTaskBackend.ts
@@ -230,7 +230,7 @@ export class GitHubIssuesTaskBackend implements TaskBackend {
 
   async getTask(id: string): Promise<Task | null> {
     try {
-      const tasks = await this.listTasks();
+      const tasks = await this.listTasks({ all: true });
       return tasks.find((task) => task.id === id) || null;
     } catch (error) {
       log.error("Failed to get task", { id, error: getErrorMessage(error) });


### PR DESCRIPTION
## Summary

One-line fix: `GitHubIssuesTaskBackend.getTask(id)` called `this.listTasks()` without `{ all: true }`, so DONE/CLOSED GitHub issues were filtered out and returned null. This broke `tasks_migrate-backend` ("Task not found in source" for closed issues) and any direct lookup of closed tasks.

Fix: pass `{ all: true }` to `listTasks` in `getTask`.