### PR TITLE
refactor(mt#828): Bridge layers -- instanceof, nativeEnum, strict/passthrough

### DIFF
--- a/src/adapters/mcp/schemas/task-parameters.ts
+++ b/src/adapters/mcp/schemas/task-parameters.ts
@@ -27,7 +27,7 @@ export const TaskTitleSchema = z.string().min(1, "Task title cannot be empty");
  * Task status schema
  * Uses the centralized TaskStatus enum
  */
-export const TaskStatusSchema = z.nativeEnum(TaskStatus, {
+export const TaskStatusSchema = z.enum(TaskStatus, {
   error: "Status must be one of: TODO, IN-PROGRESS, IN-REVIEW, DONE, BLOCKED, CLOSED",
 });
 

--- a/src/adapters/shared/bridges/parameter-mapper.ts
+++ b/src/adapters/shared/bridges/parameter-mapper.ts
@@ -197,26 +197,29 @@ function addTypeHandlingToOption(
  * Try to determine the Zod schema type for appropriate option handling
  */
 function getZodSchemaType(schema: z.ZodType): string | undefined {
+  // Use Zod v4 .type property for schema type identification
+  const schemaType = (schema as { type?: string }).type;
+
   // Handle primitive types
-  if (schema instanceof z.ZodString) return "string";
-  if (schema instanceof z.ZodNumber) return "number";
-  if (schema instanceof z.ZodBoolean) return "boolean";
+  if (schemaType === "string") return "string";
+  if (schemaType === "number") return "number";
+  if (schemaType === "boolean") return "boolean";
 
   // Handle arrays
-  if (schema instanceof z.ZodArray) return "array";
+  if (schemaType === "array") return "array";
 
   // Handle optional types and nullable types (unwrap and check inner type)
-  if (schema instanceof z.ZodOptional || schema instanceof z.ZodNullable) {
-    return getZodSchemaType(schema.unwrap() as z.ZodType);
+  if (schemaType === "optional" || schemaType === "nullable") {
+    return getZodSchemaType((schema as z.ZodOptional | z.ZodNullable).unwrap() as z.ZodType);
   }
 
-  // Handle default types (access inner type differently)
-  if (schema instanceof z.ZodDefault) {
-    return getZodSchemaType(schema._def.innerType as z.ZodType);
+  // Handle default types (unwrap and check inner type)
+  if (schemaType === "default") {
+    return getZodSchemaType((schema as z.ZodDefault).removeDefault() as z.ZodType);
   }
 
   // Handle enums
-  if (schema instanceof z.ZodEnum) return "string";
+  if (schemaType === "enum") return "string";
 
   // Default to string for other types
   return "string";

--- a/src/adapters/shared/schema-bridge.ts
+++ b/src/adapters/shared/schema-bridge.ts
@@ -73,10 +73,14 @@ export function createOptionFlag(name: string, shortFlag?: string): string {
  * @returns Formatted flag string with value placeholder
  */
 export function addValuePlaceholder(flag: string, schema: z.ZodType): string {
+  // Use Zod v4 .type property for schema type identification
+  const schemaType = (schema as { type?: string }).type;
+
   // Determine if the parameter takes a value
   const isBooleanType =
-    schema instanceof z.ZodBoolean ||
-    (schema instanceof z.ZodOptional && schema.unwrap() instanceof z.ZodBoolean);
+    schemaType === "boolean" ||
+    (schemaType === "optional" &&
+      ((schema as z.ZodOptional).unwrap() as { type?: string }).type === "boolean");
 
   // Boolean options don't need a value placeholder
   if (isBooleanType) {
@@ -86,15 +90,15 @@ export function addValuePlaceholder(flag: string, schema: z.ZodType): string {
   // Determine the placeholder text based on schema type
   let placeholder = "value";
 
-  if (schema instanceof z.ZodString) {
+  if (schemaType === "string") {
     placeholder = "string";
-  } else if (schema instanceof z.ZodNumber) {
+  } else if (schemaType === "number") {
     placeholder = "number";
-  } else if (schema instanceof z.ZodEnum) {
+  } else if (schemaType === "enum") {
     placeholder = "enum";
-  } else if (schema instanceof z.ZodOptional) {
+  } else if (schemaType === "optional") {
     // Recurse to check the inner type
-    return addValuePlaceholder(flag, schema.unwrap() as z.ZodType);
+    return addValuePlaceholder(flag, (schema as z.ZodOptional).unwrap() as z.ZodType);
   }
 
   return `${flag} <${placeholder}>`;
@@ -121,8 +125,11 @@ export function getSchemaDescription(
     (schema as { description?: string }).description!.length > 0
   ) {
     description = schema.description;
-  } else if (schema instanceof z.ZodOptional && "description" in schema.unwrap()) {
-    const innerDesc = (schema.unwrap() as { description?: string }).description;
+  } else if (
+    (schema as { type?: string }).type === "optional" &&
+    "description" in (schema as z.ZodOptional).unwrap()
+  ) {
+    const innerDesc = ((schema as z.ZodOptional).unwrap() as { description?: string }).description;
     if (typeof innerDesc === "string" && innerDesc.length > 0) {
       description = innerDesc;
     }

--- a/src/domain/configuration/schemas/ai.ts
+++ b/src/domain/configuration/schemas/ai.ts
@@ -38,82 +38,70 @@ const detectAndWarnUnknownFields = (
 /**
  * Individual AI provider configuration
  */
-export const aiProviderConfigSchema = z
-  .object({
-    // API key for the provider
-    apiKey: baseSchemas.optionalNonEmptyString,
+export const aiProviderConfigSchema = z.object({
+  // API key for the provider
+  apiKey: baseSchemas.optionalNonEmptyString,
 
-    // Path to file containing the API key
-    apiKeyFile: baseSchemas.optionalNonEmptyString,
+  // Path to file containing the API key
+  apiKeyFile: baseSchemas.optionalNonEmptyString,
 
-    // Whether this provider is enabled
-    enabled: z.boolean().default(true),
+  // Whether this provider is enabled
+  enabled: z.boolean().default(true),
 
-    // Default model to use for this provider
-    model: baseSchemas.modelName.optional(),
+  // Default model to use for this provider
+  model: baseSchemas.modelName.optional(),
 
-    // Available models for this provider
-    models: z.array(baseSchemas.modelName).default([]),
+  // Available models for this provider
+  models: z.array(baseSchemas.modelName).default([]),
 
-    // Base URL for the API (for custom endpoints)
-    baseUrl: baseSchemas.url.optional(),
+  // Base URL for the API (for custom endpoints)
+  baseUrl: baseSchemas.url.optional(),
 
-    // Maximum tokens for requests
-    maxTokens: baseSchemas.maxTokens.optional(),
+  // Maximum tokens for requests
+  maxTokens: baseSchemas.maxTokens.optional(),
 
-    // Temperature setting (0-2)
-    temperature: baseSchemas.temperature.optional(),
+  // Temperature setting (0-2)
+  temperature: baseSchemas.temperature.optional(),
 
-    // Custom headers for API requests
-    headers: z.record(z.string(), z.string()).optional(),
-  })
-  .strip();
+  // Custom headers for API requests
+  headers: z.record(z.string(), z.string()).optional(),
+});
 
 /**
  * OpenAI-specific configuration
  */
-export const openaiConfigSchema = aiProviderConfigSchema
-  .extend({
-    // OpenAI-specific organization ID
-    organization: baseSchemas.optionalNonEmptyString,
-  })
-  .strip();
+export const openaiConfigSchema = aiProviderConfigSchema.extend({
+  // OpenAI-specific organization ID
+  organization: baseSchemas.optionalNonEmptyString,
+});
 
 /**
  * Anthropic-specific configuration
  */
-export const anthropicConfigSchema = aiProviderConfigSchema
-  .extend({
-    // Anthropic-specific settings can be added here
-  })
-  .strip();
+export const anthropicConfigSchema = aiProviderConfigSchema.extend({
+  // Anthropic-specific settings can be added here
+});
 
 /**
  * Google-specific configuration
  */
-export const googleConfigSchema = aiProviderConfigSchema
-  .extend({
-    // Google-specific settings can be added here
-  })
-  .strip();
+export const googleConfigSchema = aiProviderConfigSchema.extend({
+  // Google-specific settings can be added here
+});
 
 /**
  * Cohere-specific configuration
  */
-export const cohereConfigSchema = aiProviderConfigSchema
-  .extend({
-    // Cohere-specific settings can be added here
-  })
-  .strip();
+export const cohereConfigSchema = aiProviderConfigSchema.extend({
+  // Cohere-specific settings can be added here
+});
 
 /**
  * Mistral-specific configuration
  */
-export const mistralConfigSchema = aiProviderConfigSchema
-  .extend({
-    // Mistral-specific settings can be added here
-  })
-  .strip();
+export const mistralConfigSchema = aiProviderConfigSchema.extend({
+  // Mistral-specific settings can be added here
+});
 
 /**
  * Morph-specific configuration
@@ -126,7 +114,7 @@ export const morphConfigSchema = aiProviderConfigSchema
     // Base URL defaults to Morph API
     baseUrl: z.string().default("https://api.morphllm.com/v1"),
   })
-  .strict();
+  .strict(); // Keep .strict() — chained after .extend(), can't use z.strictObject()
 
 /**
  * All AI providers configuration with unknown field detection
@@ -143,20 +131,19 @@ const baseAiProvidersSchema = z.object({
 export const aiProvidersConfigSchema = z
   .unknown()
   .transform((data) => detectAndWarnUnknownFields(data, baseAiProvidersSchema, "ai.providers"))
-  .pipe(baseAiProvidersSchema.strip());
+  .pipe(baseAiProvidersSchema);
 
 /**
  * Complete AI configuration
  */
 export const aiConfigSchema = z
-  .object({
+  .looseObject({
     // Default provider to use when no specific provider is requested
     defaultProvider: enumSchemas.aiProvider.optional(),
 
     // Provider-specific configurations
     providers: aiProvidersConfigSchema.default({}),
   })
-  .passthrough() // Changed from .strict() to .passthrough() to allow unknown fields
   .default({
     providers: {},
   });

--- a/src/domain/configuration/schemas/backend.ts
+++ b/src/domain/configuration/schemas/backend.ts
@@ -23,35 +23,30 @@ export const backendSchema = enumSchemas.backendType.optional();
 /**
  * GitHub Issues backend-specific configuration
  */
-export const githubIssuesBackendConfigSchema = z
-  .object({
-    owner: baseSchemas.organizationName.optional(),
-    repo: baseSchemas.repositoryName.optional(),
-  })
-  .strict();
+export const githubIssuesBackendConfigSchema = z.strictObject({
+  owner: baseSchemas.organizationName.optional(),
+  repo: baseSchemas.repositoryName.optional(),
+});
 
 /**
  * Combined backend-specific configurations
  */
 export const backendConfigSchema = z
-  .object({
+  .strictObject({
     "github-issues": githubIssuesBackendConfigSchema.optional(),
   })
-  .strict()
   .default({});
 
 /**
  * Complete backend configuration combining all backend-related settings
  */
-export const backendFullConfigSchema = z
-  .object({
-    // Main backend selection
-    backend: backendSchema,
+export const backendFullConfigSchema = z.strictObject({
+  // Main backend selection
+  backend: backendSchema,
 
-    // Backend-specific configurations
-    backendConfig: backendConfigSchema,
-  })
-  .strict();
+  // Backend-specific configurations
+  backendConfig: backendConfigSchema,
+});
 
 /**
  * Repository GitHub-specific configuration
@@ -67,13 +62,11 @@ export const repositoryGitHubConfigSchema = z.object({
  * Stores the project-level repository backend type and associated settings,
  * detected once at `minsky init` and stored in .minsky/config.yaml.
  */
-export const repositoryConfigSchema = z
-  .object({
-    backend: enumSchemas.repoBackendType.optional(),
-    url: z.string().optional(),
-    github: repositoryGitHubConfigSchema.optional(),
-  })
-  .passthrough();
+export const repositoryConfigSchema = z.looseObject({
+  backend: enumSchemas.repoBackendType.optional(),
+  url: z.string().optional(),
+  github: repositoryGitHubConfigSchema.optional(),
+});
 
 // Type exports
 export type Backend = z.infer<typeof backendSchema>;

--- a/src/domain/configuration/schemas/base.ts
+++ b/src/domain/configuration/schemas/base.ts
@@ -155,37 +155,31 @@ export const credentialSourceSchema = z.enum(["env", "file", "keychain", "manual
   error: "Credential source must be one of: env, file, keychain, manual",
 });
 
-export const credentialConfigSchema = z
-  .object({
-    source: credentialSourceSchema,
-    token: baseSchemas.optionalNonEmptyString,
-    tokenFile: baseSchemas.optionalNonEmptyString,
-    apiKey: baseSchemas.optionalNonEmptyString,
-    apiKeyFile: baseSchemas.optionalNonEmptyString,
-  })
-  .strict();
+export const credentialConfigSchema = z.strictObject({
+  source: credentialSourceSchema,
+  token: baseSchemas.optionalNonEmptyString,
+  tokenFile: baseSchemas.optionalNonEmptyString,
+  apiKey: baseSchemas.optionalNonEmptyString,
+  apiKeyFile: baseSchemas.optionalNonEmptyString,
+});
 
 /**
  * File configuration schema for loading from YAML/JSON files
  */
-export const fileConfigSchema = z
-  .object({
-    path: baseSchemas.filePath,
-    required: z.boolean().default(false),
-    format: z.enum(["yaml", "json", "auto"]).default("auto"),
-  })
-  .strict();
+export const fileConfigSchema = z.strictObject({
+  path: baseSchemas.filePath,
+  required: z.boolean().default(false),
+  format: z.enum(["yaml", "json", "auto"]).default("auto"),
+});
 
 /**
  * Environment variable mapping schema
  */
-export const envVarMappingSchema = z
-  .object({
-    name: baseSchemas.envVarName,
-    path: z.string().min(1, "Configuration path cannot be empty"),
-    transform: z.enum(["string", "number", "boolean", "json"]).default("string"),
-  })
-  .strict();
+export const envVarMappingSchema = z.strictObject({
+  name: baseSchemas.envVarName,
+  path: z.string().min(1, "Configuration path cannot be empty"),
+  transform: z.enum(["string", "number", "boolean", "json"]).default("string"),
+});
 
 export type CredentialConfig = z.infer<typeof credentialConfigSchema>;
 export type FileConfig = z.infer<typeof fileConfigSchema>;

--- a/src/domain/configuration/schemas/github.ts
+++ b/src/domain/configuration/schemas/github.ts
@@ -12,21 +12,20 @@ import { baseSchemas } from "./base";
  * GitHub authentication token configuration
  */
 export const githubTokenSchema = z
-  .object({
+  .strictObject({
     // Direct token value (for environment variable or direct configuration)
     token: baseSchemas.optionalNonEmptyString,
 
     // Path to file containing the token
     tokenFile: baseSchemas.optionalNonEmptyString,
   })
-  .strict()
   .optional();
 
 /**
  * GitHub organization/repository configuration
  */
 export const githubRepoConfigSchema = z
-  .object({
+  .strictObject({
     // GitHub organization or user name
     organization: baseSchemas.organizationName.optional(),
 
@@ -36,14 +35,13 @@ export const githubRepoConfigSchema = z
     // Base URL for GitHub API (for GitHub Enterprise)
     baseUrl: baseSchemas.url.optional(),
   })
-  .strict()
   .optional();
 
 /**
  * Complete GitHub configuration
  */
 export const githubConfigSchema = z
-  .object({
+  .strictObject({
     // Authentication token (from environment variable or file)
     token: baseSchemas.optionalNonEmptyString,
 
@@ -59,7 +57,6 @@ export const githubConfigSchema = z
     // GitHub API base URL (for GitHub Enterprise)
     baseUrl: baseSchemas.url.optional(),
   })
-  .strict()
   .default({});
 
 // Type exports

--- a/src/domain/configuration/schemas/index.ts
+++ b/src/domain/configuration/schemas/index.ts
@@ -37,42 +37,40 @@ import { rulesConfigSchema, type RulesConfig } from "./rules";
  * This is the root schema that defines the entire configuration structure
  * for the Minsky application, combining all domain-specific configurations.
  */
-export const configurationSchema = z
-  .object({
-    // Note: Deprecated root 'backend' property removed - use tasks.backend instead
-    backendConfig: backendConfigSchema,
+export const configurationSchema = z.looseObject({
+  // Note: Deprecated root 'backend' property removed - use tasks.backend instead
+  backendConfig: backendConfigSchema,
 
-    // Modern persistence configuration
-    persistence: persistenceConfigSchema.optional(),
+  // Modern persistence configuration
+  persistence: persistenceConfigSchema.optional(),
 
-    // GitHub integration configuration
-    github: githubConfigSchema,
+  // GitHub integration configuration
+  github: githubConfigSchema,
 
-    // AI providers configuration
-    ai: aiConfigSchema,
+  // AI providers configuration
+  ai: aiConfigSchema,
 
-    // Embeddings configuration
-    embeddings: embeddingsConfigSchema,
+  // Embeddings configuration
+  embeddings: embeddingsConfigSchema,
 
-    // Logging configuration
-    logger: loggerConfigSchema,
+  // Logging configuration
+  logger: loggerConfigSchema,
 
-    // Validation configuration
-    validation: validationConfigSchema,
+  // Validation configuration
+  validation: validationConfigSchema,
 
-    // Tasks configuration
-    tasks: tasksConfigSchema,
+  // Tasks configuration
+  tasks: tasksConfigSchema,
 
-    // Workspace configuration
-    workspace: workspaceConfigSchema,
+  // Workspace configuration
+  workspace: workspaceConfigSchema,
 
-    // Rules configuration
-    rules: rulesConfigSchema,
+  // Rules configuration
+  rules: rulesConfigSchema,
 
-    // Repository backend configuration (project-level, set during minsky init)
-    repository: repositoryConfigSchema.optional(),
-  })
-  .passthrough(); // Use passthrough instead of strict to allow extra properties
+  // Repository backend configuration (project-level, set during minsky init)
+  repository: repositoryConfigSchema.optional(),
+}); // looseObject allows extra properties (equivalent to passthrough)
 
 /**
  * Configuration type inferred from the schema

--- a/src/domain/configuration/schemas/logger.ts
+++ b/src/domain/configuration/schemas/logger.ts
@@ -12,7 +12,7 @@ import { enumSchemas } from "./base";
  * Logger configuration
  */
 export const loggerConfigSchema = z
-  .object({
+  .strictObject({
     // Logging mode: HUMAN (readable), STRUCTURED (JSON), or auto (detect based on environment)
     mode: enumSchemas.loggerMode.default("auto"),
 
@@ -40,7 +40,6 @@ export const loggerConfigSchema = z
     // Number of log files to keep during rotation
     maxFiles: z.number().min(1).max(20).default(5),
   })
-  .strict()
   .default({
     mode: "auto",
     level: "info",

--- a/src/domain/configuration/schemas/tasks.ts
+++ b/src/domain/configuration/schemas/tasks.ts
@@ -2,11 +2,10 @@ import { z } from "zod";
 import { enumSchemas } from "./base";
 
 export const tasksConfigSchema = z
-  .object({
+  .strictObject({
     strictIds: z.boolean().default(false),
     backend: enumSchemas.backendType.optional(), // Optional - let user/environment configuration set this
   })
-  .strict()
   .default({ strictIds: false }); // Removed backend from default object
 
 export type TasksConfig = z.infer<typeof tasksConfigSchema>;

--- a/src/domain/configuration/schemas/validation.ts
+++ b/src/domain/configuration/schemas/validation.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
  * Validation configuration
  */
 export const validationConfigSchema = z
-  .object({
+  .strictObject({
     // Whether to use strict validation (reject unknown fields)
     strictMode: z.boolean().default(false),
 
@@ -24,7 +24,6 @@ export const validationConfigSchema = z
     // Whether to include the validation error code in warnings
     includeCodeInWarnings: z.boolean().default(false),
   })
-  .strict()
   .default({
     strictMode: false,
     warnOnUnknown: true,

--- a/src/domain/context/components/tool-schemas.ts
+++ b/src/domain/context/components/tool-schemas.ts
@@ -17,33 +17,40 @@ type JsonSchema = {
  * Convert a Zod schema to JSON Schema format like Cursor uses
  */
 function zodToJsonSchema(zodSchema: z.ZodType): JsonSchema {
-  if (zodSchema instanceof z.ZodString) {
-    return { type: "string" };
-  } else if (zodSchema instanceof z.ZodNumber) {
-    return { type: "number" };
-  } else if (zodSchema instanceof z.ZodBoolean) {
-    return { type: "boolean" };
-  } else if (zodSchema instanceof z.ZodArray) {
-    return {
-      type: "array",
-      items: zodToJsonSchema(zodSchema._def.element as z.ZodType),
-    };
-  } else if (zodSchema instanceof z.ZodEnum) {
-    return {
-      type: "string",
-      enum: zodSchema.options as string[],
-    };
-  } else if (zodSchema instanceof z.ZodUnion) {
-    const types = (zodSchema._def.options as z.ZodType[]).map((option) => zodToJsonSchema(option));
-    // If it's a simple union of types, just use the first type for simplicity
-    return types[0] || { type: "string" };
-  } else if (zodSchema instanceof z.ZodOptional) {
-    return zodToJsonSchema(zodSchema.unwrap() as z.ZodType);
-  } else if (zodSchema instanceof z.ZodDefault) {
-    return zodToJsonSchema(zodSchema._def.innerType as z.ZodType);
-  } else {
-    // Default to string for unknown types
-    return { type: "string" };
+  // Use Zod v4 .type property for schema type identification
+  const schemaType = (zodSchema as { type?: string }).type;
+
+  switch (schemaType) {
+    case "string":
+      return { type: "string" };
+    case "number":
+      return { type: "number" };
+    case "boolean":
+      return { type: "boolean" };
+    case "array":
+      return {
+        type: "array",
+        items: zodToJsonSchema((zodSchema as z.ZodArray).element as z.ZodType),
+      };
+    case "enum":
+      return {
+        type: "string",
+        enum: (zodSchema as z.ZodEnum).options as string[],
+      };
+    case "union": {
+      const types = ((zodSchema as z.ZodUnion).options as z.ZodType[]).map((option) =>
+        zodToJsonSchema(option)
+      );
+      // If it's a simple union of types, just use the first type for simplicity
+      return types[0] || { type: "string" };
+    }
+    case "optional":
+      return zodToJsonSchema((zodSchema as z.ZodOptional).unwrap() as z.ZodType);
+    case "default":
+      return zodToJsonSchema((zodSchema as z.ZodDefault).removeDefault() as z.ZodType);
+    default:
+      // Default to string for unknown types
+      return { type: "string" };
   }
 }
 

--- a/src/domain/schemas/task-schemas.ts
+++ b/src/domain/schemas/task-schemas.ts
@@ -28,7 +28,7 @@ import {
  * Task status schema - used across all interfaces
  * Uses the TaskStatus enum for type safety and consistency
  */
-export const TaskStatusSchema = z.nativeEnum(TaskStatus);
+export const TaskStatusSchema = z.enum(TaskStatus);
 
 /**
  * Task priority schema - used across all interfaces


### PR DESCRIPTION
## Summary

Phase 3 of the Zod v3-to-v4 migration (parent: mt#824). Three categories of changes:

1. **instanceof migration**: Replaced `instanceof z.ZodString/ZodNumber/etc.` with Zod v4 `.type` property checks in tool-schemas.ts, schema-bridge.ts, and parameter-mapper.ts. Also replaced `._def.element` with `.element`, `._def.options` with `.options`, and `._def.innerType` with `.removeDefault()`. `instanceof z.ZodError` checks are preserved (valid for error catching).

2. **nativeEnum replacement**: Replaced `z.nativeEnum(TaskStatus)` with `z.enum(TaskStatus)` in task-schemas.ts and task-parameters.ts. In Zod v4, `z.enum()` accepts both arrays and enum objects directly.

3. **strict/passthrough/strip migration**: Replaced `z.object({}).strict()` with `z.strictObject({})`, `z.object({}).passthrough()` with `z.looseObject({})`, and removed `.strip()` calls (strip is the default in Zod v4). One `.strict()` is intentionally kept on `morphConfigSchema` where it's chained after `.extend()` on a non-strict base.

## Verification

- `grep -r 'instanceof z\.Zod[^E]' src/` returns 0 matches
- No remaining `z.nativeEnum()` calls
- No remaining `._def.` references in source
- TypeScript compiles clean (verified by pre-commit hook)

## Test plan

- [x] All tests pass (pre-commit hook)
- [x] grep confirms 0 instanceof z.Zod[non-Error] matches
- [x] No remaining z.nativeEnum() calls
- [x] TypeScript compiles clean

## Coherence Verification

**Files re-read**: tool-schemas.ts, schema-bridge.ts, parameter-mapper.ts, task-schemas.ts, task-parameters.ts, ai.ts, backend.ts, base.ts, github.ts, index.ts, logger.ts, tasks.ts, validation.ts

**Q1 single purpose**: pass
**Q2 comment honesty**: pass (stale "passthrough" comment removed from index.ts, explanatory comment added to morphConfigSchema)
**Q3 naming honesty**: pass
**Q4 redundant siblings**: pass
**Q5 dead exports**: pass (grep confirmed no dead exports from modified files)
**Q6 orphan code**: pass
**Q7 stray artifacts**: pass

**Items fixed in this PR (beyond original scope)**: none
**Items deferred (with justification)**: morphConfigSchema .strict() left as-is -- cannot use z.strictObject() when the base schema uses strip and we need strict only on the extension

Generated with [Claude Code](https://claude.com/claude-code)