### PR TITLE
fix(mt#830): Fix session_commit not passing sessionProvider to git operations

### DIFF
--- a/src/domain/git/git-params-facade.ts
+++ b/src/domain/git/git-params-facade.ts
@@ -4,7 +4,8 @@
  * Interface-agnostic delegation functions that wrap modularGitCommandsManager methods.
  * Extracted from git.ts to reduce file size while preserving the public API.
  */
-import { modularGitCommandsManager } from "./git-commands-modular";
+import { modularGitCommandsManager, createModularGitCommandsManager } from "./git-commands-modular";
+import type { GitOperationDependencies } from "./operations/base-git-operation";
 import type { PreparePrResult } from "./prepare-pr-operations";
 import type { MergePrResult } from "./merge-pr-operations";
 import type { CloneResult } from "./clone-operations";
@@ -31,15 +32,19 @@ export async function createPullRequestFromParams(params: {
  * Interface-agnostic function to commit changes
  * MODULARIZED: Delegates to modular operation
  */
-export async function commitChangesFromParams(params: {
-  message: string;
-  session?: string;
-  repo?: string;
-  all?: boolean;
-  amend?: boolean;
-  noStage?: boolean;
-}): Promise<{ commitHash: string; message: string }> {
-  return await modularGitCommandsManager.commitChangesFromParams(params);
+export async function commitChangesFromParams(
+  params: {
+    message: string;
+    session?: string;
+    repo?: string;
+    all?: boolean;
+    amend?: boolean;
+    noStage?: boolean;
+  },
+  deps?: GitOperationDependencies
+): Promise<{ commitHash: string; message: string }> {
+  const manager = deps ? createModularGitCommandsManager(deps) : modularGitCommandsManager;
+  return await manager.commitChangesFromParams(params);
 }
 
 /**
@@ -101,15 +106,18 @@ export async function branchFromParams(params: {
  * Interface-agnostic function to push changes to a remote repository
  * MODULARIZED: Delegates to modular operation
  */
-export async function pushFromParams(params: {
-  session?: string;
-  repo?: string;
-  remote?: string;
-  force?: boolean;
-  debug?: boolean;
-}): Promise<PushResult> {
-  const { modularGitCommandsManager } = await import("./git-commands-modular");
-  return await modularGitCommandsManager.pushFromParams(params);
+export async function pushFromParams(
+  params: {
+    session?: string;
+    repo?: string;
+    remote?: string;
+    force?: boolean;
+    debug?: boolean;
+  },
+  deps?: GitOperationDependencies
+): Promise<PushResult> {
+  const manager = deps ? createModularGitCommandsManager(deps) : modularGitCommandsManager;
+  return await manager.pushFromParams(params);
 }
 
 /**

--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -181,13 +181,16 @@ export async function sessionCommit(
     // Commit changes using session-scoped git command
     let commitResult!: { commitHash: string; message: string };
     try {
-      commitResult = await commitChangesFromParams({
-        message: params.message,
-        session: params.session, // Always use session context
-        all: params.all,
-        amend: params.amend,
-        noStage: params.noStage,
-      });
+      commitResult = await commitChangesFromParams(
+        {
+          message: params.message,
+          session: params.session, // Always use session context
+          all: params.all,
+          amend: params.amend,
+          noStage: params.noStage,
+        },
+        { createGitService, sessionProvider }
+      );
     } catch (commitErr: unknown) {
       // Handle "nothing to commit" gracefully — not an error condition
       if (commitErr instanceof NothingToCommitError) {
@@ -204,9 +207,12 @@ export async function sessionCommit(
     }
 
     // Always push changes in session context - commit and push should be atomic
-    const pushResult = await pushFromParams({
-      session: params.session, // Always use session context
-    });
+    const pushResult = await pushFromParams(
+      {
+        session: params.session, // Always use session context
+      },
+      { createGitService, sessionProvider }
+    );
 
     // Collect commit metadata and changed files
     const gitService = createGitService();


### PR DESCRIPTION
## Summary

`sessionCommit` called `commitChangesFromParams` and `pushFromParams` via the git facade, which used a singleton manager without `sessionProvider`. The session UUID could not be resolved to a directory path, causing "sessionProvider is required" errors on `mcp__minsky__session_commit`.

Fix: add optional `deps` parameter to facade functions (matching the pattern in `git-commands-modular.ts`), pass `{ createGitService, sessionProvider }` from `sessionCommit`.