### PR TITLE
feat(mt#854): Add minsky mcp register shared command

### DIFF
--- a/src/adapters/cli/customizations/mcp-customizations.ts
+++ b/src/adapters/cli/customizations/mcp-customizations.ts
@@ -1,0 +1,27 @@
+/**
+ * MCP Commands Customizations
+ *
+ * CLI customizations for MCP-related commands.
+ *
+ * The MCP category is hidden from the CLI auto-generation because the CLI
+ * has an existing non-shared `mcp` commander command tree (src/commands/mcp/)
+ * that includes `mcp.register` as a subcommand. Hiding the category here
+ * prevents Commander.js from throwing on a duplicate `mcp` top-level command.
+ */
+import type { CategoryCommandOptions } from "../../shared/bridges/cli";
+import { CommandCategory } from "../../shared/command-registry";
+
+/**
+ * Get customizations for MCP commands
+ */
+export function getMcpCustomizations(): {
+  category: CommandCategory;
+  options: CategoryCommandOptions;
+} {
+  return {
+    category: CommandCategory.MCP,
+    options: {
+      hidden: true,
+    },
+  };
+}

--- a/src/adapters/cli/setup/command-setup.ts
+++ b/src/adapters/cli/setup/command-setup.ts
@@ -12,6 +12,7 @@ import {
   getPersistenceCustomizations,
 } from "../customizations/config-customizations";
 import { getToolsCustomizations } from "../customizations/tools-customizations";
+import { getMcpCustomizations } from "../customizations/mcp-customizations";
 
 /**
  * Helper function to setup common CLI command customizations
@@ -41,6 +42,9 @@ export function setupCommonCommandCustomizations(program?: Command): void {
 
   const toolsConfig = getToolsCustomizations();
   cliFactory.customizeCategory(toolsConfig.category, toolsConfig.options);
+
+  const mcpConfig = getMcpCustomizations();
+  cliFactory.customizeCategory(mcpConfig.category, mcpConfig.options);
 }
 
 /**

--- a/src/adapters/mcp/mcp-commands.ts
+++ b/src/adapters/mcp/mcp-commands.ts
@@ -1,0 +1,24 @@
+/**
+ * MCP adapter for MCP management commands (e.g., mcp.register)
+ */
+import type { CommandMapper } from "../../mcp/command-mapper";
+import { registerMcpCommandsWithMcp } from "./shared-command-integration";
+import { log } from "../../utils/logger";
+
+/**
+ * Registers MCP management tools with the MCP command mapper
+ */
+export function registerMcpManagementTools(commandMapper: CommandMapper): void {
+  log.debug("Registering MCP management commands via shared command integration");
+
+  registerMcpCommandsWithMcp(commandMapper, {
+    debug: true,
+    commandOverrides: {
+      "mcp.register": {
+        description: "Register Minsky as an MCP server with a supported client",
+      },
+    },
+  });
+
+  log.debug("MCP management commands registered successfully via shared integration");
+}

--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -360,6 +360,19 @@ export function registerChangesetCommandsWithMcp(
 }
 
 /**
+ * Register MCP management commands with MCP (e.g., mcp.register)
+ */
+export function registerMcpCommandsWithMcp(
+  commandMapper: CommandMapper,
+  config: Omit<McpSharedCommandConfig, "categories"> = {}
+): void {
+  registerSharedCommandsWithMcp(commandMapper, {
+    categories: [CommandCategory.MCP],
+    ...config,
+  });
+}
+
+/**
  * Register all main command categories with MCP
  */
 export function registerAllMainCommandsWithMcp(
@@ -377,6 +390,7 @@ export function registerAllMainCommandsWithMcp(
       CommandCategory.INIT,
       CommandCategory.DEBUG,
       CommandCategory.PERSISTENCE,
+      CommandCategory.MCP,
     ],
     ...config,
   });

--- a/src/adapters/shared/bridges/cli/category-command-handler.ts
+++ b/src/adapters/shared/bridges/cli/category-command-handler.ts
@@ -56,6 +56,13 @@ export class CategoryCommandHandler {
 
     const customOptions = this.deps.customizationManager.getCategoryOptions(category);
 
+    // If the category is marked as hidden, skip CLI auto-generation.
+    // Used when a category's commands are wired into the CLI manually (e.g., mcp.register
+    // is added as a subcommand of the existing non-shared `mcp` commander command tree).
+    if (customOptions.hidden) {
+      return null;
+    }
+
     // Create the base category command
     const categoryCommand = this.createBaseCategoryCommand(category, customOptions);
 

--- a/src/adapters/shared/bridges/cli/command-customization-manager.ts
+++ b/src/adapters/shared/bridges/cli/command-customization-manager.ts
@@ -44,6 +44,8 @@ export interface CategoryCommandOptions {
   commandOptions?: Record<string, CliCommandOptions>;
   /** Whether to use category name as command prefix */
   usePrefix?: boolean;
+  /** Whether to suppress CLI auto-generation for this category (e.g., when the CLI wires the category manually) */
+  hidden?: boolean;
   /** Allow additional subcommand customization options */
   [key: string]: unknown;
 }

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -31,6 +31,7 @@ export enum CommandCategory {
   DEBUG = "DEBUG",
   AI = "AI",
   TOOLS = "TOOLS",
+  MCP = "MCP",
 }
 
 /**

--- a/src/adapters/shared/commands/index.ts
+++ b/src/adapters/shared/commands/index.ts
@@ -18,6 +18,7 @@ import { registerAiCommands } from "./ai";
 import { registerToolsCommands } from "./tools";
 import { registerChangesetCommands } from "./changeset";
 import { registerValidateCommands } from "./validate";
+import { registerMcpCommands } from "./mcp";
 
 /**
  * Register all shared commands in the shared command registry.
@@ -61,6 +62,9 @@ export async function registerAllSharedCommands(container?: AppContainerInterfac
   // Register validate commands (lint and typecheck)
   registerValidateCommands();
 
+  // Register MCP commands
+  registerMcpCommands();
+
   // Additional command categories can be registered here as they're implemented
 }
 
@@ -79,4 +83,5 @@ export {
   registerToolsCommands,
   registerChangesetCommands,
   registerValidateCommands,
+  registerMcpCommands,
 };

--- a/src/adapters/shared/commands/mcp/index.ts
+++ b/src/adapters/shared/commands/mcp/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared MCP Commands
+ *
+ * Registers all MCP-related commands in the shared command registry.
+ */
+
+import { registerMcpRegisterCommand } from "./register-command";
+
+export function registerMcpCommands(): void {
+  registerMcpRegisterCommand();
+}
+
+export { registerMcpRegisterCommand };

--- a/src/adapters/shared/commands/mcp/register-command.ts
+++ b/src/adapters/shared/commands/mcp/register-command.ts
@@ -1,0 +1,148 @@
+/**
+ * Shared MCP Register Command
+ *
+ * Registers Minsky as an MCP server with a supported client (e.g., Cursor).
+ * Reads the project's MCP config from `.minsky/config.yaml` and generates
+ * the appropriate harness-specific config file.
+ */
+
+import { z } from "zod";
+import { existsSync } from "fs";
+import * as path from "path";
+import { select, isCancel, cancel, confirm } from "@clack/prompts";
+import {
+  sharedCommandRegistry,
+  CommandCategory,
+  defineCommand,
+  type CommandParameterMap,
+} from "../../command-registry";
+import { CommonParameters, composeParams } from "../../common-parameters";
+import { isInteractive } from "../../../../utils/interactive";
+import { detectInstalledClients } from "../../../../domain/runtime/harness-detection";
+import { registerWithClient, getRegistrar } from "../../../../domain/mcp/registration";
+import { loadProjectConfiguration } from "../../../../domain/configuration/sources/project";
+import { ValidationError, getErrorMessage } from "../../../../errors/index";
+import type { McpConfig } from "../../../../domain/configuration/schemas/mcp";
+
+const mcpRegisterParams = composeParams(
+  {
+    repo: CommonParameters.repo,
+    workspacePath: CommonParameters.workspace,
+    overwrite: CommonParameters.overwrite,
+  },
+  {
+    client: {
+      schema: z.string().optional(),
+      description: "The MCP client to register with (e.g., cursor)",
+      required: false,
+    },
+  }
+) satisfies CommandParameterMap;
+
+export function registerMcpRegisterCommand(): void {
+  sharedCommandRegistry.registerCommand(
+    defineCommand({
+      id: "mcp.register",
+      category: CommandCategory.MCP,
+      name: "register",
+      description: "Register Minsky as an MCP server with a supported client",
+      parameters: mcpRegisterParams,
+      execute: async (params, _ctx) => {
+        try {
+          // 1. Resolve the repo path
+          const repoPath = params.repo || params.workspacePath || process.cwd();
+
+          // 2. Check that .minsky/config.yaml exists
+          const configYamlPath = path.join(repoPath, ".minsky", "config.yaml");
+          if (!existsSync(configYamlPath)) {
+            throw new ValidationError(
+              "This project hasn't been initialized. Run `minsky init` first."
+            );
+          }
+
+          // 3. Load the project config and read the `mcp` section
+          const projectConfig = loadProjectConfiguration(repoPath);
+          const mcpConfig: McpConfig = (projectConfig as Record<string, unknown>).mcp as McpConfig;
+          const resolvedMcpConfig = mcpConfig ?? { transport: "stdio" as const };
+
+          // 4. Determine the client to register with
+          let client = params.client;
+
+          if (!client) {
+            const detectedClients = detectInstalledClients();
+
+            if (detectedClients.length === 0) {
+              throw new ValidationError(
+                "No supported MCP clients detected. Use --client to specify."
+              );
+            }
+
+            if (detectedClients.length === 1) {
+              const singleClient = detectedClients[0] as string;
+              if (isInteractive()) {
+                // Confirm with user in interactive mode
+                const useDetected = await confirm({
+                  message: `Detected MCP client: ${singleClient}. Register with it?`,
+                  initialValue: true,
+                });
+
+                if (isCancel(useDetected)) {
+                  cancel("Registration cancelled.");
+                  return { success: false, message: "Registration cancelled by user." };
+                }
+
+                if (!useDetected) {
+                  throw new ValidationError(
+                    "No client selected. Use --client to specify a client."
+                  );
+                }
+              }
+              // In non-interactive mode, use the single detected client directly
+              client = singleClient;
+            } else {
+              // Multiple clients found
+              if (!isInteractive()) {
+                throw new ValidationError(
+                  `Multiple MCP clients detected: ${detectedClients.join(", ")}. Use --client to specify one.`
+                );
+              }
+
+              // Prompt user to select in interactive mode
+              const selectedClient = await select({
+                message: "Multiple MCP clients detected. Select one to register with:",
+                options: detectedClients.map((c) => ({ value: c, label: c })),
+              });
+
+              if (isCancel(selectedClient)) {
+                cancel("Registration cancelled.");
+                return { success: false, message: "Registration cancelled by user." };
+              }
+
+              client = selectedClient as string;
+            }
+          }
+
+          // 5. Register with the selected client
+          const overwrite = params.overwrite ?? false;
+          await registerWithClient(repoPath, resolvedMcpConfig, client, undefined, overwrite);
+
+          // Determine the config file path for the success message
+          const registrar = getRegistrar(client);
+          const configFilePath = registrar.configPath(repoPath);
+
+          return {
+            success: true,
+            message: `Registered Minsky as MCP server with ${client}.`,
+            configFilePath,
+            client,
+          };
+        } catch (error: unknown) {
+          if (error instanceof ValidationError) {
+            throw error;
+          }
+          throw new ValidationError(getErrorMessage(error));
+        }
+      },
+    })
+  );
+}

--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -3,6 +3,7 @@ import { createStartCommand } from "./start-command";
 import { createToolsCommand } from "./tools-command";
 import { createCallCommand } from "./call-command";
 import { createInspectCommand } from "./inspect-command";
+import { createRegisterCommand } from "./register-command";
 
 /**
  * Create the MCP command
@@ -17,6 +18,7 @@ export function createMCPCommand(): Command {
   mcpCommand.addCommand(createToolsCommand());
   mcpCommand.addCommand(createCallCommand());
   mcpCommand.addCommand(createInspectCommand());
+  mcpCommand.addCommand(createRegisterCommand());
 
   return mcpCommand;
 }

--- a/src/commands/mcp/register-command.ts
+++ b/src/commands/mcp/register-command.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import { sharedCommandRegistry } from "../../adapters/shared/command-registry";
+import { getErrorMessage } from "../../errors/index";
+import { log } from "../../utils/logger";
+
+/**
+ * Create the `mcp register` CLI subcommand.
+ *
+ * Delegates execution to the shared `mcp.register` command definition,
+ * keeping the logic DRY while wiring into the existing non-shared `mcp`
+ * commander command tree.
+ */
+export function createRegisterCommand(): Command {
+  const registerCmd = new Command("register");
+  registerCmd.description("Register Minsky as an MCP server with a supported client");
+
+  registerCmd.option("--client <client>", "The MCP client to register with (e.g., cursor)");
+  registerCmd.option("--repo <path>", "Repository path");
+  registerCmd.option("--workspace-path <path>", "Workspace path");
+  registerCmd.option("--overwrite", "Overwrite existing config", false);
+
+  registerCmd.action(async (options) => {
+    try {
+      const commandDef = sharedCommandRegistry.getCommand("mcp.register");
+      if (!commandDef) {
+        log.error("[mcp register] Shared command 'mcp.register' not found in registry");
+        process.exit(1);
+      }
+
+      const result = await commandDef.execute(
+        {
+          client: options.client,
+          repo: options.repo,
+          workspacePath: options.workspacePath,
+          overwrite: options.overwrite ?? false,
+        },
+        { interface: "cli" }
+      );
+
+      const typedResult = result as {
+        success: boolean;
+        message?: string;
+        configFilePath?: string;
+        client?: string;
+      };
+
+      if (typedResult.success) {
+        console.log(typedResult.message ?? "Registration successful.");
+        if (typedResult.configFilePath) {
+          console.log(`Config written to: ${typedResult.configFilePath}`);
+        }
+      } else {
+        console.error(typedResult.message ?? "Registration failed.");
+        process.exit(1);
+      }
+    } catch (error: unknown) {
+      console.error(`Error: ${getErrorMessage(error)}`);
+      process.exit(1);
+    }
+  });
+
+  return registerCmd;
+}

--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -24,6 +24,7 @@ import { registerConfigTools } from "../../adapters/mcp/config";
 import { registerSessionFileTools } from "../../adapters/mcp/session-files";
 import { registerSessionEditTools } from "../../adapters/mcp/session-edit-tools";
 import { registerValidateTools } from "../../adapters/mcp/validate";
+import { registerMcpManagementTools } from "../../adapters/mcp/mcp-commands";
 
 const DEFAULT_HTTP_PORT = 3000;
 const DEFAULT_HTTP_HOST = "localhost";
@@ -58,6 +59,7 @@ function registerAllTools(commandMapper: CommandMapper): void {
   registerConfigTools(commandMapper);
   registerChangesetTools(commandMapper);
   registerValidateTools(commandMapper);
+  registerMcpManagementTools(commandMapper);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `minsky mcp register` command that reads `.minsky/config.yaml` and generates the appropriate harness-specific MCP config file (e.g., `.cursor/mcp.json`)
- Implements `CommandCategory.MCP` in the shared command registry with a `hidden` CLI suppression mechanism to avoid conflict with the existing non-shared `mcp` commander tree
- Wires the command into both the CLI adapter (via `commands/mcp/index.ts`) and the MCP adapter (via `shared-command-integration.ts`)

## Key design decisions

- `CommandCategory.MCP` is added to the shared registry for MCP adapter exposure, but the CLI auto-generation is suppressed via a new `hidden: true` option in `CategoryCommandOptions` — this prevents Commander.js from throwing a duplicate-command error with the existing non-shared `mcp start/tools/call/inspect` tree
- The CLI-facing `mcp register` subcommand delegates to the shared `mcp.register` execute function, keeping logic DRY
- Interactive prompts use `@clack/prompts` (same as init command); `isInteractive()` gates all interactive paths

## Files changed

- `src/adapters/shared/commands/mcp/register-command.ts` — shared command definition
- `src/adapters/shared/commands/mcp/index.ts` — barrel export
- `src/adapters/shared/commands/index.ts` — registration wiring
- `src/adapters/shared/command-registry.ts` — `CommandCategory.MCP` added
- `src/adapters/shared/bridges/cli/command-customization-manager.ts` — `hidden` field added to `CategoryCommandOptions`
- `src/adapters/shared/bridges/cli/category-command-handler.ts` — honor `hidden: true` in `generateCategoryCommand`
- `src/adapters/cli/customizations/mcp-customizations.ts` — sets `hidden: true` for MCP category
- `src/adapters/cli/setup/command-setup.ts` — applies MCP customization
- `src/adapters/mcp/mcp-commands.ts` — MCP adapter registration
- `src/adapters/mcp/shared-command-integration.ts` — `registerMcpCommandsWithMcp` + include in `registerAllMainCommandsWithMcp`
- `src/commands/mcp/register-command.ts` — CLI-facing wrapper
- `src/commands/mcp/index.ts` — adds `register` subcommand
- `src/commands/mcp/start-command.ts` — wires `registerMcpManagementTools`

## Test plan

- [ ] Run `minsky mcp register --client cursor` in an initialized project → `.cursor/mcp.json` created
- [ ] Run `minsky mcp register` with no `--client` when cursor is installed → detects and prompts
- [ ] Run in non-interactive mode with multiple clients → errors with actionable message
- [ ] Run in an uninitialized project → errors with "Run `minsky init` first"
- [ ] Verify `minsky mcp start` exposes `mcp.register` as an MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)