### PR TITLE
refactor(mt#887): remove defaultInstance singleton from PersistenceService

### DIFF
--- a/src/adapters/shared/commands/tools/index-embeddings-command.ts
+++ b/src/adapters/shared/commands/tools/index-embeddings-command.ts
@@ -53,7 +53,13 @@ export class ToolsIndexEmbeddingsCommand {
       const { createLogger } = await import("../../../../utils/logger");
 
       const log = createLogger();
-      const service = await createToolEmbeddingService();
+      const persistence = ctx?.container?.get("persistence");
+      if (!persistence) {
+        throw new Error(
+          "Persistence provider not available. Ensure the DI container is initialized."
+        );
+      }
+      const service = await createToolEmbeddingService({}, persistence);
 
       // If limit is specified, we'll need to get all tools and slice
       // For now, index all tools (following the pattern)

--- a/src/adapters/shared/commands/tools/similarity-commands.ts
+++ b/src/adapters/shared/commands/tools/similarity-commands.ts
@@ -9,6 +9,7 @@ import type { CommandExecutionContext, CommandParameterMap } from "../../command
 import { sharedCommandRegistry } from "../../command-registry";
 import { createLogger } from "../../../../utils/logger";
 import { CommonParameters } from "../../common-parameters";
+import type { PersistenceProvider } from "../../../../domain/persistence/types";
 
 const log = createLogger();
 
@@ -110,6 +111,8 @@ export class ToolsSimilarCommand {
   readonly description = "Find tools similar to the given tool using embeddings";
   readonly parameters = toolsSimilarParams;
 
+  constructor(private readonly getPersistenceProvider?: () => PersistenceProvider) {}
+
   /**
    * Enhance search results with tool details for better CLI output
    */
@@ -163,7 +166,7 @@ export class ToolsSimilarCommand {
     const { createToolSimilarityService } = await import(
       "../../../../domain/tools/similarity/tool-similarity-service"
     );
-    const service = await createToolSimilarityService();
+    const service = await createToolSimilarityService({}, this.getPersistenceProvider!());
 
     const searchResults = await service.similarToTool(toolId, limit, threshold);
 
@@ -209,6 +212,8 @@ export class ToolsSearchCommand {
   readonly name = "search";
   readonly description = "Search for tools using natural language queries";
   readonly parameters = toolsSearchParams;
+
+  constructor(private readonly getPersistenceProvider?: () => PersistenceProvider) {}
 
   /**
    * Enhance search results with tool details for better CLI output
@@ -263,7 +268,7 @@ export class ToolsSearchCommand {
     const { createToolSimilarityService } = await import(
       "../../../../domain/tools/similarity/tool-similarity-service"
     );
-    const service = await createToolSimilarityService();
+    const service = await createToolSimilarityService({}, this.getPersistenceProvider!());
 
     // Immediate progress hint to stderr unless JSON/quiet
     if (!params.quiet && !params.json && ctx?.format !== "json") {

--- a/src/composition/cli.ts
+++ b/src/composition/cli.ts
@@ -27,17 +27,14 @@ export async function createCliContainer(): Promise<AppContainerInterface> {
   container.register(
     "persistence",
     async () => {
-      // Use the defaultInstance during migration — code that hasn't been
-      // migrated to container access still uses defaultInstance.getProvider().
-      // Once all callers use the container, this can create a fresh instance.
-      const { defaultInstance } = await import("../domain/persistence/service");
-      await defaultInstance.initialize();
-      return defaultInstance.getProvider();
+      const { PersistenceService } = await import("../domain/persistence/service");
+      const service = new PersistenceService();
+      await service.initialize();
+      return service.getProvider();
     },
     {
-      dispose: async () => {
-        const { defaultInstance } = await import("../domain/persistence/service");
-        await defaultInstance.close();
+      dispose: async (provider) => {
+        await provider.close();
       },
     }
   );

--- a/src/domain/context/components/tool-schemas.ts
+++ b/src/domain/context/components/tool-schemas.ts
@@ -130,7 +130,11 @@ export const ToolSchemasComponent: ContextComponent = {
       const userQuery = context.userQuery || context.userPrompt;
       // IMPORTANT: When a custom commandRegistry is provided (e.g., in unit tests),
       // disable query-based filtering to ensure full registry visibility.
-      let shouldFilterByQuery = Boolean(userQuery?.trim()) && !context.commandRegistry;
+      // Also disable if no persistence provider is available (required for embedding lookup).
+      let shouldFilterByQuery =
+        Boolean(userQuery?.trim()) &&
+        !context.commandRegistry &&
+        Boolean(context.persistenceProvider);
 
       const toolSchemas: Record<string, unknown> = {};
       let totalTools = 0;
@@ -141,7 +145,10 @@ export const ToolSchemasComponent: ContextComponent = {
       if (shouldFilterByQuery) {
         try {
           // NEW: Query-aware tool filtering using ToolSimilarityService
-          const toolSimilarityService = await createToolSimilarityService();
+          const toolSimilarityService = await createToolSimilarityService(
+            {},
+            context.persistenceProvider!
+          );
 
           const relevantTools = await toolSimilarityService.findRelevantTools({
             query: userQuery!,

--- a/src/domain/context/components/types.ts
+++ b/src/domain/context/components/types.ts
@@ -18,6 +18,8 @@ export interface ComponentInput {
   rulesService?: unknown;
   // Optional session provider for DI (avoids reaching into shared singleton)
   sessionProvider?: import("../../session/index").SessionProviderInterface;
+  // Optional persistence provider for DI (used by query-aware tool filtering)
+  persistenceProvider?: import("../../persistence/types").PersistenceProvider;
   // ... other potential inputs
 }
 

--- a/src/domain/persistence/service.ts
+++ b/src/domain/persistence/service.ts
@@ -131,32 +131,3 @@ export class PersistenceService {
     }
   }
 }
-
-/**
- * Convenience function to get persistence provider from the default instance.
- * @deprecated Use container.get("persistence") instead.
- */
-export function getPersistenceProvider(): PersistenceProvider {
-  return defaultInstance.getProvider();
-}
-
-/**
- * Default instance — used during migration period while callers
- * transition to container-based injection. Will be removed in Phase E.
- */
-export const defaultInstance = new PersistenceService();
-
-/**
- * Resolve a PersistenceProvider: use the explicit one if provided,
- * otherwise fall back to the default instance lazily.
- *
- * Callers with DI container access should always pass the provider
- * explicitly. This helper exists as a transitional bridge for domain
- * code that hasn't been fully migrated to container-based DI yet.
- *
- * @deprecated Prefer receiving the provider via constructor injection or deps interface.
- */
-export function resolveProvider(provider?: PersistenceProvider): PersistenceProvider {
-  if (provider) return provider;
-  return defaultInstance.getProvider();
-}

--- a/src/domain/similarity/create-rule-similarity-core.ts
+++ b/src/domain/similarity/create-rule-similarity-core.ts
@@ -7,16 +7,15 @@ import { createRulesVectorStorageFromConfig } from "../storage/vector/vector-sto
 import { RuleService } from "../rules";
 import { getConfiguration } from "../configuration";
 import type { PersistenceProvider } from "../persistence/types";
-import { resolveProvider } from "../persistence/service";
 
 export interface RuleSimilarityCoreOptions {
   disableEmbeddings?: boolean;
-  persistenceProvider?: PersistenceProvider;
+  persistenceProvider: PersistenceProvider;
 }
 
 export async function createRuleSimilarityCore(
   workspacePath: string,
-  options: RuleSimilarityCoreOptions = {}
+  options: RuleSimilarityCoreOptions
 ) {
   const cfg = getConfiguration();
   const model = cfg?.embeddings?.model || "text-embedding-3-small";
@@ -25,9 +24,11 @@ export async function createRuleSimilarityCore(
   let embeddings: EmbeddingsSimilarityBackend | null = null;
   if (!options.disableEmbeddings) {
     try {
-      const resolvedProvider = resolveProvider(options.persistenceProvider);
       const embedding = await createEmbeddingServiceFromConfig();
-      const storage = await createRulesVectorStorageFromConfig(dimension, resolvedProvider);
+      const storage = await createRulesVectorStorageFromConfig(
+        dimension,
+        options.persistenceProvider
+      );
       embeddings = new EmbeddingsSimilarityBackend(embedding, storage);
     } catch {
       embeddings = null;

--- a/src/domain/tasks/taskCommands.db-wiring.test.ts
+++ b/src/domain/tasks/taskCommands.db-wiring.test.ts
@@ -4,11 +4,11 @@ import { listTasksFromParams } from "./taskCommands";
 describe("DB wiring for minsky backend", () => {
   beforeAll(async () => {
     // Set up mock persistence provider before any tests run
-    const { defaultInstance: persistenceService } = await import("../persistence/service");
+    const { PersistenceService } = await import("../persistence/service");
     const { FakePersistenceProvider } = await import("../persistence/fake-persistence-provider");
 
+    const persistenceService = new PersistenceService();
     const fakeProvider = new FakePersistenceProvider();
-    // Set provider directly on the default instance for testing
     (persistenceService as any).provider = fakeProvider;
 
     // Initialize configuration for persistence tests

--- a/src/domain/tasks/taskCommands.test.ts
+++ b/src/domain/tasks/taskCommands.test.ts
@@ -21,11 +21,12 @@ import path from "path";
 
 describe("Interface-Agnostic Task Command Functions", () => {
   beforeAll(async () => {
-    const { defaultInstance: persistenceService } = await import("../persistence/service");
+    const { PersistenceService } = await import("../persistence/service");
     const { FakePersistenceProvider } = await import("../persistence/fake-persistence-provider");
     const { FakeSessionProvider } = await import("../session/fake-session-provider");
     const { setSharedSessionProvider } = await import("../session/session-provider-cache-seams");
 
+    const persistenceService = new PersistenceService();
     (persistenceService as any).provider = new FakePersistenceProvider();
     setSharedSessionProvider(new FakeSessionProvider());
 

--- a/src/domain/tools/similarity/create-tool-similarity-core.ts
+++ b/src/domain/tools/similarity/create-tool-similarity-core.ts
@@ -8,14 +8,13 @@ import { getEmbeddingDimension } from "../../ai/embedding-models";
 import { getConfiguration } from "../../configuration";
 import { sharedCommandRegistry } from "../../../adapters/shared/command-registry";
 import type { PersistenceProvider } from "../../persistence/types";
-import { resolveProvider } from "../../persistence/service";
 
 export interface ToolSimilarityCoreOptions {
   disableEmbeddings?: boolean;
-  persistenceProvider?: PersistenceProvider;
+  persistenceProvider: PersistenceProvider;
 }
 
-export async function createToolSimilarityCore(options: ToolSimilarityCoreOptions = {}) {
+export async function createToolSimilarityCore(options: ToolSimilarityCoreOptions) {
   const cfg = getConfiguration();
   const model = cfg?.embeddings?.model || "text-embedding-3-small";
   const dimension = getEmbeddingDimension(model, 1536);
@@ -23,9 +22,11 @@ export async function createToolSimilarityCore(options: ToolSimilarityCoreOption
   let embeddings: EmbeddingsSimilarityBackend | null = null;
   if (!options.disableEmbeddings) {
     try {
-      const resolvedProvider = resolveProvider(options.persistenceProvider);
       const embedding = await createEmbeddingServiceFromConfig();
-      const storage = await createToolsVectorStorageFromConfig(dimension, resolvedProvider);
+      const storage = await createToolsVectorStorageFromConfig(
+        dimension,
+        options.persistenceProvider
+      );
       embeddings = new EmbeddingsSimilarityBackend(embedding, storage);
     } catch {
       embeddings = null; // Treat embeddings as unavailable when misconfigured in tests

--- a/src/domain/tools/similarity/tool-similarity-service.ts
+++ b/src/domain/tools/similarity/tool-similarity-service.ts
@@ -169,8 +169,7 @@ export class ToolSimilarityService {
  */
 export async function createToolSimilarityService(
   config: ToolSimilarityServiceConfig = {},
-  persistenceProvider?: PersistenceProvider
+  persistenceProvider: PersistenceProvider
 ): Promise<ToolSimilarityService> {
-  const { resolveProvider } = await import("../../persistence/service");
-  return new ToolSimilarityService(resolveProvider(persistenceProvider), config);
+  return new ToolSimilarityService(persistenceProvider, config);
 }

--- a/src/domain/tools/tool-embedding-service.ts
+++ b/src/domain/tools/tool-embedding-service.ts
@@ -165,8 +165,7 @@ export class ToolEmbeddingService {
  */
 export async function createToolEmbeddingService(
   config: ToolEmbeddingServiceConfig = {},
-  persistenceProvider?: PersistenceProvider
+  persistenceProvider: PersistenceProvider
 ): Promise<ToolEmbeddingService> {
-  const { resolveProvider } = await import("../persistence/service");
-  return new ToolEmbeddingService(resolveProvider(persistenceProvider), config);
+  return new ToolEmbeddingService(persistenceProvider, config);
 }


### PR DESCRIPTION
## Summary

Remove the `defaultInstance` singleton export, `getPersistenceProvider()`, and `resolveProvider()` from PersistenceService. This eliminates the transitional bridge anti-pattern identified in the mt#811 retrospective.

### Changes:
- **service.ts**: Removed `defaultInstance`, `getPersistenceProvider()`, `resolveProvider()` exports
- **cli.ts**: Composition root creates fresh `PersistenceService` instance, disposes via `provider.close()`
- **4 domain files**: Updated `resolveProvider` callers to require explicit provider (no fallback)
- **index-embeddings-command.ts**: Gets provider from DI container (`ctx.container`)
- **2 test files**: Create `PersistenceService` instances directly instead of importing singleton

Part of mt#879 (Phase E: DI lockdown).