### PR TITLE
feat(mt#858): Add project setup guard for uninitialized projects

### DIFF
--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -14,6 +14,7 @@ import {
 } from "../shared/command-registry";
 import { log } from "../../utils/logger";
 import { z } from "zod";
+import { guardProjectSetup } from "../../domain/configuration/guard";
 
 /**
  * Convert shared command parameters to a Zod schema that MCP can use
@@ -176,6 +177,11 @@ export function registerSharedCommandsWithMcp(
 
             const parameters = convertMcpArgsToParameters(filteredArgs, command.parameters);
             log.debug(`[MCP] Converted parameters: ${command.id}`, { parameters });
+
+            // Guard: verify the project is initialized before executing non-exempt commands
+            if (command.requiresSetup !== false) {
+              guardProjectSetup(command.id);
+            }
 
             // Execute the shared command (no timeout - debug actual hang)
             log.debug(`[MCP] About to execute command: ${command.id}`);

--- a/src/adapters/shared/bridges/cli/command-generator-core.ts
+++ b/src/adapters/shared/bridges/cli/command-generator-core.ts
@@ -20,6 +20,7 @@ import {
 } from "./command-customization-manager";
 import { type ParameterProcessor } from "./parameter-processor";
 import { type CommandResultFormatter } from "./result-formatter";
+import { guardProjectSetup } from "../../../../domain/configuration/guard";
 
 /**
  * CLI-specific execution context
@@ -181,6 +182,11 @@ export class CommandGeneratorCore {
 
         // Normalize parameters
         const normalizedParams = normalizeCliParameters(commandDef.parameters, rawParameters);
+
+        // Guard: verify the project is initialized before executing non-exempt commands
+        if (commandDef.requiresSetup !== false) {
+          guardProjectSetup(commandDef.id);
+        }
 
         // Execute the command with parameters and context
         const result = await commandDef.execute(normalizedParams, context);

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -116,6 +116,12 @@ export interface CommandDefinition<
   parameters: T;
   /** Command execution handler */
   execute: CommandExecutionHandler<T, R>;
+  /**
+   * Whether this command requires the project to be initialized before execution.
+   * Defaults to true. Set to false for commands like `init`, `setup`, and `mcp.register`
+   * that are responsible for initialization themselves.
+   */
+  requiresSetup?: boolean;
 }
 
 /**
@@ -170,6 +176,7 @@ export interface SharedCommand<T extends CommandParameterMap = CommandParameterM
   description: string;
   parameters: T;
   execute: CommandExecutionHandler<T, R>;
+  requiresSetup?: boolean;
 }
 
 /**

--- a/src/adapters/shared/commands/init.ts
+++ b/src/adapters/shared/commands/init.ts
@@ -82,6 +82,7 @@ export function registerInitCommands() {
       name: "init",
       description: "Initialize a project for Minsky",
       parameters: initParams,
+      requiresSetup: false,
       execute: async (params, _ctx) => {
         try {
           // Map CLI params to domain params

--- a/src/adapters/shared/commands/mcp/register-command.ts
+++ b/src/adapters/shared/commands/mcp/register-command.ts
@@ -47,6 +47,7 @@ export function registerMcpRegisterCommand(): void {
       name: "register",
       description: "Register Minsky as an MCP server with a supported client",
       parameters: mcpRegisterParams,
+      requiresSetup: false,
       execute: async (params, _ctx) => {
         try {
           // 1. Resolve the repo path

--- a/src/adapters/shared/commands/setup.ts
+++ b/src/adapters/shared/commands/setup.ts
@@ -50,6 +50,7 @@ export function registerSetupCommands() {
       description:
         "Set up developer-local configuration for Minsky (MCP registration + local config)",
       parameters: setupParams,
+      requiresSetup: false,
       execute: async (params, _ctx) => {
         try {
           const repoPath = params.repo || params.workspacePath || process.cwd();

--- a/src/domain/configuration/guard.test.ts
+++ b/src/domain/configuration/guard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the project setup guard.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { checkProjectSetup, guardProjectSetup, EXEMPT_COMMANDS } from "./guard";
+import { ValidationError } from "../../errors/index";
+
+const FAKE_REPO = "/fake/repo";
+const CONFIG_YAML = `${FAKE_REPO}/.minsky/config.yaml`;
+const CONFIG_LOCAL_YAML = `${FAKE_REPO}/.minsky/config.local.yaml`;
+
+/**
+ * Create a minimal mock existsSync that returns true only for paths in the given set.
+ */
+function makeExistsSync(existingPaths: Set<string>): (p: string) => boolean {
+  return (p: string) => existingPaths.has(p);
+}
+
+describe("checkProjectSetup", () => {
+  it("throws ValidationError with minsky init guidance when config.yaml is missing", () => {
+    const deps = { existsSync: makeExistsSync(new Set()) };
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ValidationError);
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(
+      "This project hasn't been initialized. Run `minsky init` first."
+    );
+  });
+
+  it("throws ValidationError with minsky setup guidance when config.yaml exists but config.local.yaml is missing", () => {
+    const deps = {
+      existsSync: makeExistsSync(new Set([CONFIG_YAML])),
+    };
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ValidationError);
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(
+      "Developer setup incomplete. Run `minsky setup` first."
+    );
+  });
+
+  it("does not throw when both config.yaml and config.local.yaml exist", () => {
+    const deps = {
+      existsSync: makeExistsSync(new Set([CONFIG_YAML, CONFIG_LOCAL_YAML])),
+    };
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).not.toThrow();
+  });
+});
+
+describe("guardProjectSetup", () => {
+  const missingDeps = { existsSync: makeExistsSync(new Set()) };
+  const fullDeps = {
+    existsSync: makeExistsSync(new Set([CONFIG_YAML, CONFIG_LOCAL_YAML])),
+  };
+
+  it("does not throw for exempt commands even when project is not initialized", () => {
+    for (const commandId of EXEMPT_COMMANDS) {
+      expect(() => guardProjectSetup(commandId, FAKE_REPO, missingDeps)).not.toThrow();
+    }
+  });
+
+  it("throws for non-exempt commands when project is not initialized", () => {
+    expect(() => guardProjectSetup("tasks.list", FAKE_REPO, missingDeps)).toThrow(ValidationError);
+    expect(() => guardProjectSetup("tasks.list", FAKE_REPO, missingDeps)).toThrow(
+      "This project hasn't been initialized. Run `minsky init` first."
+    );
+  });
+
+  it("passes for non-exempt commands when project is fully initialized", () => {
+    expect(() => guardProjectSetup("tasks.list", FAKE_REPO, fullDeps)).not.toThrow();
+  });
+});
+
+describe("EXEMPT_COMMANDS", () => {
+  it("contains init, setup, and mcp.register", () => {
+    expect(EXEMPT_COMMANDS.has("init")).toBe(true);
+    expect(EXEMPT_COMMANDS.has("setup")).toBe(true);
+    expect(EXEMPT_COMMANDS.has("mcp.register")).toBe(true);
+  });
+});

--- a/src/domain/configuration/guard.ts
+++ b/src/domain/configuration/guard.ts
@@ -1,0 +1,63 @@
+/**
+ * Project Setup Guard
+ *
+ * Provides a guard function that verifies a project has been properly initialized
+ * before commands are executed. Throws actionable errors when setup is incomplete.
+ */
+
+import { existsSync } from "fs";
+import * as path from "path";
+import { ValidationError } from "../../errors/index";
+
+/**
+ * Set of command IDs that are exempt from the project setup guard.
+ * These commands are responsible for initialization themselves, or are
+ * infrastructure commands that must work without a configured project.
+ */
+export const EXEMPT_COMMANDS = new Set(["init", "setup", "mcp.register"]);
+
+/**
+ * Dependencies for the project setup guard (injectable for testing).
+ */
+export interface GuardDeps {
+  existsSync: (path: string) => boolean;
+}
+
+/**
+ * Check whether the project at `repoPath` has been properly initialized.
+ *
+ * - Missing `.minsky/config.yaml` → error with "minsky init" guidance
+ * - Missing `.minsky/config.local.yaml` (when config.yaml exists) → error with "minsky setup" guidance
+ * - Both files present → no error
+ *
+ * @param repoPath - Path to the project root
+ * @param deps     - Injectable dependencies (defaults to real fs)
+ * @throws {ValidationError} When project setup is incomplete
+ */
+export function checkProjectSetup(repoPath: string, deps: GuardDeps = { existsSync }): void {
+  const configPath = path.join(repoPath, ".minsky", "config.yaml");
+  const localConfigPath = path.join(repoPath, ".minsky", "config.local.yaml");
+
+  if (!deps.existsSync(configPath)) {
+    throw new ValidationError("This project hasn't been initialized. Run `minsky init` first.");
+  }
+
+  if (!deps.existsSync(localConfigPath)) {
+    throw new ValidationError("Developer setup incomplete. Run `minsky setup` first.");
+  }
+}
+
+/**
+ * Run the project setup guard unless the command is exempt.
+ *
+ * @param commandId - The command ID being executed
+ * @param repoPath  - Path to the project root (defaults to process.cwd())
+ * @param deps      - Injectable dependencies (defaults to real fs)
+ */
+export function guardProjectSetup(commandId: string, repoPath?: string, deps?: GuardDeps): void {
+  if (EXEMPT_COMMANDS.has(commandId)) {
+    return;
+  }
+
+  checkProjectSetup(repoPath ?? process.cwd(), deps);
+}


### PR DESCRIPTION
## Summary

- Adds `src/domain/configuration/guard.ts` with `checkProjectSetup()` and `guardProjectSetup()` functions that throw actionable `ValidationError`s when `.minsky/config.yaml` or `.minsky/config.local.yaml` are missing
- Integrates the guard into both the CLI execution path (`command-generator-core.ts`) and the MCP execution path (`shared-command-integration.ts`) so it fires for all shared commands in both interfaces
- Adds `requiresSetup?: boolean` field to `CommandDefinition` / `SharedCommand`; exempted commands (`init`, `setup`, `mcp.register`) set `requiresSetup: false` to bypass the guard
- Tests in `guard.test.ts` cover all three cases (missing config.yaml, missing config.local.yaml, both present) using injected mock `existsSync` — no real filesystem access

## Test plan

- [ ] `bun test src/domain/configuration/guard.test.ts` passes
- [ ] Running any non-exempt command in an uninitialized project prints the "minsky init" error
- [ ] Running any non-exempt command with only `config.yaml` (no `config.local.yaml`) prints the "minsky setup" error
- [ ] `init`, `setup`, and `mcp.register` commands run without triggering the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)