### PR TITLE
feat(mt#845): add @injectable decorators to core service classes

### DIFF
--- a/src/composition/container.test.ts
+++ b/src/composition/container.test.ts
@@ -14,7 +14,6 @@
  * - Async factories are properly awaited
  */
 
-import "reflect-metadata";
 import { describe, test, expect } from "bun:test";
 import { TsyringeContainer } from "./container";
 import type { AppServices } from "./types";

--- a/src/domain/changeset/changeset-service.ts
+++ b/src/domain/changeset/changeset-service.ts
@@ -5,6 +5,7 @@
  * across different VCS platforms using the adapter pattern.
  */
 
+import { injectable } from "tsyringe";
 import type {
   Changeset,
   ChangesetListOptions,
@@ -28,6 +29,7 @@ import { log } from "../../utils/logger";
  * Main changeset service that provides unified access to changesets
  * across different VCS platforms
  */
+@injectable()
 export class ChangesetService {
   private adapters = new Map<ChangesetPlatform, ChangesetAdapter>();
   private factories = new Map<ChangesetPlatform, ChangesetAdapterFactory>();

--- a/src/domain/git.ts
+++ b/src/domain/git.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import { join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { normalizeRepoName } from "./repo-utils";
@@ -97,6 +98,7 @@ export interface GitServiceDeps {
   sessionProvider?: SessionProviderInterface;
 }
 
+@injectable()
 export class GitService implements GitServiceInterface {
   private readonly baseDir: string;
   private sessionDb: SessionProviderInterface | null = null;

--- a/src/domain/persistence/architecture.test.ts
+++ b/src/domain/persistence/architecture.test.ts
@@ -7,7 +7,6 @@
  * 2. Error swallowing: catch blocks returning defaults instead of propagating
  * 3. DI bypass: commands importing *FromParams instead of using getDeps()
  */
-import "reflect-metadata";
 import { describe, test, expect, beforeAll } from "bun:test";
 
 // Source file paths — single source of truth for all test references

--- a/src/domain/persistence/service.ts
+++ b/src/domain/persistence/service.ts
@@ -8,6 +8,7 @@
  * @see mt#814 — converted from static singleton to injectable instance
  */
 
+import { injectable } from "tsyringe";
 import {
   PersistenceProvider,
   VectorCapablePersistenceProvider,
@@ -25,6 +26,7 @@ import type { VectorStorage } from "../storage/vector/types";
  * Manages the lifecycle of a PersistenceProvider (database connection).
  * Created once per application context (CLI, MCP, test) via the DI container.
  */
+@injectable()
 export class PersistenceService {
   private provider: PersistenceProvider | null = null;
   private initPromise: Promise<void> | null = null;

--- a/src/domain/rules/rule-service.ts
+++ b/src/domain/rules/rule-service.ts
@@ -3,6 +3,7 @@
  *
  * Handles CRUD operations for rule files with frontmatter metadata.
  */
+import { injectable } from "tsyringe";
 import { promises as nodeFsPromises } from "fs";
 import { HTTP_OK } from "../../utils/constants";
 import { join } from "path";
@@ -23,6 +24,7 @@ import type {
 
 const matter = grayMatterNamespace.default || grayMatterNamespace;
 
+@injectable()
 export class RuleService {
   private workspacePath: string;
   private fs: Pick<

--- a/src/domain/session/session-db-adapter.ts
+++ b/src/domain/session/session-db-adapter.ts
@@ -5,6 +5,7 @@
  * PersistenceProvider system for unified database access.
  */
 
+import { injectable, inject } from "tsyringe";
 import type { SessionProviderInterface, SessionRecord } from "./types";
 import { createSessionProviderWithAutoRepair } from "./session-auto-repair-provider";
 
@@ -22,10 +23,11 @@ import { getRepoPathFn } from "./session-db";
 import { log } from "../../utils/logger";
 import { getErrorMessage } from "../../errors/index";
 
+@injectable()
 export class SessionDbAdapter implements SessionProviderInterface {
   private storage: DatabaseStorage<SessionRecord, SessionDbState> | null = null;
 
-  constructor(private readonly persistence: PersistenceProvider) {}
+  constructor(@inject("persistence") private readonly persistence: PersistenceProvider) {}
 
   private async getStorage(): Promise<DatabaseStorage<SessionRecord, SessionDbState>> {
     log.debug("Getting storage from persistence provider");

--- a/src/domain/session/session-service.ts
+++ b/src/domain/session/session-service.ts
@@ -8,6 +8,7 @@
  * manual wiring.
  */
 
+import { injectable, inject } from "tsyringe";
 import { createGitService } from "../git";
 import type { GitServiceInterface } from "../git/types";
 import { createWorkspaceUtils, getCurrentSession } from "../workspace";
@@ -133,8 +134,9 @@ export interface ApproveResult {
  * Holds a set of injected dependencies and delegates each operation to the
  * corresponding impl function in the session sub-modules.
  */
+@injectable()
 export class SessionService {
-  constructor(private deps: SessionDeps) {}
+  constructor(@inject("sessionDeps") private deps: SessionDeps) {}
 
   /**
    * Get a session by name, task ID, or repo path.

--- a/src/domain/tasks/multi-backend-service.ts
+++ b/src/domain/tasks/multi-backend-service.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import type {
   Task,
   TaskBackend,
@@ -77,6 +78,7 @@ export interface TaskService extends TaskServiceInterface {
 }
 
 // Complete implementation that supports both single-backend and multi-backend operations
+@injectable()
 export class TaskServiceImpl implements TaskService {
   private readonly backends: TaskBackend[] = [];
   private readonly workspacePath: string;

--- a/src/domain/workspace.ts
+++ b/src/domain/workspace.ts
@@ -1,3 +1,4 @@
+import { injectable } from "tsyringe";
 import { promises as fs } from "fs";
 import { join } from "path";
 import { execAsync } from "../utils/exec";
@@ -412,6 +413,7 @@ export async function getWorkspaceSession(
   }
 }
 
+@injectable()
 export class WorkspaceUtils {
   constructor(
     private execAsyncFn: typeof execAsync,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 /**
  * Global Test Setup
  *


### PR DESCRIPTION
## Summary

- Add `@injectable()` decorators from tsyringe to 8 core service classes: `PersistenceService`, `SessionService`, `SessionDbAdapter`, `GitService`, `TaskServiceImpl`, `RuleService`, `ChangesetService`, `WorkspaceUtils`
- Add `@inject()` parameter decorators to `SessionService` and `SessionDbAdapter` constructors for their injectable dependencies
- Centralize `import "reflect-metadata"` in `tests/setup.ts` so all tests get the polyfill automatically, removing per-file imports from `container.test.ts` and `architecture.test.ts`

## Test plan

- [x] TypeScript typecheck passes (`bun run tsc --noEmit`)
- [x] `src/composition/` tests pass (17/17)
- [x] `grep -rn '@injectable' src/domain/ --include='*.ts' | wc -l` returns 8

Part of mt#842 (DI container phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)