### PR TITLE
feat(mt#833): Add includeSubtasks opt-in parameter to tasks.get

### DIFF
--- a/src/adapters/shared/commands/tasks/base-task-command.ts
+++ b/src/adapters/shared/commands/tasks/base-task-command.ts
@@ -160,6 +160,26 @@ export abstract class BaseTaskCommand<TParams = BaseTaskParams, TResult = unknow
             output += `Spec: ${taskObj.spec}\n`;
           }
 
+          // Display subtask summary if present
+          if (
+            taskResult.subtasks &&
+            typeof taskResult.subtasks === "object" &&
+            taskResult.subtasks !== null
+          ) {
+            const subtasks = taskResult.subtasks as {
+              total: number;
+              done: number;
+              remaining: Array<{ id: string; title: string; status: string }>;
+            };
+            output += `\nSubtasks: ${subtasks.done} of ${subtasks.total} done\n`;
+            if (subtasks.remaining.length > 0) {
+              output += `Remaining:\n`;
+              for (const sub of subtasks.remaining) {
+                output += `  ${sub.id}: ${sub.title} [${sub.status}]\n`;
+              }
+            }
+          }
+
           return output.trim();
         }
       }

--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -42,6 +42,7 @@ interface TasksListParams extends BaseTaskParams {
 interface TasksGetParams extends BaseTaskParams {
   taskId: string;
   includeSpec?: boolean;
+  includeSubtasks?: boolean;
 }
 
 /**
@@ -305,7 +306,7 @@ export class TasksGetCommand extends BaseTaskCommand<TasksGetParams> {
       });
       this.debug("Task retrieved successfully", { task: task?.id || "unknown" });
 
-      // Enrich with subtask summary if this task has children
+      // Enrich with subtask summary if requested and this task has children
       let subtaskSummary:
         | {
             total: number;
@@ -314,7 +315,7 @@ export class TasksGetCommand extends BaseTaskCommand<TasksGetParams> {
           }
         | undefined;
 
-      if (this.getPersistenceProvider) {
+      if (params.includeSubtasks && this.getPersistenceProvider) {
         try {
           const persistence = this.getPersistenceProvider();
           const db = (await persistence.getDatabaseConnection?.()) as PostgresJsDatabase;

--- a/src/adapters/shared/commands/tasks/task-parameters.ts
+++ b/src/adapters/shared/commands/tasks/task-parameters.ts
@@ -296,6 +296,11 @@ export const tasksGetParams = {
     description: "Include task specification content in the response",
     required: false,
   },
+  includeSubtasks: {
+    schema: z.boolean().default(false),
+    description: "Include subtask summary in the response",
+    required: false,
+  },
 } satisfies CommandParameterMap;
 
 /**

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -69,6 +69,7 @@ export const taskGetParamsSchema = commonCommandOptionsSchema.extend({
     .boolean()
     .optional()
     .describe("Include task specification content in the response"),
+  includeSubtasks: z.boolean().optional().describe("Include subtask summary in the response"),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `includeSubtasks` boolean parameter (default false) to the `tasks.get` command across all layers: interface, `task-parameters.ts`, and `schemas/tasks.ts`
- Gate the subtask enrichment block in `crud-commands.ts` behind `if (params.includeSubtasks)` — the enrichment logic itself was correct, it just shouldn't run unconditionally on every call
- Fix `formatResult` in `base-task-command.ts` to display subtask summary ("Subtasks: X of Y done" + "Remaining:" list) when `subtasks` data is present in the result object
- JSON output: subtasks data already flows via `extras` spread — present when `includeSubtasks=true` and absent when false
- Leaf tasks (no children): when `includeSubtasks=true` but no children exist, no subtask section appears (the enrichment block only sets `subtaskSummary` when `childIds.length > 0`)

## Test plan

- [ ] `tasks.get <task-id>` (without flag) — no subtask enrichment, clean output
- [ ] `tasks.get <parent-task-id> --include-subtasks` — shows "Subtasks: X of Y done" + remaining list
- [ ] `tasks.get <leaf-task-id> --include-subtasks` — no subtask section shown
- [ ] `tasks.get <parent-task-id> --include-subtasks --json` — JSON result includes `subtasks` field
- [ ] `tasks.get <task-id> --json` (without flag) — JSON result has no `subtasks` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)