### PR TITLE
fix(mt#850): move post-merge verification to verify-completion subagent

### DIFF
--- a/.claude/agents/verify-completion.md
+++ b/.claude/agents/verify-completion.md
@@ -55,9 +55,22 @@ Your final output MUST follow this structure exactly:
 **Recommendation**: <merge / fix before merge / needs discussion>
 ```
 
+# Post-merge baseline checks
+
+After checking all spec criteria, ALWAYS run these baseline checks regardless of whether the spec mentions them. These catch integration issues that spec criteria may not cover:
+
+1. **Full test suite**: `bun test --preload ./tests/setup.ts --timeout=15000 src tests/adapters tests/domain` — report pass count and any failures
+2. **Type check**: `bun run tsc --noEmit` — report clean or errors
+3. **Lint**: `bun run lint` — report new errors (pre-existing errors in unrelated files are noted but not blocking)
+4. **E2E smoke test**: Run at least one CLI command that exercises the changed code path (e.g., if the task changed DI, run `bun src/cli.ts tasks list` to verify the container initializes correctly)
+5. **Documentation staleness**: Check if `docs/architecture.md` has content related to the task's domain — if so, verify it's still accurate post-change
+
+Include these in the output table as "Baseline" criteria.
+
 # Anti-patterns
 
 - Never infer a criterion is met from prior conversation context — verify against current code
 - Never treat "the PR was merged" as evidence for any criterion — the spec defines completeness, not the PR
 - Never skip a criterion because it seems "obviously met"
 - If the spec is vague about a criterion, mark it AMBIGUOUS and explain what's unclear
+- Never treat "CI passed" as sufficient evidence for "all tests pass" — run the suite yourself on the post-merge codebase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,17 +123,6 @@ A PR merging is NOT the same as a task being complete. Before marking any task D
 3. **If scope was reduced**, update the spec FIRST to reflect actual scope, note what was deferred, and create follow-up tasks for gaps before marking DONE
 4. **If criteria can't be verified**, the task is not DONE — use IN-REVIEW or create follow-up tasks
 
-### Post-merge verification (mandatory)
-
-After the final PR merges, run these on the post-merge codebase before declaring completion:
-
-1. **Full test suite** — `bun test --preload ./tests/setup.ts --timeout=15000 src tests/adapters tests/domain` (not just the files you changed)
-2. **Lint** — `bun run lint` (confirm no new errors)
-3. **E2E smoke test** — execute at least one CLI command that exercises the changed code path end-to-end
-4. **Documentation** — search `docs/` for existing content on the same topic; update if stale
-
-"CI passed" is not a substitute for running verification locally on the merged codebase. CI verifies the branch; post-merge verification catches integration issues.
-
 Never treat "code merged" as equivalent to "task complete." The spec defines completeness, not the PR.
 
 ### Pre-flight: Verify spec before starting work
@@ -205,13 +194,6 @@ Minsky exposes 80+ MCP tools. Use them for all task and session operations inste
 - Prefer template literals over string concatenation
 - Max 400 lines per file (warn), 1500 (error)
 - 10 custom ESLint rules enforce architectural patterns
-
-## Documentation
-
-- **CLAUDE.md** is for agent behavioral instructions only — not project architecture, design decisions, or system documentation
-- **`docs/architecture.md`** is the canonical architecture reference — update it when making architectural changes (new frameworks, patterns, system design)
-- **`docs/architecture/`** contains ADRs and design docs
-- Before creating new documentation, **search `docs/` for existing content** on the same topic — update in place rather than creating duplicates
 
 ## Key Architecture
 


### PR DESCRIPTION
## Summary

Corrects the retrospective fixes from PR #540 — moves verification steps from CLAUDE.md (behavioral rule, weakest tier) to the verify-completion subagent (structural, invoked mechanism).

- **CLAUDE.md**: Removed post-merge verification checklist and Documentation section (both were wrong tier per agent-guidance-mechanisms)
- **verify-completion subagent**: Added post-merge baseline checks (full test suite, typecheck, lint, E2E smoke test, docs staleness) that run as part of every completion verification
- Added anti-pattern about CI-as-proxy for local verification

Per Minsky design principles: Rules < Skills < Subagents < Hooks. Verification belongs in the subagent (structural), not in CLAUDE.md (behavioral).