### PR TITLE
feat(mt#864): enforce documentation freshness via PR review gate

### DIFF
--- a/.claude/hooks/require-review-before-merge.ts
+++ b/.claude/hooks/require-review-before-merge.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 // PreToolUse hook: block session_pr_merge if no review exists on the PR,
-// the review lacks a spec verification section, or the review is stale
-// (covers an older commit than PR HEAD).
-// Ensures code review, spec verification, AND review freshness before merging.
+// the review lacks a spec verification or documentation impact section,
+// or the review is stale (covers an older commit than PR HEAD).
+// Ensures code review, spec verification, documentation impact assessment,
+// AND review freshness before merging.
 
 import { readInput, writeOutput, execSync } from "./types";
 import type { ToolHookInput } from "./types";
@@ -62,6 +63,19 @@ if (!hasSpec) {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason: `Review on PR #${pr} lacks spec verification section. Use /review-pr to post a review that includes spec verification before merging.`,
+    },
+  });
+  process.exit(0);
+}
+
+// Check that at least one review contains documentation impact assessment
+const hasDocImpact = reviews.some((r) => r.body && /documentation impact/i.test(r.body));
+if (!hasDocImpact) {
+  writeOutput({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: `Review on PR #${pr} lacks documentation impact section. Use /review-pr to post a review that includes documentation impact assessment before merging.`,
     },
   });
   process.exit(0);

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -88,6 +88,25 @@ Any hits are **blocking findings** — they indicate incomplete removal.
    - Follow-up tasks must be created for deferred items
    - The review must explicitly list what was deferred and why
 
+### 6a. Assess documentation impact
+
+**This step is mandatory.** The pre-merge hook will reject merges without a "Documentation impact" section in the review.
+
+Assess whether the PR's changes affect any project documentation. Consider:
+
+- **Architectural changes** (new pattern, changed lifecycle, new subsystem, changed command registry) → check `docs/architecture.md`
+- **Theoretical/structural changes** (new enforcement mechanism, changed VSM organ status, new environmental constraint) → check `docs/theory-of-operation.md`
+- **Developer workflow changes** (new test pattern, changed hooks, changed DI approach, new commands) → check `CONTRIBUTING.md`
+- **User-facing changes** (new capabilities, changed CLI interface, changed configuration) → check `README.md`
+
+Classify the impact:
+
+- **"No update needed — [reason]"** — the change doesn't affect documented behavior (bugfix, internal refactor, cosmetic)
+- **"Updated [doc] in this PR"** — the PR includes documentation updates alongside the code changes
+- **"BLOCKING — [doc] needs updating but isn't updated in this PR"** — the change affects documented architecture/behavior and the docs weren't updated. This is a **blocking finding** that should trigger `REQUEST_CHANGES`. The PR cannot merge until the docs are updated in the same PR.
+
+"Follow-up task" is only acceptable when the reviewer provides explicit justification for why the doc update cannot be done in this PR (e.g., requires information from a different workstream that hasn't landed yet).
+
 ### 7. Post to GitHub
 
 Use `mcp__github__pull_request_review_write` to post the review:
@@ -126,6 +145,17 @@ Use `mcp__github__pull_request_review_write` to post the review:
 <If any criteria not met:>
 **Action required:** <spec update needed / follow-up task needed / blocking>
 
+### Documentation impact
+
+<One of:>
+No update needed — <reason: bugfix, internal refactor, cosmetic, etc.>
+
+<or:>
+Updated <doc> in this PR.
+
+<or:>
+**BLOCKING** — <doc> needs updating: <what changed and what section is affected>
+
 (Had Claude look into this — AI-assisted review)
 ```
 
@@ -136,4 +166,5 @@ Use `mcp__github__pull_request_review_write` to post the review:
 - **The diff shows what changed; the codebase shows whether the change is correct.** Always check both.
 - **Include CI status.** Don't approve with failing checks.
 - **Spec verification is mandatory.** The review must include a spec verification table. The pre-merge hook will reject merges without it.
+- **Documentation impact is mandatory.** The review must include a documentation impact section. The pre-merge hook will reject merges without it. If docs need updating but aren't updated in the PR, that's a blocking finding.
 - **Attribute AI involvement** per user preferences.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,13 +142,14 @@ After completing any investigation, audit, or research phase for a task, persist
 2. Mark completed criteria (e.g., `[x] Audit completed`)
 3. Then present a summary to the user in chat
 
-### Spec verification gates merge
+### Spec verification and documentation impact gate merge
 
-The `/review-pr` skill requires a **Spec verification** section in every review. The pre-merge hook (`require-review-before-merge.ts`) blocks merges if the review lacks this section. This ensures:
+The `/review-pr` skill requires both a **Spec verification** section and a **Documentation impact** section in every review. The pre-merge hook (`require-review-before-merge.ts`) blocks merges if either section is missing. This ensures:
 
 - Every spec criterion is checked before merge
 - Scope reductions are caught and documented
 - Follow-up tasks are created for deferred work
+- Documentation freshness is assessed for every PR — if docs need updating, the update must be in the same PR (not deferred to a follow-up)
 
 ## Work Completion
 


### PR DESCRIPTION
## Summary

Add mandatory "Documentation impact" section to PR reviews, enforced by the pre-merge hook. This is the same environmental enforcement pattern used for spec verification — the hook ensures the question was asked; the reviewer provides the semantic judgment.

**Changes:**
- `require-review-before-merge.ts`: added `/documentation impact/i` regex check parallel to existing `/spec verification/i` check. Merge blocked if section missing.
- `review-pr/SKILL.md`: added step 6a (assess documentation impact) with classification system and blocking rules. Added section to review body template.
- `CLAUDE.md`: documented the new requirement alongside spec verification.

**Enforcement chain:** The hook can't judge whether docs need updating (that's semantic). It judges whether the question was consciously answered. The reviewer reads the diff, assesses architectural/behavioral significance, and states the impact. If docs need updating but aren't updated in the PR, that's BLOCKING — same as an unmet spec criterion.

## Test plan

- [ ] Submit a PR review WITHOUT "Documentation impact" → pre-merge hook blocks
- [ ] Submit a PR review WITH "Documentation impact: No update needed" → hook passes
- [ ] Review skill prompts for doc assessment when invoked

🤖 Had Claude look into it — AI-assisted implementation

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>