### PR TITLE
refactor(mt#851): Remove dead code - getMinskyConfigContent (JSON) and mcpOnly flag

### DIFF
--- a/src/adapters/shared/commands/init.ts
+++ b/src/adapters/shared/commands/init.ts
@@ -69,11 +69,6 @@ const initParams = composeParams(
       description: "Host for MCP network transports",
       required: false,
     },
-    mcpOnly: {
-      schema: z.boolean().optional(),
-      description: "Only configure MCP, skip other initialization steps",
-      required: false,
-    },
   }
 ) satisfies CommandParameterMap;
 
@@ -222,7 +217,7 @@ export function registerInitCommands() {
               port: params.mcpPort ? Number(params.mcpPort) : undefined,
               host: params.mcpHost,
             };
-          } else if (isInteractive() && !params.mcpOnly) {
+          } else if (isInteractive()) {
             // Interactive MCP configuration
             const enableMcp = await confirm({
               message: "Enable MCP (Model Context Protocol) configuration?",
@@ -289,7 +284,6 @@ export function registerInitCommands() {
             }
           }
 
-          const mcpOnly = params.mcpOnly ?? false;
           const overwrite = params.overwrite ?? false;
 
           // Detect repository backend from git remote
@@ -335,7 +329,6 @@ export function registerInitCommands() {
             backend: domainBackend,
             ruleFormat: ruleFormat as "cursor" | "generic" | "minsky",
             mcp,
-            mcpOnly,
             overwrite,
             repository,
           });

--- a/src/domain/init-backend-selection.test.ts
+++ b/src/domain/init-backend-selection.test.ts
@@ -35,7 +35,6 @@ describe("Init System Backend Selection", () => {
           backend: backend,
           ruleFormat: "cursor",
           mcp: { enabled: false },
-          mcpOnly: false,
           overwrite: false,
         },
         mockFileSystem
@@ -65,7 +64,6 @@ describe("Init System Backend Selection", () => {
         backend: "minsky",
         ruleFormat: "cursor",
         mcp: { enabled: false },
-        mcpOnly: false,
         overwrite: false,
       },
       mockFileSystem
@@ -85,7 +83,6 @@ describe("Init System Backend Selection", () => {
         backend: "github-issues",
         ruleFormat: "cursor",
         mcp: { enabled: false },
-        mcpOnly: false,
         overwrite: false,
       },
       mockFileSystem
@@ -112,7 +109,6 @@ describe("Init System Backend Selection", () => {
             backend: backend as unknown as "minsky", // cast to satisfy TS; intentionally invalid
             ruleFormat: "cursor",
             mcp: { enabled: false },
-            mcpOnly: false,
             overwrite: false,
           },
           mockFileSystem

--- a/src/domain/init.ts
+++ b/src/domain/init.ts
@@ -30,7 +30,6 @@ export function detectRepositoryBackend(repoPath: string): ResolvedRepositoryCon
 
 // Re-export content helpers for consumers that may reference them
 export {
-  getMinskyConfigContent,
   getMinskyConfigContentYaml,
   getLocalConfigContentYaml,
   getMCPConfigContent,
@@ -54,7 +53,6 @@ export const initializeProjectParamsSchema = z.object({
       host: z.string().optional(),
     })
     .optional(),
-  mcpOnly: z.boolean().optional().default(false),
   overwrite: z.boolean().optional().default(false),
   repository: z
     .object({
@@ -94,7 +92,6 @@ export interface InitializeProjectOptions {
     port?: number;
     host?: string;
   };
-  mcpOnly?: boolean;
   overwrite?: boolean;
   repository?: ResolvedRepositoryConfig;
 }
@@ -104,57 +101,46 @@ export interface InitializeProjectOptions {
  * Orchestrates all project initialization steps.
  */
 export async function initializeProject(
-  {
-    repoPath,
-    backend,
-    ruleFormat,
-    mcp,
-    mcpOnly = false,
-    overwrite = false,
-    repository,
-  }: InitializeProjectOptions,
+  { repoPath, backend, ruleFormat, mcp, overwrite = false, repository }: InitializeProjectOptions,
   fileSystem: FsLike = createRealFs()
 ): Promise<void> {
-  // When mcpOnly is true, we only set up MCP configuration and skip other setup
-  if (!mcpOnly) {
-    // Create process/tasks directory structure
-    const tasksDir = path.join(repoPath, "process", "tasks");
-    await createDirectoryIfNotExists(tasksDir, fileSystem);
+  // Create process/tasks directory structure
+  const tasksDir = path.join(repoPath, "process", "tasks");
+  await createDirectoryIfNotExists(tasksDir, fileSystem);
 
-    // Initialize the tasks backend based on user selection
-    switch (backend) {
-      case "github-issues":
-        // GitHub Issues backend uses external GitHub repository - no local files needed
-        // Configuration will be set up in the config file below
-        break;
+  // Initialize the tasks backend based on user selection
+  switch (backend) {
+    case "github-issues":
+      // GitHub Issues backend uses external GitHub repository - no local files needed
+      // Configuration will be set up in the config file below
+      break;
 
-      case "minsky":
-        // Minsky backend uses database - no task files needed
-        // Database configuration will be set up in the config file below
-        break;
+    case "minsky":
+      // Minsky backend uses database - no task files needed
+      // Database configuration will be set up in the config file below
+      break;
 
-      default:
-        throw new Error(`Backend "${backend}" is not supported.`);
-    }
+    default:
+      throw new Error(`Backend "${backend}" is not supported.`);
+  }
 
-    // Create rule file directory
-    const rulesDirPath =
-      ruleFormat === "cursor"
-        ? path.join(repoPath, ".cursor", "rules")
-        : path.join(repoPath, ".ai", "rules");
-    await createDirectoryIfNotExists(rulesDirPath, fileSystem);
+  // Create rule file directory
+  const rulesDirPath =
+    ruleFormat === "cursor"
+      ? path.join(repoPath, ".cursor", "rules")
+      : path.join(repoPath, ".ai", "rules");
+  await createDirectoryIfNotExists(rulesDirPath, fileSystem);
 
-    // Generate rules using template system (tolerate missing command registry in tests)
-    try {
-      await generateRulesWithTemplateSystem(
-        rulesDirPath,
-        ruleFormat,
-        overwrite,
-        mcp?.enabled ?? false
-      );
-    } catch (_e) {
-      // Skip rule generation when the command registry isn't available (unit tests)
-    }
+  // Generate rules using template system (tolerate missing command registry in tests)
+  try {
+    await generateRulesWithTemplateSystem(
+      rulesDirPath,
+      ruleFormat,
+      overwrite,
+      mcp?.enabled ?? false
+    );
+  } catch (_e) {
+    // Skip rule generation when the command registry isn't available (unit tests)
   }
 
   // Create main Minsky configuration file with user's backend choice

--- a/src/domain/init/config-content.ts
+++ b/src/domain/init/config-content.ts
@@ -12,42 +12,6 @@ export interface McpOptions {
 }
 
 /**
- * Returns the content for the main Minsky config file
- */
-export function getMinskyConfigContent(
-  backend: z.infer<typeof enumSchemas.backendType>,
-  repository?: ResolvedRepositoryConfig
-): string {
-  const config: Record<string, unknown> = {
-    tasks: {
-      backend: backend,
-      strictIds: false,
-    },
-    sessiondb: {
-      backend: "sqlite",
-    },
-    logger: {
-      mode: "auto",
-      level: "info",
-      enableAgentLogs: false,
-    },
-  };
-
-  if (repository) {
-    const repoSection: Record<string, unknown> = { backend: repository.backend };
-    if (repository.url) {
-      repoSection.url = repository.url;
-    }
-    if (repository.github) {
-      repoSection.github = repository.github;
-    }
-    config.repository = repoSection;
-  }
-
-  return JSON.stringify(config, null, 2);
-}
-
-/**
  * Returns the content for the main Minsky config file in YAML format
  */
 export function getMinskyConfigContentYaml(

--- a/src/schemas/init.ts
+++ b/src/schemas/init.ts
@@ -16,7 +16,6 @@ export const initParamsSchema = z.object({
   mcpTransport: z.string().optional(),
   mcpPort: z.string().optional(),
   mcpHost: z.string().optional(),
-  mcpOnly: z.boolean().optional(),
   overwrite: z.boolean().optional(),
   workspacePath: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- Remove `getMinskyConfigContent` (JSON version) from `src/domain/init/config-content.ts` — only `getMinskyConfigContentYaml` is used
- Remove its re-export from `src/domain/init.ts`
- Remove `mcpOnly` flag from schema, interface, function signature, conditional wrapper, and all call sites across 5 files

## Changes

- `src/domain/init/config-content.ts`: delete `getMinskyConfigContent` function (lines 17–48)
- `src/domain/init.ts`: remove `getMinskyConfigContent` from re-exports; remove `mcpOnly` from schema and interface; remove `mcpOnly` param from `initializeProject` and unwrap the `if (!mcpOnly)` block (the body always runs now)
- `src/schemas/init.ts`: remove `mcpOnly` field from `initParamsSchema`
- `src/adapters/shared/commands/init.ts`: remove `mcpOnly` param definition, `&& !params.mcpOnly` condition, `const mcpOnly` assignment, and `mcpOnly` pass-through in the domain call
- `src/domain/init-backend-selection.test.ts`: remove `mcpOnly: false` from all four test invocations

## Verification

- `grep -r 'getMinskyConfigContent[^Y]' src/` → 0 results
- `grep -r 'mcpOnly' src/` → 0 results

## Coherence Verification

**Files re-read**: `src/domain/init/config-content.ts`, `src/domain/init.ts`, `src/schemas/init.ts`, `src/adapters/shared/commands/init.ts`, `src/domain/init-backend-selection.test.ts`

**Q1 single purpose**: pass — each file retains a clear, coherent purpose after removal; `config-content.ts` now contains only YAML config helpers

**Q2 comment honesty**: pass — the `initializeProject` docstring still accurately says "Orchestrates all project initialization steps"; the removed `// When mcpOnly is true...` comment is gone with the conditional

**Q3 naming honesty**: pass — file names unchanged and still accurate; no concept names became misleading

**Q4 redundant siblings**: pass — no new redundancy introduced

**Q5 dead exports**: pass — `getMCPRuleContent` in `config-content.ts` is a pre-existing dead export not introduced by this change (not imported anywhere); no dead exports created by this PR. `getMinskyConfigContent` is confirmed fully removed.

**Q6 orphan code**: pass — the `if (!mcpOnly)` wrapper body is preserved and now always runs; no orphan helpers existed solely for `mcpOnly`

**Q7 stray artifacts**: pass — no backup/tmp files; no TODO markers left over from the refactor

**Items fixed in this PR (beyond original scope)**: none
**Items deferred (with justification)**: pre-existing dead export `getMCPRuleContent` — out of scope for this task

---
*Had Claude refactor this dead code removal.*