### PR TITLE
refactor(mt#857): Separate minsky init into Phase 1 (project) and Phase 2 (developer-local)

### DIFF
--- a/src/adapters/shared/commands/init.ts
+++ b/src/adapters/shared/commands/init.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { existsSync } from "fs";
+import * as path from "path";
 import { select, isCancel, cancel, text, confirm } from "@clack/prompts";
 import { getErrorMessage } from "../../../errors/index";
 import {
@@ -84,6 +86,21 @@ export function registerInitCommands() {
         try {
           // Map CLI params to domain params
           const repoPath = params.repo || params.workspacePath || process.cwd();
+          const overwrite = params.overwrite ?? false;
+
+          // If config.yaml already exists and --overwrite is not set, inform the user
+          // and return early — the project is already initialized.
+          const configYamlPath = path.join(repoPath, ".minsky", "config.yaml");
+          if (!overwrite && existsSync(configYamlPath)) {
+            log.info(
+              "Project already initialized. Run `minsky setup` for developer-local configuration."
+            );
+            return {
+              success: true,
+              message:
+                "Project already initialized. Run `minsky setup` for developer-local configuration.",
+            };
+          }
 
           // Interactive backend selection if not provided
           let backend = params.backend;
@@ -283,8 +300,6 @@ export function registerInitCommands() {
               }
             }
           }
-
-          const overwrite = params.overwrite ?? false;
 
           // Detect repository backend from git remote
           let repository: ResolvedRepositoryConfig | undefined;

--- a/src/domain/init.ts
+++ b/src/domain/init.ts
@@ -4,7 +4,7 @@ import { enumSchemas } from "./configuration/schemas/base";
 import { createDirectoryIfNotExists, createFileIfNotExists } from "./init/file-system";
 import type { FsLike } from "./interfaces/fs-like";
 import { createRealFs } from "./interfaces/real-fs";
-import { getMinskyConfigContentYaml, getLocalConfigContentYaml } from "./init/config-content";
+import { getMinskyConfigContentYaml } from "./init/config-content";
 import {
   generateRulesWithTemplateSystem,
   generateMcpRuleWithTemplateSystem,
@@ -13,7 +13,7 @@ import {
   resolveRepositoryFromGitRemote,
   type ResolvedRepositoryConfig,
 } from "./session/repository-backend-detection";
-import { registerWithClient } from "./mcp/registration";
+import { performSetup } from "./setup";
 
 export type { ResolvedRepositoryConfig } from "./session/repository-backend-detection";
 
@@ -26,7 +26,7 @@ export function detectRepositoryBackend(repoPath: string): ResolvedRepositoryCon
 }
 
 // Re-export content helpers for consumers that may reference them
-export { getMinskyConfigContentYaml, getLocalConfigContentYaml } from "./init/config-content";
+export { getMinskyConfigContentYaml } from "./init/config-content";
 export {
   getMinskyRuleContent,
   getRulesIndexContent,
@@ -90,13 +90,23 @@ export interface InitializeProjectOptions {
 }
 
 /**
- * Creates directories if they don't exist, and errors if files already exist.
- * Orchestrates all project initialization steps.
+ * Orchestrates project initialization in two phases:
+ *
+ * Phase 1 (project-init): Creates project-level files checked into the repo —
+ *   .minsky/config.yaml (with mcp section), process/tasks/ dir, rules directory,
+ *   rule files. No harness-specific files.
+ *
+ * Phase 2 (developer-setup): Calls performSetup() to handle developer-local
+ *   configuration — MCP client registration (.cursor/mcp.json) and
+ *   .minsky/config.local.yaml with workspace.mainPath and harness field.
+ *   Skipped when mcp.enabled is false.
  */
 export async function initializeProject(
   { repoPath, backend, ruleFormat, mcp, overwrite = false, repository }: InitializeProjectOptions,
   fileSystem: FsLike = createRealFs()
 ): Promise<void> {
+  // === Phase 1: Project initialization ===
+
   // Create process/tasks directory structure
   const tasksDir = path.join(repoPath, "process", "tasks");
   await createDirectoryIfNotExists(tasksDir, fileSystem);
@@ -148,28 +158,8 @@ export async function initializeProject(
   const configContent = getMinskyConfigContentYaml(backend, repository, mcpForConfig);
   await createFileIfNotExists(configPath, configContent, overwrite, fileSystem);
 
-  // Write machine-specific local config (gitignored) with workspace.mainPath
-  // so session_start can use --reference cloning for fast session creation.
-  const localConfigPath = path.join(minskyDir, "config.local.yaml");
-  const localConfigContent = getLocalConfigContentYaml(repoPath);
-  await createFileIfNotExists(localConfigPath, localConfigContent, overwrite, fileSystem);
-
-  // Setup MCP if enabled (default to enabled if not explicitly disabled)
+  // Generate MCP rule file (project-level rule checked into repo) when MCP is enabled
   if (mcp?.enabled !== false) {
-    // Register Minsky with the Cursor MCP client
-    await registerWithClient(
-      repoPath,
-      {
-        transport: mcp?.transport || "stdio",
-        port: mcp?.port,
-        host: mcp?.host,
-      },
-      "cursor",
-      fileSystem,
-      overwrite
-    );
-
-    // Determine rules dir path for MCP rule
     const mcpRulesDirPath =
       ruleFormat === "cursor"
         ? path.join(repoPath, ".cursor", "rules")
@@ -183,5 +173,13 @@ export async function initializeProject(
     } catch (_e) {
       // Skip in unit tests without registry
     }
+  }
+
+  // === Phase 2: Developer-local setup ===
+  // Skipped when MCP is explicitly disabled (e.g. in tests or non-MCP workflows).
+  // performSetup() writes .minsky/config.local.yaml (with harness field) and
+  // registers Minsky with the MCP client (e.g. .cursor/mcp.json).
+  if (mcp?.enabled !== false) {
+    await performSetup({ repoPath, client: "cursor", overwrite }, fileSystem);
   }
 }


### PR DESCRIPTION
## Summary

- **Phase 1 (project-init):** `initializeProject()` now creates only project-level files: `.minsky/config.yaml` (with mcp section), `process/tasks/` dir, rules directory, rule files. No harness-specific files.
- **Phase 2 (developer-setup):** `initializeProject()` now calls `performSetup()` from `src/domain/setup.ts` to handle MCP client registration (`.cursor/mcp.json`) and `.minsky/config.local.yaml` with `harness` field. Phase 2 is skipped when `mcp.enabled === false`.
- **Init command early-return:** When `.minsky/config.yaml` already exists and `--overwrite` is not set, the command logs `"Project already initialized. Run \`minsky setup\` for developer-local configuration."` and returns successfully without prompting.
- **Dead export removed:** `getLocalConfigContentYaml` re-export from `domain/init` removed (no external consumers — function still exists in `domain/init/config-content`).

## Test plan

- [ ] Existing tests in `src/domain/init-backend-selection.test.ts` pass unchanged — they use `mcp: { enabled: false }`, so Phase 2 is skipped and no mock filesystem calls to `performSetup` occur
- [ ] `minsky init` on a fresh repo runs both phases
- [ ] `minsky init` on an already-initialized repo (without `--overwrite`) logs the early-return message
- [ ] `minsky init --overwrite` on an already-initialized repo re-runs both phases
- [ ] `minsky setup` still works standalone (no change to `performSetup()`)

## Coherence Verification

**Files re-read**: `src/domain/init.ts`, `src/adapters/shared/commands/init.ts`, `src/domain/setup.ts`, `src/domain/init/config-content.ts`, `src/domain/init-backend-selection.test.ts`

**Q1 single purpose**: pass — `init.ts` is the project-init orchestrator, `setup.ts` is the developer-local setup handler. Clear boundary.

**Q2 comment honesty**: pass — `initializeProject()` docstring updated to describe Phase 1/Phase 2 split. Comments inside the function are accurate.

**Q3 naming honesty**: pass — no renames needed; `initializeProject` still initializes, `performSetup` still sets up.

**Q4 redundant siblings**: pass — `setup.ts` and `init.ts` have distinct responsibilities and no overlap post-refactor.

**Q5 dead exports**: pass — removed `getLocalConfigContentYaml` from re-exports in `domain/init` after confirming via grep that no external file imports it from there. `getMinskyConfigContentYaml` still has a caller (line 158). All rule-template re-exports verified to exist in `rule-templates.ts`.

**Q6 orphan code**: pass — no helper functions existed solely to support the removed direct-registration pattern. `getLocalConfigContentYaml` in `config-content.ts` is still referenced by that module's own export (may be useful standalone); left in place.

**Q7 stray artifacts**: pass — no `.bak`, `.tmp`, `.old` files created.

**Items fixed in this PR (beyond original scope)**: Dead `getLocalConfigContentYaml` re-export removed from `domain/init`.

**Items deferred**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (had Claude do the refactor work)