### PR TITLE
fix(mt#889): fix task title parsing and add MCP to Zod category schema

### DIFF
--- a/.claude/hooks/post-session-start.ts
+++ b/.claude/hooks/post-session-start.ts
@@ -90,9 +90,10 @@ async function main(): Promise<void> {
     if (result.exitCode === 0) {
       const output = result.stdout.toString().trim();
       if (output) {
-        const taskData = JSON.parse(output) as { title?: string };
-        if (taskData.title) {
-          title = taskData.title;
+        const taskData = JSON.parse(output) as { task?: { title?: string }; title?: string };
+        const taskTitle = taskData.task?.title ?? taskData.title;
+        if (taskTitle) {
+          title = taskTitle;
         }
       }
     }

--- a/src/schemas/command-registry.ts
+++ b/src/schemas/command-registry.ts
@@ -21,6 +21,7 @@ export const commandCategorySchema = z.enum([
   "DEBUG",
   "AI",
   "TOOLS",
+  "MCP",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Fix task title parsing in `post-session-start.ts`: CLI returns `{ task: { title } }`, not `{ title }`
- Add missing `MCP` to `commandCategorySchema` in Zod — was breaking MCP server startup after mt#854 added `MCP` to the TypeScript enum but not the Zod schema

## Test plan

- [x] Manual hook test returns full task title instead of falling back to task ID
- [x] MCP server starts successfully with the schema fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)