### PR TITLE
feat(mt#852): Add MCP config schema and persist MCP settings during init

### DIFF
--- a/src/domain/configuration/schemas/index.ts
+++ b/src/domain/configuration/schemas/index.ts
@@ -30,6 +30,7 @@ import { tasksConfigSchema, type TasksConfig } from "./tasks";
 import { embeddingsConfigSchema, type EmbeddingsConfig } from "./embeddings";
 import { workspaceConfigSchema, type WorkspaceConfig } from "./workspace";
 import { rulesConfigSchema, type RulesConfig } from "./rules";
+import { mcpConfigSchema, type McpConfig } from "./mcp";
 
 /**
  * Complete application configuration schema
@@ -70,6 +71,9 @@ export const configurationSchema = z.looseObject({
 
   // Repository backend configuration (project-level, set during minsky init)
   repository: repositoryConfigSchema.optional(),
+
+  // MCP transport configuration (project-level invariants set during minsky init)
+  mcp: mcpConfigSchema,
 }); // looseObject allows extra properties (equivalent to passthrough)
 
 /**
@@ -243,6 +247,7 @@ export type {
   EmbeddingsConfig,
   WorkspaceConfig,
   RulesConfig,
+  McpConfig,
 };
 
 // Re-export schemas for external use
@@ -258,6 +263,7 @@ export {
   embeddingsConfigSchema,
   workspaceConfigSchema,
   rulesConfigSchema,
+  mcpConfigSchema,
 };
 
 // Export the main schema as default

--- a/src/domain/configuration/schemas/mcp.ts
+++ b/src/domain/configuration/schemas/mcp.ts
@@ -1,0 +1,22 @@
+/**
+ * MCP (Model Context Protocol) Configuration Schema
+ *
+ * Defines the project-level MCP transport preferences written to config.yaml
+ * during `minsky init`. These represent project-level invariants, not
+ * client-specific registration details.
+ */
+
+import { z } from "zod";
+
+/**
+ * MCP configuration schema
+ */
+export const mcpConfigSchema = z
+  .object({
+    transport: z.enum(["stdio", "sse", "httpStream"]).default("stdio"),
+    port: z.number().optional(),
+    host: z.string().optional(),
+  })
+  .optional();
+
+export type McpConfig = z.infer<typeof mcpConfigSchema>;

--- a/src/domain/init-backend-selection.test.ts
+++ b/src/domain/init-backend-selection.test.ts
@@ -49,7 +49,53 @@ describe("Init System Backend Selection", () => {
 
       const config = yamlParse(configContent!);
       expect(config.tasks.backend).toBe(backend);
+      // When mcp.enabled is false, no mcp section should appear in config
+      expect(config.mcp).toBeUndefined();
     }
+  });
+
+  test("should include mcp section in config when MCP is enabled", async () => {
+    const testRepo = "/tmp/test-repo";
+
+    await initializeProject(
+      {
+        repoPath: testRepo,
+        backend: "minsky",
+        ruleFormat: "cursor",
+        mcp: { enabled: true, transport: "stdio" },
+        overwrite: false,
+      },
+      mockFileSystem
+    );
+
+    const configPath = path.join(testRepo, ".minsky", "config.yaml");
+    expect(mockFileSystem.files.has(configPath)).toBe(true);
+
+    const config = yamlParse(mockFileSystem.files.get(configPath)!);
+    expect(config.mcp).toBeDefined();
+    expect(config.mcp.transport).toBe("stdio");
+  });
+
+  test("should include mcp section with port and host for SSE transport", async () => {
+    const testRepo = "/tmp/test-repo";
+
+    await initializeProject(
+      {
+        repoPath: testRepo,
+        backend: "minsky",
+        ruleFormat: "cursor",
+        mcp: { enabled: true, transport: "sse", port: 3000, host: "0.0.0.0" },
+        overwrite: false,
+      },
+      mockFileSystem
+    );
+
+    const configPath = path.join(testRepo, ".minsky", "config.yaml");
+    const config = yamlParse(mockFileSystem.files.get(configPath)!);
+    expect(config.mcp).toBeDefined();
+    expect(config.mcp.transport).toBe("sse");
+    expect(config.mcp.port).toBe(3000);
+    expect(config.mcp.host).toBe("0.0.0.0");
   });
 
   test("should create appropriate files for each backend type", async () => {

--- a/src/domain/init.ts
+++ b/src/domain/init.ts
@@ -148,7 +148,11 @@ export async function initializeProject(
   await createDirectoryIfNotExists(minskyDir, fileSystem);
 
   const configPath = path.join(minskyDir, "config.yaml");
-  const configContent = getMinskyConfigContentYaml(backend, repository);
+  const mcpForConfig =
+    mcp?.enabled !== false
+      ? { transport: mcp?.transport, port: mcp?.port, host: mcp?.host }
+      : undefined;
+  const configContent = getMinskyConfigContentYaml(backend, repository, mcpForConfig);
   await createFileIfNotExists(configPath, configContent, overwrite, fileSystem);
 
   // Write machine-specific local config (gitignored) with workspace.mainPath

--- a/src/domain/init/config-content.ts
+++ b/src/domain/init/config-content.ts
@@ -16,7 +16,8 @@ export interface McpOptions {
  */
 export function getMinskyConfigContentYaml(
   backend: z.infer<typeof enumSchemas.backendType>,
-  repository?: ResolvedRepositoryConfig
+  repository?: ResolvedRepositoryConfig,
+  mcp?: McpOptions
 ): string {
   const config: Record<string, unknown> = {
     tasks: {
@@ -42,6 +43,19 @@ export function getMinskyConfigContentYaml(
       repoSection.github = repository.github;
     }
     config.repository = repoSection;
+  }
+
+  if (mcp) {
+    const mcpSection: Record<string, unknown> = {
+      transport: mcp.transport ?? "stdio",
+    };
+    if (mcp.port !== undefined) {
+      mcpSection.port = mcp.port;
+    }
+    if (mcp.host !== undefined) {
+      mcpSection.host = mcp.host;
+    }
+    config.mcp = mcpSection;
   }
 
   return yamlStringify(config);


### PR DESCRIPTION
## Summary

- Added `src/domain/configuration/schemas/mcp.ts` with `mcpConfigSchema` (transport/port/host fields, backward-compatible via `.optional()`)
- Added `mcp` field to the root `configurationSchema` in `schemas/index.ts`
- Updated `getMinskyConfigContentYaml` to accept an optional `McpOptions` parameter and write an `mcp:` section to the YAML when provided
- Updated `initializeProject` to pass MCP options through to `getMinskyConfigContentYaml` (only when `mcp.enabled !== false`)
- Added three new tests in `init-backend-selection.test.ts` verifying: no `mcp` section when disabled, `mcp.transport` present when enabled, and port/host written for SSE transport

## Test plan

- [ ] Existing backend-selection tests still pass (mcp disabled path unchanged)
- [ ] New test: config has no `mcp` section when `mcp.enabled: false`
- [ ] New test: config includes `mcp.transport: "stdio"` when enabled with stdio
- [ ] New test: config includes `mcp.transport`, `mcp.port`, `mcp.host` for SSE transport
- [ ] Configs without an `mcp` section load fine (field is `.optional()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)