### PR TITLE
fix(mt#837): Align MCP tasks_available minReadiness default with CLI

### DIFF
--- a/src/adapters/shared/commands/tasks/routing-commands.ts
+++ b/src/adapters/shared/commands/tasks/routing-commands.ts
@@ -39,8 +39,8 @@ const tasksAvailableParams = {
     required: false,
   },
   minReadiness: {
-    schema: z.number().min(0).max(1).default(1.0),
-    description: "Minimum readiness score (0.0-1.0) - use 1.0 for truly available tasks only",
+    schema: z.number().min(0).max(1).default(0.5),
+    description: "Minimum readiness score (0.0-1.0) - default 0.5 shows partially-ready tasks",
     required: false,
   },
 } satisfies CommandParameterMap;
@@ -153,7 +153,7 @@ export function createTasksAvailableCommand(getPersistenceProvider: () => Persis
         }));
       }
 
-      // Filter by readiness score (default 1.0 = only truly available tasks)
+      // Filter by readiness score (default 0.5 = shows partially-ready tasks)
       const readyTasks = availableTasks.filter(
         (task) => task.readinessScore >= params.minReadiness
       );


### PR DESCRIPTION
## Summary

- MCP `tasks_available` defaulted `minReadiness` to `1.0`, filtering out any task with partial dependency readiness
- CLI correctly defaulted to `0.5`
- Changed MCP default to `0.5` to match, so `tasks_available` with no parameters returns workable tasks

## Test plan

- [x] Existing routing-commands tests pass (4/4)
- [ ] Call `tasks_available` via MCP with no parameters — returns TODO tasks
- [ ] Call `tasks_available` with `minReadiness: 1.0` — strict filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)