### PR TITLE
refactor(mt#827): Migrate .merge() → .extend() across all schema files

### DIFF
--- a/src/adapters/mcp/schemas/common-parameters.ts
+++ b/src/adapters/mcp/schemas/common-parameters.ts
@@ -242,49 +242,53 @@ export const GrepSearchSchema = z.object({
  * Base schema for all session file operations
  * Combines session identifier and file path
  */
-export const SessionFileOperationSchema = SessionIdentifierSchema.merge(FilePathSchema);
+export const SessionFileOperationSchema = SessionIdentifierSchema.extend(FilePathSchema.shape);
 
 /**
  * Schema for session file read operations
  * Includes line range support and explanation
  */
-export const SessionFileReadSchema =
-  SessionFileOperationSchema.merge(LineRangeSchema).merge(ExplanationSchema);
+export const SessionFileReadSchema = SessionFileOperationSchema.extend(
+  LineRangeSchema.shape
+).extend(ExplanationSchema.shape);
 
 /**
  * Schema for session file write operations
  * Includes content and directory creation options
  */
-export const SessionFileWriteSchema =
-  SessionFileOperationSchema.merge(FileContentSchema).merge(CreateDirectoriesSchema);
+export const SessionFileWriteSchema = SessionFileOperationSchema.extend(
+  FileContentSchema.shape
+).extend(CreateDirectoriesSchema.shape);
 
 /**
  * Schema for session file edit operations
  * Includes edit instructions, directory creation options, and dry-run support
  */
-export const SessionFileEditSchema = SessionFileOperationSchema.merge(EditInstructionsSchema)
-  .merge(CreateDirectoriesSchema)
-  .merge(DryRunSchema);
+export const SessionFileEditSchema = SessionFileOperationSchema.extend(EditInstructionsSchema.shape)
+  .extend(CreateDirectoriesSchema.shape)
+  .extend(DryRunSchema.shape);
 
 /**
  * Schema for session search and replace operations
  * Includes search/replace parameters
  */
-export const SessionSearchReplaceSchema = SessionFileOperationSchema.merge(SearchReplaceSchema);
+export const SessionSearchReplaceSchema = SessionFileOperationSchema.extend(
+  SearchReplaceSchema.shape
+);
 
 /**
  * Schema for session directory listing operations
  * Includes optional directory path and hidden files option
  */
-export const SessionDirectoryListSchema = SessionIdentifierSchema.merge(
-  OptionalDirectoryPathSchema
-).merge(ShowHiddenFilesSchema);
+export const SessionDirectoryListSchema = SessionIdentifierSchema.extend(
+  OptionalDirectoryPathSchema.shape
+).extend(ShowHiddenFilesSchema.shape);
 
 /**
  * Schema for session grep search operations
  * Includes session identifier and grep parameters
  */
-export const SessionGrepSearchSchema = SessionIdentifierSchema.merge(GrepSearchSchema);
+export const SessionGrepSearchSchema = SessionIdentifierSchema.extend(GrepSearchSchema.shape);
 
 /**
  * Schema for session file existence check
@@ -301,35 +305,35 @@ export const SessionFileDeleteSchema = SessionFileOperationSchema;
 /**
  * Schema for session file movement/rename operations
  */
-export const SessionFileMoveSchema = SessionIdentifierSchema.merge(
+export const SessionFileMoveSchema = SessionIdentifierSchema.extend(
   z.object({
     sourcePath: z.string().describe("Current file path within the session workspace"),
     targetPath: z.string().describe("New file path within the session workspace"),
     overwrite: z.boolean().optional().default(false).describe("Overwrite target if it exists"),
-  })
-).merge(CreateDirectoriesSchema);
+  }).shape
+).extend(CreateDirectoriesSchema.shape);
 
 /**
  * Schema for session file rename operations
  */
-export const SessionFileRenameSchema = SessionFileOperationSchema.merge(
+export const SessionFileRenameSchema = SessionFileOperationSchema.extend(
   z.object({
     newName: z.string().describe("New filename (not full path)"),
     overwrite: z.boolean().optional().default(false).describe("Overwrite target if it exists"),
-  })
+  }).shape
 );
 
 /**
  * Schema for session directory creation
  */
-export const SessionDirectoryCreateSchema = SessionFileOperationSchema.merge(
+export const SessionDirectoryCreateSchema = SessionFileOperationSchema.extend(
   z.object({
     recursive: z
       .boolean()
       .optional()
       .default(true)
       .describe("Create parent directories if they don't exist"),
-  })
+  }).shape
 );
 
 // ========================

--- a/src/adapters/mcp/task-edit-tools.ts
+++ b/src/adapters/mcp/task-edit-tools.ts
@@ -35,22 +35,22 @@ const TaskIdentifierSchema = z.object({
 /**
  * Schema for task edit operations
  */
-const TaskEditSchema = TaskIdentifierSchema.merge(
+const TaskEditSchema = TaskIdentifierSchema.extend(
   z.object({
     instructions: z.string().describe("Instructions describing the edit to make"),
     content: z.string().describe("The edit content with '// ... existing code ...' markers"),
     dryRun: z.boolean().optional().default(false).describe("Preview changes without applying"),
-  })
+  }).shape
 );
 
 /**
  * Schema for task search and replace operations
  */
-const TaskSearchReplaceSchema = TaskIdentifierSchema.merge(
+const TaskSearchReplaceSchema = TaskIdentifierSchema.extend(
   z.object({
     search: z.string().describe("Text to search for (must be unique in the task spec)"),
     replace: z.string().describe("Text to replace with"),
-  })
+  }).shape
 );
 
 // ========================

--- a/src/domain/schemas/common-schemas.ts
+++ b/src/domain/schemas/common-schemas.ts
@@ -191,7 +191,7 @@ export const BaseSortingSchema = z.object({
 /**
  * Complete listing parameters combining pagination and sorting
  */
-export const BaseListingParametersSchema = BasePaginationSchema.merge(BaseSortingSchema);
+export const BaseListingParametersSchema = BasePaginationSchema.extend(BaseSortingSchema.shape);
 
 // ========================
 // COMMON RESPONSE BUILDERS

--- a/src/domain/schemas/file-schemas.ts
+++ b/src/domain/schemas/file-schemas.ts
@@ -178,39 +178,39 @@ export const BaseDirectoryOperationSchema = z.object({
 /**
  * File read operation schema
  */
-export const FileReadSchema = BaseFileOperationSchema.merge(LineRangeSchema).merge(
-  z.object({ explanation: ExplanationSchema })
+export const FileReadSchema = BaseFileOperationSchema.extend(LineRangeSchema.shape).extend(
+  z.object({ explanation: ExplanationSchema }).shape
 );
 
 /**
  * File write operation schema
  */
-export const FileWriteSchema = BaseFileOperationSchema.merge(
+export const FileWriteSchema = BaseFileOperationSchema.extend(
   z.object({
     content: FileContentSchema,
     createDirs: CreateDirectoriesSchema,
-  })
+  }).shape
 );
 
 /**
  * File edit operation schema
  */
-export const FileEditSchema = BaseFileOperationSchema.merge(
+export const FileEditSchema = BaseFileOperationSchema.extend(
   z.object({
     instructions: EditInstructionsSchema,
     content: EditContentSchema,
     createDirs: CreateDirectoriesSchema,
-  })
+  }).shape
 );
 
 /**
  * File search/replace operation schema
  */
-export const FileSearchReplaceSchema = BaseFileOperationSchema.merge(
+export const FileSearchReplaceSchema = BaseFileOperationSchema.extend(
   z.object({
     search: SearchTextSchema,
     replace: ReplacementTextSchema,
-  })
+  }).shape
 );
 
 /**
@@ -237,20 +237,20 @@ export const FileMoveSchema = z.object({
 /**
  * File rename operation schema
  */
-export const FileRenameSchema = BaseFileOperationSchema.merge(
+export const FileRenameSchema = BaseFileOperationSchema.extend(
   z.object({
     newName: NewFilenameSchema,
     overwrite: OverwriteSchema,
-  })
+  }).shape
 );
 
 /**
  * Directory listing schema
  */
-export const DirectoryListSchema = BaseDirectoryOperationSchema.merge(
+export const DirectoryListSchema = BaseDirectoryOperationSchema.extend(
   z.object({
     showHidden: ShowHiddenSchema,
-  })
+  }).shape
 );
 
 /**
@@ -308,7 +308,7 @@ export const BaseFileResponseSchema = z.object({
  * File operation response schema
  */
 export const FileOperationResponseSchema = z.union([
-  BaseSuccessResponseSchema.merge(BaseFileResponseSchema).extend({
+  BaseSuccessResponseSchema.extend(BaseFileResponseSchema.shape).extend({
     bytesWritten: z.number().optional(),
     created: z.boolean().optional(),
     edited: z.boolean().optional(),
@@ -343,7 +343,7 @@ export const FileOperationResponseSchema = z.union([
  * File read response schema
  */
 export const FileReadResponseSchema = z.union([
-  BaseSuccessResponseSchema.merge(BaseFileResponseSchema).extend({
+  BaseSuccessResponseSchema.extend(BaseFileResponseSchema.shape).extend({
     content: FileContentSchema,
     totalLines: z.number().optional(),
     linesRead: z
@@ -387,7 +387,7 @@ export const DirectoryListResponseSchema = z.union([
  * File existence response schema
  */
 export const FileExistsResponseSchema = z.union([
-  BaseSuccessResponseSchema.merge(BaseFileResponseSchema).extend({
+  BaseSuccessResponseSchema.extend(BaseFileResponseSchema.shape).extend({
     exists: z.boolean(),
     isFile: z.boolean().optional(),
     isDirectory: z.boolean().optional(),

--- a/src/domain/schemas/session-schemas.ts
+++ b/src/domain/schemas/session-schemas.ts
@@ -72,8 +72,8 @@ export const SessionStartParametersSchema = z
     noStatusUpdate: z.boolean().default(false),
     quiet: QuietSchema,
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 /**
  * Session retrieval parameters
@@ -85,14 +85,14 @@ export const SessionGetParametersSchema = z
     task: TaskIdSchema.optional(),
     json: z.boolean().optional(),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session listing parameters
  */
-export const SessionListParametersSchema = BaseBackendParametersSchema.merge(
-  BaseExecutionContextSchema
-).merge(BaseListingParametersSchema);
+export const SessionListParametersSchema = BaseBackendParametersSchema.extend(
+  BaseExecutionContextSchema.shape
+).extend(BaseListingParametersSchema.shape);
 
 /**
  * Session deletion parameters
@@ -105,7 +105,7 @@ export const SessionDeleteParametersSchema = z
     force: ForceSchema,
     json: z.boolean().optional(),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session update parameters
@@ -126,7 +126,7 @@ export const SessionUpdateParametersSchema = z
     skipConflictCheck: z.boolean().default(false),
     skipIfAlreadyMerged: z.boolean().default(false),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session directory parameters
@@ -138,7 +138,7 @@ export const SessionDirectoryParametersSchema = z
     task: TaskIdSchema.optional(),
     json: z.boolean().optional(),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session PR creation parameters
@@ -160,7 +160,7 @@ export const SessionPRParametersSchema = z
     autoResolveDeleteConflicts: z.boolean().default(false),
     draft: z.boolean().default(false),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session approval parameters
@@ -173,7 +173,7 @@ export const SessionApproveParametersSchema = z
     task: TaskIdSchema.optional(),
     noStash: z.boolean().default(false),
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Session commit parameters

--- a/src/domain/schemas/task-schemas.ts
+++ b/src/domain/schemas/task-schemas.ts
@@ -86,7 +86,7 @@ export const TaskCreateParametersSchema = z
     dueDate: TaskDueDateSchema,
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Task update parameters
@@ -103,7 +103,7 @@ export const TaskUpdateParametersSchema = z
     dueDate: TaskDueDateSchema,
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Task deletion parameters
@@ -113,7 +113,7 @@ export const TaskDeleteParametersSchema = z
     taskId: TaskIdSchema,
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Task retrieval parameters
@@ -122,8 +122,8 @@ export const TaskGetParametersSchema = z
   .object({
     taskId: TaskIdSchema,
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 /**
  * Task listing parameters
@@ -136,9 +136,9 @@ export const TaskListParametersSchema = z
     tags: TaskTagsSchema,
     all: z.boolean().default(false),
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema)
-  .merge(BaseListingParametersSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape)
+  .extend(BaseListingParametersSchema.shape);
 
 /**
  * Task status update parameters
@@ -148,7 +148,7 @@ export const TaskStatusUpdateParametersSchema = z
     taskId: TaskIdSchema,
     status: TaskStatusSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Task specification retrieval parameters
@@ -158,8 +158,8 @@ export const TaskSpecParametersSchema = z
     taskId: TaskIdSchema,
     section: z.string().optional(),
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 // ========================
 // MULTI-BACKEND TASK PARAMETERS
@@ -179,7 +179,7 @@ export const MultiBackendTaskCreateParametersSchema = z
     force: ForceSchema,
     backend: BackendIdSchema.optional(), // Optional backend selection
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Multi-backend task update parameters
@@ -196,7 +196,7 @@ export const MultiBackendTaskUpdateParametersSchema = z
     dueDate: TaskDueDateSchema,
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Multi-backend task deletion parameters
@@ -206,7 +206,7 @@ export const MultiBackendTaskDeleteParametersSchema = z
     taskId: NormalizedTaskIdSchema, // Auto-migrates legacy IDs
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema);
+  .extend(BaseBackendParametersSchema.shape);
 
 /**
  * Multi-backend task retrieval parameters
@@ -215,8 +215,8 @@ export const MultiBackendTaskGetParametersSchema = z
   .object({
     taskId: NormalizedTaskIdSchema, // Auto-migrates legacy IDs
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 /**
  * Multi-backend task listing parameters
@@ -230,9 +230,9 @@ export const MultiBackendTaskListParametersSchema = z
     backend: BackendIdSchema.optional(), // Filter by specific backend
     backends: z.array(BackendIdSchema).optional(), // Filter by multiple backends
   })
-  .merge(BaseListingParametersSchema)
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseListingParametersSchema.shape)
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 /**
  * Cross-backend task search parameters
@@ -244,9 +244,9 @@ export const CrossBackendTaskSearchParametersSchema = z
     status: TaskStatusSchema.optional(),
     priority: TaskPrioritySchema.optional(),
   })
-  .merge(BaseListingParametersSchema)
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseListingParametersSchema.shape)
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 /**
  * Task migration parameters
@@ -257,8 +257,8 @@ export const TaskMigrationParametersSchema = z
     targetBackend: BackendIdSchema,
     force: ForceSchema,
   })
-  .merge(BaseBackendParametersSchema)
-  .merge(BaseExecutionContextSchema);
+  .extend(BaseBackendParametersSchema.shape)
+  .extend(BaseExecutionContextSchema.shape);
 
 // ========================
 // TASK RESPONSE SCHEMAS

--- a/src/schemas/git.ts
+++ b/src/schemas/git.ts
@@ -21,7 +21,7 @@ export const gitCloneParamsSchema = z
     branch: z.string().optional().describe("Branch to checkout after cloning"),
     depth: z.number().optional().describe("Create a shallow clone with specified depth"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for git clone parameters
@@ -36,7 +36,7 @@ export const gitBranchParamsSchema = z
     name: z.string().min(1).describe("Name of the _branch to create"),
     repo: repoPathSchema.optional().describe("Path to the git repository"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for git branch parameters
@@ -92,7 +92,7 @@ export const gitPushParamsSchema = z
     branch: z.string().optional().describe("Branch to push"),
     force: flagSchema("Force push"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for git push parameters

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -48,7 +48,7 @@ export const sessionGetParamsSchema = z
     name: sessionIdSchema.optional().describe("Name of the session to retrieve"),
     task: taskIdSchema.optional().describe("Task ID associated with the session"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.name !== undefined || data.task !== undefined, {
     message: "Either session ID or task ID must be provided",
   });
@@ -76,7 +76,7 @@ export const sessionStartParamsSchema = z
       .optional()
       .describe("Override the detected package manager"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine(
     (data) => {
       // Phase 2: Task association is required
@@ -105,7 +105,7 @@ export const sessionDeleteParamsSchema = z
     task: taskIdSchema.optional().describe("Task ID associated with the session"),
     force: flagSchema("Skip confirmation prompt"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.name !== undefined || data.task !== undefined, {
     message: "Either session ID or task ID must be provided",
   });
@@ -123,7 +123,7 @@ export const sessionDirParamsSchema = z
     name: sessionIdSchema.optional().describe("Name of the session"),
     task: taskIdSchema.optional().describe("Task ID associated with the session"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.name !== undefined || data.task !== undefined, {
     message: "Either session ID or task ID must be provided",
   });
@@ -152,7 +152,7 @@ export const sessionUpdateParamsSchema = z
     dryRun: flagSchema("Check for conflicts without performing actual update"),
     skipIfAlreadyMerged: flagSchema("Skip update if session changes are already in base branch"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.name !== undefined || data.task !== undefined, {
     message: "Either session ID or task ID must be provided",
   });
@@ -176,7 +176,7 @@ export const sessionApproveParamsSchema = z
       .default(false)
       .describe("Skip automatic stashing of uncommitted changes"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.name !== undefined || data.task !== undefined || data.repo !== undefined, {
     message: "Either session ID, task ID, or repo path must be provided",
   });
@@ -205,7 +205,7 @@ export const sessionPrParamsSchema = z
     ),
     skipConflictCheck: flagSchema("Skip proactive conflict detection during update"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => !(data.body && data.bodyPath), {
     message: "Cannot provide both 'body' and 'bodyPath' - use one or the other",
     path: ["body"],
@@ -231,7 +231,7 @@ export const sessionReviewParamsSchema = z
     output: z.string().optional().describe("File path to save the review output"),
     prBranch: z.string().optional().describe("PR branch name (defaults to 'pr/<session>')"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for session review parameters
@@ -241,7 +241,7 @@ export type SessionReviewParams = z.infer<typeof sessionReviewParamsSchema>;
 /**
  * Schema for session inspect parameters
  */
-export const sessionInspectParamsSchema = z.object({}).merge(commonCommandOptionsSchema);
+export const sessionInspectParamsSchema = z.object({}).extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for session inspect parameters

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -83,7 +83,7 @@ export const taskStatusGetParamsSchema = z
       .optional()
       .describe("Specify task backend (available: github-issues, minsky)"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for task status get parameters
@@ -102,7 +102,7 @@ export const taskStatusSetParamsSchema = z
       .optional()
       .describe("Specify task backend (available: github-issues, minsky)"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for task status set parameters
@@ -134,7 +134,7 @@ export const taskCreateParamsSchema = z
       .optional()
       .describe("Tags/labels for thematic batching (e.g., ['di-cleanup', 'test-quality'])"),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine(
     (data) => {
       // Either spec or description must be provided (description is deprecated alias for spec)
@@ -176,7 +176,7 @@ export const taskCreateFromTitleAndSpecParamsSchema = z
         "GitHub repository override in 'owner/repo' format (only for github-issues backend)"
       ),
   })
-  .merge(commonCommandOptionsSchema)
+  .extend(commonCommandOptionsSchema.shape)
   .refine((data) => data.spec, {
     message: "'spec' must be provided",
     path: ["spec"],
@@ -197,7 +197,7 @@ export const taskSpecContentParamsSchema = z
       .optional()
       .describe("Specify task backend (available: github-issues, minsky)"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for task spec content parameters
@@ -216,7 +216,7 @@ export const taskDeleteParamsSchema = z
       .optional()
       .describe("Specify task backend (available: github-issues, minsky)"),
   })
-  .merge(commonCommandOptionsSchema);
+  .extend(commonCommandOptionsSchema.shape);
 
 /**
  * Type for task delete parameters


### PR DESCRIPTION
## Summary

Phase 2 of the Zod v3→v4 migration (parent: mt#824). Replaces all 81 `.merge()` calls with `.extend(B.shape)` across 9 schema files. `.merge()` is deprecated in Zod v4.

Files changed:
- `src/domain/schemas/task-schemas.ts` — 24 merges
- `src/adapters/mcp/schemas/common-parameters.ts` — 14 merges
- `src/domain/schemas/session-schemas.ts` — 10 merges
- `src/domain/schemas/file-schemas.ts` — 9 merges
- `src/schemas/session.ts` — 9 merges
- `src/schemas/tasks.ts` — 6 merges
- `src/schemas/git.ts` — 3 merges
- `src/adapters/mcp/task-edit-tools.ts` — 2 merges
- `src/domain/schemas/common-schemas.ts` — 1 merge

The three "may be non-Zod" files (changeset-service.ts, github-pr-operations.ts, changeset-service.test.ts) had zero `.merge(` calls and required no changes.

## Test plan

- [ ] All tests pass
- [ ] TypeScript compilation passes
- [ ] No remaining Zod `.merge()` calls in src/

## Coherence Verification

**Files re-read**: src/domain/schemas/task-schemas.ts, src/adapters/mcp/schemas/common-parameters.ts, src/domain/schemas/session-schemas.ts, src/domain/schemas/file-schemas.ts, src/schemas/session.ts, src/schemas/tasks.ts, src/schemas/git.ts, src/adapters/mcp/task-edit-tools.ts, src/domain/schemas/common-schemas.ts

**Q1 single purpose**: pass — all files retain the same single purpose (schema definitions). No new mixing of concerns.

**Q2 comment honesty**: pass — all JSDoc comments describe the same schema shapes/purposes. The `.extend(X.shape)` replacement is semantically equivalent to `.merge(X)` and no comments referenced the merge API.

**Q3 naming honesty**: pass — file names and exported schema names are unchanged. The refactor is a pure API substitution.

**Q4 redundant siblings**: pass — no files were added or removed. All 9 files still have distinct purposes.

**Q5 dead exports**: pass — no exports were removed or added. All existing exports remain. The replacement is call-site only.

**Q6 orphan code**: pass — no helper functions or types existed solely to support `.merge()`. The substitution is mechanical.

**Q7 stray artifacts**: pass — no backup files, no TODO markers left by this refactor.

**Items fixed in this PR (beyond original scope)**: none
**Items deferred**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)