### PR TITLE
feat(mt#844): tsyringe infrastructure + container replacement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,9 @@
         "gray-matter": "^4.0.3",
         "logform": "^2.7.0",
         "postgres": "^3.4.8",
+        "reflect-metadata": "^0.2.2",
         "tiktoken": "^1.0.22",
+        "tsyringe": "^4.10.0",
         "winston": "^3.17.0",
         "yaml": "^2.8.0",
         "zod": "^4.3.6",
@@ -1140,6 +1142,8 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
@@ -1308,7 +1312,9 @@
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
-    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -1402,6 +1408,12 @@
 
     "@dotenvx/dotenvx/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -1450,11 +1462,15 @@
 
     "@ts-morph/common/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 
+    "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1516,11 +1532,19 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "react-remove-scroll-bar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "react-style-singleton/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
+
+    "rxjs/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "send/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -1545,6 +1569,10 @@
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "use-sidecar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,9 @@
     "gray-matter": "^4.0.3",
     "logform": "^2.7.0",
     "postgres": "^3.4.8",
+    "reflect-metadata": "^0.2.2",
     "tiktoken": "^1.0.22",
+    "tsyringe": "^4.10.0",
     "winston": "^3.17.0",
     "yaml": "^2.8.0",
     "zod": "^4.3.6"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import "reflect-metadata";
 
 // CRITICAL: Import and setup config FIRST before any other imports that might use configuration
 // This ensures the custom configuration system is initialized before any code tries to access it

--- a/src/composition/cli.ts
+++ b/src/composition/cli.ts
@@ -12,7 +12,7 @@
  * @see mt#761 spec, "Phase 2: Create composition roots and wire CLI"
  */
 
-import { AppContainer } from "./container";
+import { TsyringeContainer } from "./container";
 import type { AppContainerInterface } from "./types";
 
 /**
@@ -20,7 +20,7 @@ import type { AppContainerInterface } from "./types";
  * Does NOT call initialize() — the caller controls when async services start.
  */
 export async function createCliContainer(): Promise<AppContainerInterface> {
-  const container = new AppContainer();
+  const container = new TsyringeContainer();
 
   // --- Infrastructure (async) ---
 

--- a/src/composition/container.test.ts
+++ b/src/composition/container.test.ts
@@ -14,8 +14,9 @@
  * - Async factories are properly awaited
  */
 
+import "reflect-metadata";
 import { describe, test, expect } from "bun:test";
-import { AppContainer } from "./container";
+import { TsyringeContainer } from "./container";
 import type { AppServices } from "./types";
 
 // Minimal fakes that satisfy the type constraints
@@ -40,18 +41,18 @@ const fakeGitService = {
   execInRepository: async () => "",
 } as unknown as AppServices["gitService"];
 
-describe("AppContainer", () => {
+describe("TsyringeContainer", () => {
   // --- register() + initialize() + get() ---
 
   test("register + initialize + get: basic sync factory", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.register("persistence", () => fakePersistence);
     await container.initialize();
     expect(container.get("persistence")).toBe(fakePersistence);
   });
 
   test("register + initialize + get: async factory", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.register("persistence", async () => {
       // Simulate async work (DB connection)
       await new Promise((r) => setTimeout(r, 1));
@@ -64,14 +65,14 @@ describe("AppContainer", () => {
   // --- set() ---
 
   test("set: directly provides instance without factory", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.set("persistence", fakePersistence);
     expect(container.get("persistence")).toBe(fakePersistence);
   });
 
   test("set: takes precedence over register (factory not called)", async () => {
     let factoryCalled = false;
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.register("persistence", () => {
       factoryCalled = true;
       return fakePersistence;
@@ -85,12 +86,12 @@ describe("AppContainer", () => {
   // --- get() throws ---
 
   test("get: throws for unregistered service", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     expect(() => container.get("persistence")).toThrow(SERVICE_NOT_AVAILABLE);
   });
 
   test("get: throws for registered but not initialized service", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.register("persistence", () => fakePersistence);
     // initialize() not called
     expect(() => container.get("persistence")).toThrow(SERVICE_NOT_AVAILABLE);
@@ -99,18 +100,18 @@ describe("AppContainer", () => {
   // --- has() ---
 
   test("has: returns false for unregistered service", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     expect(container.has("persistence")).toBe(false);
   });
 
   test("has: returns true after set()", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.set("persistence", fakePersistence);
     expect(container.has("persistence")).toBe(true);
   });
 
   test("has: returns true after initialize()", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.register("persistence", () => fakePersistence);
     expect(container.has("persistence")).toBe(false);
     await container.initialize();
@@ -121,7 +122,7 @@ describe("AppContainer", () => {
 
   test("initialize: resolves factories in registration order", async () => {
     const order: string[] = [];
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     container.register("persistence", () => {
       order.push("persistence");
@@ -143,7 +144,7 @@ describe("AppContainer", () => {
   // --- Dependency resolution via get() ---
 
   test("factories can access previously resolved services", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     container.register("persistence", () => fakePersistence);
     container.register("sessionProvider", (c) => {
@@ -158,7 +159,7 @@ describe("AppContainer", () => {
   });
 
   test("factory throws if dependency not yet resolved (wrong registration order)", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     // Register sessionProvider BEFORE persistence — wrong order
     container.register("sessionProvider", (c) => {
@@ -174,7 +175,7 @@ describe("AppContainer", () => {
 
   test("close: calls registered disposers", async () => {
     let disposed = false;
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     container.register("persistence", () => fakePersistence, {
       dispose: async () => {
@@ -190,7 +191,7 @@ describe("AppContainer", () => {
 
   test("close: disposes in reverse registration order", async () => {
     const order: string[] = [];
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     container.register("persistence", () => fakePersistence, {
       dispose: async () => {
@@ -215,7 +216,7 @@ describe("AppContainer", () => {
   });
 
   test("close: clears all instances", async () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     container.set("persistence", fakePersistence);
     expect(container.has("persistence")).toBe(true);
     await container.close();
@@ -225,7 +226,7 @@ describe("AppContainer", () => {
   // --- Chaining ---
 
   test("register and set return this for chaining", () => {
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
     const result = container
       .register("persistence", () => fakePersistence)
       .set("gitService", fakeGitService);
@@ -236,7 +237,7 @@ describe("AppContainer", () => {
 
   test("re-registering a key updates the factory and moves to end of init order", async () => {
     const order: string[] = [];
-    const container = new AppContainer();
+    const container = new TsyringeContainer();
 
     container.register("persistence", () => {
       order.push("persistence-v1");

--- a/src/composition/container.ts
+++ b/src/composition/container.ts
@@ -1,20 +1,18 @@
 /**
- * Typed DI Container
+ * Typed DI Container — tsyringe-backed
  *
- * A lightweight (~80 lines) container that maps service keys to factory functions,
- * caches resolved instances as singletons, and manages async lifecycle.
+ * Wraps tsyringe's DependencyContainer to implement AppContainerInterface.
+ * Preserves the existing register/get/set/initialize/close lifecycle while
+ * delegating resolution to tsyringe.
  *
- * Design decisions (see mt#761 spec):
- * - DIY rather than a library: the codebase is function-oriented with 18+ DI interfaces
- *   already in place. A 80-line container fits better than decorator-based frameworks.
- * - Async initialization is first-class: JS constructors can't be async, so TypeScript
- *   DI libraries punt on this. We make initialize() a core lifecycle method.
- * - Registration order = dependency order: factories are resolved sequentially during
- *   initialize(). Each factory can call container.get() to access earlier services.
- *   This is explicit and debuggable — no topological sort needed for ~20 services.
- * - Domain code never sees this container. It receives typed deps interfaces
- *   (SessionDeps, StartSessionDependencies, etc.) assembled by composition roots.
+ * The async initialize() pattern is not native to tsyringe (which resolves
+ * synchronously). We handle it by running factories during initialize() and
+ * registering resolved instances into tsyringe with useValue.
+ *
+ * @see mt#842 — Phase D: tsyringe adoption
  */
+
+import { container as rootContainer, type DependencyContainer } from "tsyringe";
 
 import type {
   AppServices,
@@ -29,18 +27,23 @@ interface Registration<T> {
   dispose?: (instance: T) => Promise<void>;
 }
 
-export class AppContainer implements AppContainerInterface {
-  private instances = new Map<string, unknown>();
-  private registrations = new Map<string, Registration<unknown>>();
+export class TsyringeContainer implements AppContainerInterface {
+  private readonly tsyringe: DependencyContainer;
+  private readonly factories = new Map<string, Registration<unknown>>();
   /** Tracks registration order for sequential initialization and reverse-order disposal. */
-  private registrationOrder: string[] = [];
+  private readonly registrationOrder: string[] = [];
+
+  constructor() {
+    // Use a child container so each TsyringeContainer instance is isolated
+    this.tsyringe = rootContainer.createChildContainer();
+  }
 
   register<K extends ServiceKey>(
     key: K,
     factory: ServiceFactory<AppServices[K]>,
     options?: RegisterOptions<AppServices[K]>
   ): this {
-    this.registrations.set(key, {
+    this.factories.set(key, {
       factory: factory as ServiceFactory<unknown>,
       dispose: options?.dispose as ((instance: unknown) => Promise<void>) | undefined,
     });
@@ -52,33 +55,34 @@ export class AppContainer implements AppContainerInterface {
   }
 
   set<K extends ServiceKey>(key: K, instance: AppServices[K]): this {
-    this.instances.set(key, instance);
+    this.tsyringe.register(key, { useValue: instance });
     return this;
   }
 
   get<K extends ServiceKey>(key: K): AppServices[K] {
-    const instance = this.instances.get(key);
-    if (instance !== undefined) return instance as AppServices[K];
-    throw new Error(
-      `Service "${String(key)}" is not available. ` +
-        `Call initialize() first or use set() to provide an instance.`
-    );
+    if (!this.tsyringe.isRegistered(key)) {
+      throw new Error(
+        `Service "${String(key)}" is not available. ` +
+          `Call initialize() first or use set() to provide an instance.`
+      );
+    }
+    return this.tsyringe.resolve(key) as AppServices[K];
   }
 
   has<K extends ServiceKey>(key: K): boolean {
-    return this.instances.has(key);
+    return this.tsyringe.isRegistered(key);
   }
 
   async initialize(): Promise<void> {
     for (const key of this.registrationOrder) {
       // Skip services already provided via set()
-      if (this.instances.has(key)) continue;
+      if (this.tsyringe.isRegistered(key)) continue;
 
-      const registration = this.registrations.get(key);
+      const registration = this.factories.get(key);
       if (!registration) continue;
 
       const instance = await Promise.resolve(registration.factory(this));
-      this.instances.set(key, instance);
+      this.tsyringe.register(key, { useValue: instance });
     }
   }
 
@@ -86,12 +90,15 @@ export class AppContainer implements AppContainerInterface {
     // Dispose in reverse registration order (tear down leaves before roots)
     const keys = [...this.registrationOrder].reverse();
     for (const key of keys) {
-      const registration = this.registrations.get(key);
-      const instance = this.instances.get(key);
-      if (registration?.dispose && instance !== undefined) {
-        await registration.dispose(instance);
+      const registration = this.factories.get(key);
+      if (registration?.dispose && this.tsyringe.isRegistered(key)) {
+        const instance = this.tsyringe.resolve(key);
+        if (instance !== undefined) {
+          await registration.dispose(instance);
+        }
       }
     }
-    this.instances.clear();
+    // Clear all registrations from the child container
+    this.tsyringe.reset();
   }
 }

--- a/src/composition/index.ts
+++ b/src/composition/index.ts
@@ -7,7 +7,8 @@
  * Domain code should NEVER import from this module.
  */
 
-export { AppContainer } from "./container";
+export { TsyringeContainer } from "./container";
+export { TOKENS } from "./tokens";
 export { createCliContainer } from "./cli";
 export { createTestContainer } from "./test";
 export type {

--- a/src/composition/test.ts
+++ b/src/composition/test.ts
@@ -11,7 +11,7 @@
  * @see mt#761 spec, "Phase 2: Create composition roots"
  */
 
-import { AppContainer } from "./container";
+import { TsyringeContainer } from "./container";
 import type { AppServices, AppContainerInterface } from "./types";
 
 /**
@@ -20,7 +20,7 @@ import type { AppServices, AppContainerInterface } from "./types";
  * No initialize() call needed — all services are set directly.
  */
 export function createTestContainer(overrides: Partial<AppServices> = {}): AppContainerInterface {
-  const container = new AppContainer();
+  const container = new TsyringeContainer();
 
   // Default fakes — minimal stubs that satisfy the type constraints.
   // Tests override the services they actually care about.

--- a/src/composition/tokens.ts
+++ b/src/composition/tokens.ts
@@ -1,0 +1,21 @@
+/**
+ * DI Injection Tokens
+ *
+ * String-based tokens for the 7 core AppServices. Used with tsyringe's
+ * container.register() and @inject() decorator.
+ *
+ * These tokens match the keys in AppServices for consistency with the
+ * existing container.get("key") pattern.
+ */
+
+export const TOKENS = {
+  persistence: "persistence",
+  sessionProvider: "sessionProvider",
+  sessionDeps: "sessionDeps",
+  gitService: "gitService",
+  taskService: "taskService",
+  workspaceUtils: "workspaceUtils",
+  repositoryBackend: "repositoryBackend",
+} as const;
+
+export type TokenKey = keyof typeof TOKENS;

--- a/src/domain/persistence/architecture.test.ts
+++ b/src/domain/persistence/architecture.test.ts
@@ -7,6 +7,7 @@
  * 2. Error swallowing: catch blocks returning defaults instead of propagating
  * 3. DI bypass: commands importing *FromParams instead of using getDeps()
  */
+import "reflect-metadata";
 import { describe, test, expect, beforeAll } from "bun:test";
 
 // Source file paths — single source of truth for all test references
@@ -158,18 +159,17 @@ describe("DI bypass prevention", () => {
 
 describe("Provider reuse (runtime)", () => {
   test("container returns the same sessionDeps instance on consecutive get() calls", async () => {
-    const { AppContainer } = await import("../../composition/container");
-    const container = new AppContainer();
+    const { TsyringeContainer } = await import("../../composition/container");
+    const container = new TsyringeContainer();
 
-    // Inject a mock sessionDeps via the internal instances map to bypass type checking
-    const instancesMap = (container as unknown as { instances: Map<string, unknown> }).instances;
-    const mockDeps = { sessionProvider: { id: "singleton-test" } };
-    instancesMap.set("sessionDeps", mockDeps);
+    // Inject a mock sessionDeps via set() — tests use the public API
+    const mockDeps = { sessionProvider: { id: "singleton-test" } } as any;
+    container.set("sessionDeps", mockDeps);
 
     // Verify the container returns the same reference on consecutive calls —
     // this is the invariant getDeps() relies on for provider reuse
-    const result1 = instancesMap.get("sessionDeps");
-    const result2 = instancesMap.get("sessionDeps");
+    const result1 = container.get("sessionDeps");
+    const result2 = container.get("sessionDeps");
     expect(result1).toBe(result2);
     expect(result1).toBe(mockDeps);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
 
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary

Replace the DIY `AppContainer` with a tsyringe-backed `TsyringeContainer` as the first step of Phase D (mt#842) — adopting tsyringe for dependency injection.

- **Dependencies**: Added `tsyringe` + `reflect-metadata` to package.json
- **tsconfig**: Enabled `experimentalDecorators` + `emitDecoratorMetadata` (required by tsyringe for constructor metadata)
- **Polyfill**: Added `import "reflect-metadata"` at top of `src/cli.ts` (must load before any decorated classes)
- **Tokens**: Created `src/composition/tokens.ts` with injection tokens for all 7 AppServices keys
- **Container**: Replaced `AppContainer` class with `TsyringeContainer` — implements same `AppContainerInterface`, backed by tsyringe's `DependencyContainer` internally
- **Composition roots**: Updated `cli.ts` and `test.ts` to use `TsyringeContainer`
- **Exports**: Updated barrel exports in `composition/index.ts`

### Design decisions:
- **Wrapper approach**: `TsyringeContainer` implements `AppContainerInterface` so ~20 call sites don't need to change
- **Child container isolation**: Each `TsyringeContainer` instance creates a child container via `rootContainer.createChildContainer()`
- **Async lifecycle**: Factories are stored locally and executed during `initialize()`, then registered into tsyringe with `useValue` — bridging tsyringe's sync resolution with our async init needs
- **String tokens**: Match existing `AppServices` key pattern for consistency

All 17 container tests pass. Typecheck clean.