### PR TITLE
feat(mt#855): Add minsky setup shared command for developer-local initialization

### DIFF
--- a/src/adapters/shared/commands/index.ts
+++ b/src/adapters/shared/commands/index.ts
@@ -11,6 +11,7 @@ import { registerTasksCommands } from "./tasks";
 import { registerSessionCommands } from "./session";
 import { registerRulesCommands } from "./rules";
 import { registerInitCommands } from "./init";
+import { registerSetupCommands } from "./setup";
 import { registerConfigCommands } from "./config";
 import { registerDebugCommands } from "./debug";
 import { registerPersistenceCommands } from "./persistence";
@@ -39,6 +40,9 @@ export async function registerAllSharedCommands(container?: AppContainerInterfac
 
   // Register init commands
   registerInitCommands();
+
+  // Register setup commands
+  registerSetupCommands();
 
   // Register config commands
   registerConfigCommands();
@@ -72,6 +76,7 @@ export {
   registerSessionCommands,
   registerRulesCommands,
   registerInitCommands,
+  registerSetupCommands,
   registerConfigCommands,
   registerDebugCommands,
   registerPersistenceCommands,

--- a/src/adapters/shared/commands/setup.ts
+++ b/src/adapters/shared/commands/setup.ts
@@ -1,0 +1,109 @@
+/**
+ * Setup command — developer-local initialization.
+ *
+ * Reads the existing project config and derives local configuration
+ * (MCP registration + local config file). Unlike `init`, this works
+ * with an already-initialized project without requiring the full config
+ * system to be initialized.
+ */
+
+import { z } from "zod";
+import { select, isCancel, cancel } from "@clack/prompts";
+import { getErrorMessage } from "../../../errors/index";
+import {
+  sharedCommandRegistry,
+  CommandCategory,
+  defineCommand,
+  type CommandParameterMap,
+} from "../command-registry";
+import { performSetup } from "../../../domain/setup";
+import { detectInstalledClients } from "../../../domain/runtime/harness-detection";
+import { ValidationError } from "../../../errors/index";
+import { CommonParameters, composeParams } from "../common-parameters";
+import { isInteractive } from "../../../utils/interactive";
+
+const setupParams = composeParams(
+  {
+    repo: {
+      schema: z.string().optional(),
+      description: "Repository path to set up",
+      required: false,
+    },
+    workspacePath: CommonParameters.workspace,
+    overwrite: CommonParameters.overwrite,
+  },
+  {
+    client: {
+      schema: z.string().optional(),
+      description: "MCP client to register with (e.g. cursor)",
+      required: false,
+    },
+  }
+) satisfies CommandParameterMap;
+
+export function registerSetupCommands() {
+  sharedCommandRegistry.registerCommand(
+    defineCommand({
+      id: "setup",
+      category: CommandCategory.INIT,
+      name: "setup",
+      description:
+        "Set up developer-local configuration for Minsky (MCP registration + local config)",
+      parameters: setupParams,
+      execute: async (params, _ctx) => {
+        try {
+          const repoPath = params.repo || params.workspacePath || process.cwd();
+          const overwrite = params.overwrite ?? false;
+
+          // Determine which client to register with
+          let client = params.client;
+          if (!client) {
+            const installedClients = detectInstalledClients();
+
+            if (installedClients.length === 0) {
+              // No known clients detected — default to cursor
+              client = "cursor";
+            } else if (installedClients.length === 1) {
+              // Only one client detected — use it automatically
+              client = installedClients[0];
+            } else {
+              // Multiple clients detected — prompt if interactive
+              if (!isInteractive()) {
+                throw new ValidationError(
+                  `Multiple MCP clients detected (${installedClients.join(", ")}). Use --client to specify one.`
+                );
+              }
+
+              const selectedClient = await select({
+                message: "Select an MCP client to register Minsky with:",
+                options: installedClients.map((c) => ({ value: c, label: c })),
+                initialValue: installedClients[0],
+              });
+
+              if (isCancel(selectedClient)) {
+                cancel("Setup cancelled.");
+                return { success: false, message: "Setup cancelled by user." };
+              }
+
+              client = selectedClient as string;
+            }
+          }
+
+          const result = await performSetup({ repoPath, client, overwrite });
+
+          return {
+            success: result.success,
+            message: result.message,
+            localConfigPath: result.localConfigPath,
+            harnessConfigPath: result.harnessConfigPath,
+            client: result.client,
+          };
+        } catch (error: unknown) {
+          throw error instanceof ValidationError
+            ? error
+            : new ValidationError(getErrorMessage(error));
+        }
+      },
+    })
+  );
+}

--- a/src/domain/setup.ts
+++ b/src/domain/setup.ts
@@ -1,0 +1,104 @@
+/**
+ * Setup domain function.
+ *
+ * Performs developer-local initialization: reads the existing project config
+ * and derives local configuration (MCP registration + local config file).
+ * Unlike `init`, this works with an already-initialized project and does
+ * not require full config system initialization.
+ */
+
+import * as path from "path";
+import { parse as yamlParse, stringify as yamlStringify } from "yaml";
+import type { FsLike } from "./interfaces/fs-like";
+import { createRealFs } from "./interfaces/real-fs";
+import { createFileIfNotExists } from "./init/file-system";
+import { registerWithClient, getRegistrar } from "./mcp/registration";
+
+export interface SetupOptions {
+  repoPath: string;
+  client?: string;
+  overwrite?: boolean;
+}
+
+export interface SetupResult {
+  success: boolean;
+  localConfigPath: string;
+  harnessConfigPath: string;
+  client: string;
+  message: string;
+}
+
+interface MinimalMcpConfig {
+  transport?: string;
+  port?: number;
+  host?: string;
+}
+
+interface MinimalProjectConfig {
+  mcp?: MinimalMcpConfig;
+}
+
+/**
+ * Perform developer-local setup for a Minsky project.
+ *
+ * Steps:
+ * 1. Check .minsky/config.yaml exists — error if not
+ * 2. Read and parse it (use yaml.parse)
+ * 3. Extract mcp section (default to { transport: "stdio" } if missing)
+ * 4. Call registerWithClient() to write the harness config file
+ * 5. Write .minsky/config.local.yaml with workspace.mainPath AND harness field
+ * 6. Return result describing what was written
+ */
+export async function performSetup(
+  options: SetupOptions,
+  fileSystem: FsLike = createRealFs()
+): Promise<SetupResult> {
+  const { repoPath, client = "cursor", overwrite = false } = options;
+
+  // 1. Check .minsky/config.yaml exists — error if not
+  const configPath = path.join(repoPath, ".minsky", "config.yaml");
+  const configExists = await fileSystem.exists(configPath);
+  if (!configExists) {
+    throw new Error(
+      `No .minsky/config.yaml found at ${configPath}. Run 'minsky init' first to initialize this project.`
+    );
+  }
+
+  // 2. Read and parse config.yaml
+  const configContent = await fileSystem.readFile(configPath, "utf-8");
+  const projectConfig = yamlParse(configContent) as MinimalProjectConfig;
+
+  // 3. Extract mcp section (default to { transport: "stdio" } if missing)
+  const mcpConfig: MinimalMcpConfig = projectConfig?.mcp ?? { transport: "stdio" };
+  const transport = mcpConfig.transport ?? "stdio";
+
+  // 4. Register with the MCP client — writes the harness config file (e.g. .cursor/mcp.json)
+  await registerWithClient(
+    repoPath,
+    { transport, port: mcpConfig.port, host: mcpConfig.host },
+    client,
+    fileSystem,
+    overwrite
+  );
+
+  // Determine the harness config path for the result (for reporting)
+  const registrar = getRegistrar(client);
+  const harnessConfigPath = registrar.configPath(repoPath);
+
+  // 5. Write .minsky/config.local.yaml with workspace.mainPath AND harness field
+  const localConfigPath = path.join(repoPath, ".minsky", "config.local.yaml");
+  const localConfigContent = yamlStringify({
+    workspace: { mainPath: repoPath },
+    harness: client,
+  });
+  await createFileIfNotExists(localConfigPath, localConfigContent, overwrite, fileSystem);
+
+  // 6. Return result
+  return {
+    success: true,
+    localConfigPath,
+    harnessConfigPath,
+    client,
+    message: `Setup complete. Local config written to ${localConfigPath}. Harness config written to ${harnessConfigPath}.`,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `performSetup()` domain function in `src/domain/setup.ts` that reads `.minsky/config.yaml`, registers the MCP client via `registerWithClient()`, and writes `.minsky/config.local.yaml` with both `workspace.mainPath` and `harness` fields
- Adds a `setup` shared command in `src/adapters/shared/commands/setup.ts` under `CommandCategory.INIT` with `--client` and `--overwrite` flags; detects installed MCP clients and prompts interactively when multiple are present
- Registers the command in the shared command index (`src/adapters/shared/commands/index.ts`) so it is automatically exposed via both the CLI (`minsky init setup`) and MCP adapters

## Test plan

- [ ] Run `minsky init setup` in a project with `.minsky/config.yaml` — verifies `.minsky/config.local.yaml` and `.cursor/mcp.json` are created
- [ ] Run with `--overwrite` flag to confirm existing files are replaced
- [ ] Run with `--client cursor` to bypass interactive detection
- [ ] Run in a project without `.minsky/config.yaml` — expect a clear error message directing user to run `minsky init` first
- [ ] Run in non-interactive mode with multiple clients detected — expect a validation error asking for `--client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)