### PR TITLE
feat(mt#836): Add includeSpec parameter to tasks.get command

### DIFF
--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -41,6 +41,7 @@ interface TasksListParams extends BaseTaskParams {
  */
 interface TasksGetParams extends BaseTaskParams {
   taskId: string;
+  includeSpec?: boolean;
 }
 
 /**
@@ -361,6 +362,20 @@ export class TasksGetCommand extends BaseTaskCommand<TasksGetParams> {
         extras.subtasks = subtaskSummary;
       }
 
+      // Optionally fetch spec content
+      if (params.includeSpec) {
+        const { getTaskSpecContentFromParams } = await import("../../../../domain/tasks");
+        try {
+          const specResult = await getTaskSpecContentFromParams(
+            { ...this.createTaskParams(params), taskId: validatedTaskId },
+            { persistenceProvider: this.getPersistenceProvider?.() }
+          );
+          extras.spec = specResult.content;
+        } catch {
+          extras.spec = "";
+        }
+      }
+
       let message = `Task ${validatedTaskId} retrieved`;
       if (subtaskSummary) {
         message += `\n\nSubtasks: ${subtaskSummary.done} of ${subtaskSummary.total} done`;
@@ -370,6 +385,9 @@ export class TasksGetCommand extends BaseTaskCommand<TasksGetParams> {
             message += `\n  ${sub.id}: ${sub.title} [${sub.status}]`;
           }
         }
+      }
+      if (params.includeSpec && extras.spec !== undefined) {
+        message += extras.spec ? `\n\nSpec:\n${extras.spec}` : `\n\nSpec: (not found)`;
       }
 
       const result = this.formatResult(

--- a/src/adapters/shared/commands/tasks/task-parameters.ts
+++ b/src/adapters/shared/commands/tasks/task-parameters.ts
@@ -291,6 +291,11 @@ export const tasksGetParams = {
   ...taskIdParam,
   ...taskContextParams,
   ...outputFormatParams,
+  includeSpec: {
+    schema: z.boolean().default(false),
+    description: "Include task specification content in the response",
+    required: false,
+  },
 } satisfies CommandParameterMap;
 
 /**

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -65,6 +65,10 @@ export const taskGetParamsSchema = commonCommandOptionsSchema.extend({
     .string()
     .optional()
     .describe("Specify task backend (available: github-issues, minsky)"),
+  includeSpec: z
+    .boolean()
+    .optional()
+    .describe("Include task specification content in the response"),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Adds `includeSpec` boolean parameter to the `tasks.get` command
- When `true`, fetches the task's spec content and includes it as `extras.spec` in the response and appends it to the message
- Falls back to empty string if spec content cannot be retrieved

## Changes

- `src/adapters/shared/commands/tasks/task-parameters.ts`: Added `includeSpec` to `tasksGetParams` with Zod boolean schema
- `src/schemas/tasks.ts`: Added `includeSpec: z.boolean().optional()` to `taskGetParamsSchema`
- `src/adapters/shared/commands/tasks/crud-commands.ts`: Extended `TasksGetParams` interface and added spec-fetching logic in `execute()`