### PR TITLE
Add session auto-labeling hooks for iTerm2 tab title and color

### DIFF
--- a/.claude/hooks/auto-session-title.ts
+++ b/.claude/hooks/auto-session-title.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+import { readInput, writeOutput } from "./types";
+import type { ClaudeHookInput, HookOutput } from "./types";
+import { existsSync, readFileSync, unlinkSync } from "fs";
+
+async function main(): Promise<void> {
+  const input = await readInput<ClaudeHookInput>();
+  const sessionId = input.session_id;
+
+  const labelFile = `/tmp/claude-session-label-${sessionId}.json`;
+
+  if (!existsSync(labelFile)) {
+    process.exit(0);
+  }
+
+  let taskId: string;
+  let title: string;
+
+  try {
+    const contents = readFileSync(labelFile, "utf8");
+    const data = JSON.parse(contents) as { taskId: string; title: string };
+    taskId = data.taskId;
+    title = data.title;
+  } catch {
+    // If we can't read/parse the file, clean it up and exit
+    try {
+      unlinkSync(labelFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+    process.exit(0);
+  }
+
+  // Delete the file so it's only consumed once
+  try {
+    unlinkSync(labelFile);
+  } catch {
+    // Ignore cleanup errors
+  }
+
+  const sessionTitle = `${taskId} — ${title}`;
+
+  const output: HookOutput = {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      sessionTitle,
+    } as HookOutput["hookSpecificOutput"] & { sessionTitle: string },
+  };
+
+  writeOutput(output);
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/.claude/hooks/post-session-start.ts
+++ b/.claude/hooks/post-session-start.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env bun
+import { readInput } from "./types";
+import type { ToolHookInput } from "./types";
+import { writeFileSync } from "fs";
+
+const COLORS: [number, number, number][] = [
+  [86, 182, 194], // teal
+  [210, 144, 52], // amber
+  [138, 118, 206], // purple
+  [92, 190, 93], // green
+  [219, 104, 107], // coral
+  [72, 152, 218], // blue
+  [204, 168, 82], // gold
+  [176, 108, 180], // magenta
+  [108, 189, 152], // mint
+  [218, 136, 78], // orange
+];
+
+function getColorForTaskId(taskId: string): [number, number, number] {
+  // Extract numeric portion from taskId (e.g., "mt#843" -> 843)
+  const match = taskId.match(/\d+/);
+  const num = match ? parseInt(match[0], 10) : 0;
+  return COLORS[num % COLORS.length];
+}
+
+function emitITermEscapes(taskId: string, title: string): void {
+  const termProgram = process.env.TERM_PROGRAM;
+  const lcTerminal = process.env.LC_TERMINAL;
+
+  if (termProgram !== "iTerm.app" && lcTerminal !== "iTerm2") {
+    return;
+  }
+
+  // Skip if running as a subagent (shares parent terminal)
+  if (process.env.CLAUDE_AGENT_ID) {
+    return;
+  }
+
+  const shortTitle = title.length > 50 ? title.slice(0, 47) + "..." : title;
+  const tabLabel = `${taskId} — ${shortTitle}`;
+
+  // Set tab title via OSC 1
+  const ttyEscapes =
+    `\x1b]1;${tabLabel}\x07` +
+    (() => {
+      const [r, g, b] = getColorForTaskId(taskId);
+      return (
+        `\x1b]6;1;bg;red;brightness;${r}\x07` +
+        `\x1b]6;1;bg;green;brightness;${g}\x07` +
+        `\x1b]6;1;bg;blue;brightness;${b}\x07`
+      );
+    })();
+
+  try {
+    // Write escape sequences directly to /dev/tty
+    const ttyFd = require("fs").openSync("/dev/tty", "w");
+    require("fs").writeSync(ttyFd, ttyEscapes);
+    require("fs").closeSync(ttyFd);
+  } catch {
+    // Silently ignore if /dev/tty is not available
+  }
+}
+
+async function main(): Promise<void> {
+  const input = await readInput<ToolHookInput>();
+
+  // Extract session data from tool_result
+  const toolResult = input.tool_result as Record<string, unknown> | undefined;
+  if (!toolResult) {
+    process.exit(0);
+  }
+
+  const taskId = (toolResult.taskId as string) || "";
+  const sessionId = input.session_id;
+
+  if (!taskId) {
+    process.exit(0);
+  }
+
+  // Fetch task title via minsky CLI
+  let title = taskId;
+  try {
+    const minskyPath = "minsky";
+    const pathPrefix = `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH || ""}`;
+
+    const result = Bun.spawnSync([minskyPath, "tasks", "get", taskId, "--json"], {
+      env: { ...process.env, PATH: pathPrefix },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    if (result.exitCode === 0) {
+      const output = result.stdout.toString().trim();
+      if (output) {
+        const taskData = JSON.parse(output) as { title?: string };
+        if (taskData.title) {
+          title = taskData.title;
+        }
+      }
+    }
+  } catch {
+    // Silently fall back to using taskId as title
+  }
+
+  // Emit iTerm2 escape sequences
+  emitITermEscapes(taskId, title);
+
+  // Write state file for auto-session-title hook
+  const labelFile = `/tmp/claude-session-label-${sessionId}.json`;
+  try {
+    writeFileSync(labelFile, JSON.stringify({ taskId, title }), "utf8");
+  } catch {
+    // Silently ignore write errors
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/.claude/hooks/post-session-start.ts
+++ b/.claude/hooks/post-session-start.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { readInput } from "./types";
 import type { ToolHookInput } from "./types";
-import { writeFileSync } from "fs";
+import { openSync, writeSync, closeSync, writeFileSync } from "fs";
 
 const COLORS: [number, number, number][] = [
   [86, 182, 194], // teal
@@ -36,26 +36,22 @@ function emitITermEscapes(taskId: string, title: string): void {
     return;
   }
 
-  const shortTitle = title.length > 50 ? title.slice(0, 47) + "..." : title;
+  const shortTitle = title.length > 50 ? `${title.slice(0, 47)}...` : title;
   const tabLabel = `${taskId} — ${shortTitle}`;
 
-  // Set tab title via OSC 1
+  // Set tab title via OSC 1 and tab color via OSC 6
+  const [r, g, b] = getColorForTaskId(taskId);
   const ttyEscapes =
     `\x1b]1;${tabLabel}\x07` +
-    (() => {
-      const [r, g, b] = getColorForTaskId(taskId);
-      return (
-        `\x1b]6;1;bg;red;brightness;${r}\x07` +
-        `\x1b]6;1;bg;green;brightness;${g}\x07` +
-        `\x1b]6;1;bg;blue;brightness;${b}\x07`
-      );
-    })();
+    `\x1b]6;1;bg;red;brightness;${r}\x07` +
+    `\x1b]6;1;bg;green;brightness;${g}\x07` +
+    `\x1b]6;1;bg;blue;brightness;${b}\x07`;
 
   try {
     // Write escape sequences directly to /dev/tty
-    const ttyFd = require("fs").openSync("/dev/tty", "w");
-    require("fs").writeSync(ttyFd, ttyEscapes);
-    require("fs").closeSync(ttyFd);
+    const ttyFd = openSync("/dev/tty", "w");
+    writeSync(ttyFd, ttyEscapes);
+    closeSync(ttyFd);
   } catch {
     // Silently ignore if /dev/tty is not available
   }
@@ -70,7 +66,9 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const taskId = (toolResult.taskId as string) || "";
+  // session_start returns { success, session: { session, repoUrl, repoName, taskId }, ... }
+  const sessionData = toolResult.session as Record<string, unknown> | undefined;
+  const taskId = (sessionData?.taskId as string) || "";
   const sessionId = input.session_id;
 
   if (!taskId) {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,29 @@
             "statusMessage": "Pulling latest main..."
           }
         ]
+      },
+      {
+        "matcher": "mcp__minsky__session_start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-session-start.ts",
+            "timeout": 10,
+            "statusMessage": "Labeling session..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/auto-session-title.ts",
+            "timeout": 5,
+            "statusMessage": "Checking session label..."
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Adds `post-session-start.ts`: a PostToolUse hook on `mcp__minsky__session_start` that (a) sets the iTerm2 tab title and color via OSC escape sequences written to `/dev/tty`, and (b) writes a JSON state file to `/tmp/claude-session-label-<session_id>.json` for the next hook to pick up. Task title is fetched via `minsky tasks get <taskId> --json`.
- Adds `auto-session-title.ts`: a UserPromptSubmit hook that reads and deletes the state file, then emits `sessionTitle` in `hookSpecificOutput` so Claude Code sets the session title.
- Updates `settings.json` to register both hooks (PostToolUse with `mcp__minsky__session_start` matcher, UserPromptSubmit without matcher).

## Behavior details

- iTerm2 escape sequences are only emitted when `TERM_PROGRAM === "iTerm.app"` or `LC_TERMINAL === "iTerm2"`, and skipped when `CLAUDE_AGENT_ID` is set (subagents share the parent terminal).
- Tab color is deterministic: `taskIdNumber % 10` indexes into a palette of 10 visually distinct medium-brightness colors for dark backgrounds.
- All error paths are silent (try/catch) so hook failures never block the user.

## Test plan

- [ ] Start a Minsky session in iTerm2 — tab title should update to `mt#NNN — <task title>` and tab color should change
- [ ] Submit the next user prompt — Claude Code session title should be set to the same label
- [ ] Verify subagent sessions do not emit escape sequences (CLAUDE_AGENT_ID set)
- [ ] Verify no errors in non-iTerm2 terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)