### PR TITLE
fix(mt#891): Fix setup-required guard: sessions, infra commands, and setup overwrite

### DIFF
--- a/src/adapters/shared/commands/config/get-set-commands.ts
+++ b/src/adapters/shared/commands/config/get-set-commands.ts
@@ -33,6 +33,7 @@ export const configGetRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "get",
   description: "Get a configuration value by key path",
+  requiresSetup: false,
   parameters: composeParams(configCommandParams, {
     key: {
       schema: z.string(),
@@ -84,6 +85,7 @@ export const configSetRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "set",
   description: "Set a configuration value",
+  requiresSetup: false,
   parameters: composeParams(configCommandParams, {
     key: {
       schema: z.string(),
@@ -142,6 +144,7 @@ export const configUnsetRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "unset",
   description: "Remove a configuration value",
+  requiresSetup: false,
   parameters: composeParams(configCommandParams, {
     key: {
       schema: z.string(),

--- a/src/adapters/shared/commands/config/list-show-commands.ts
+++ b/src/adapters/shared/commands/config/list-show-commands.ts
@@ -51,6 +51,7 @@ export const configListRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "list",
   description: "Show all configuration from all sources",
+  requiresSetup: false,
   parameters: configListParams,
   execute: async (params, _ctx) => {
     try {
@@ -107,6 +108,7 @@ export const configShowRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "show",
   description: "Show the final resolved configuration",
+  requiresSetup: false,
   parameters: configShowParams,
   execute: async (params, _ctx) => {
     try {

--- a/src/adapters/shared/commands/config/validate-doctor-commands.ts
+++ b/src/adapters/shared/commands/config/validate-doctor-commands.ts
@@ -31,6 +31,7 @@ export const configValidateRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "validate",
   description: "Validate configuration against schemas",
+  requiresSetup: false,
   parameters: composeParams(configCommandParams, {
     verbose: {
       schema: z.boolean(),
@@ -74,6 +75,7 @@ export const configDoctorRegistration = defineCommand({
   category: CommandCategory.CONFIG,
   name: "doctor",
   description: "Diagnose common configuration problems",
+  requiresSetup: false,
   parameters: composeParams(configCommandParams, {
     verbose: {
       schema: z.boolean(),

--- a/src/adapters/shared/commands/debug.ts
+++ b/src/adapters/shared/commands/debug.ts
@@ -69,6 +69,7 @@ export function registerDebugCommands(): void {
       category: CommandCategory.DEBUG,
       name: "listMethods",
       description: "List all registered methods for debugging",
+      requiresSetup: false,
       parameters: debugListMethodsParams,
       execute: async (params, context) => {
         log.debug("Executing debug.listMethods command", { params });
@@ -98,6 +99,7 @@ export function registerDebugCommands(): void {
       category: CommandCategory.DEBUG,
       name: "echo",
       description: "Echo back the provided parameters (for testing communication)",
+      requiresSetup: false,
       parameters: debugEchoParams,
       execute: async (params, context) => {
         log.debug("Executing debug.echo command", { params });
@@ -124,6 +126,7 @@ export function registerDebugCommands(): void {
       category: CommandCategory.DEBUG,
       name: "systemInfo",
       description: "Get system information for diagnostics",
+      requiresSetup: false,
       parameters: debugSystemInfoParams,
       execute: async (params, context) => {
         log.debug("Executing debug.systemInfo command", { params });

--- a/src/adapters/shared/commands/persistence.ts
+++ b/src/adapters/shared/commands/persistence.ts
@@ -86,6 +86,7 @@ const persistenceMigrateRegistration = defineCommand({
   name: "migrate",
   description:
     "Migrate session database between backends, or run schema migrations when no target is provided",
+  requiresSetup: false,
   parameters: persistenceMigrateCommandParams,
   async execute(params, context) {
     const {
@@ -405,6 +406,7 @@ const persistenceCheckRegistration = defineCommand({
   category: CommandCategory.PERSISTENCE,
   name: "check",
   description: "Check database integrity and detect issues",
+  requiresSetup: false,
   parameters: persistenceCheckCommandParams,
   async execute(params, context) {
     const { file, backend, fix, report } = params;

--- a/src/adapters/shared/commands/session/management-commands.ts
+++ b/src/adapters/shared/commands/session/management-commands.ts
@@ -90,6 +90,7 @@ export function createSessionMigrateBackendCommand(getDeps: LazySessionDeps): Co
     category: CommandCategory.SESSION,
     name: "migrate-backend",
     description: "Migrate a session's repository backend to GitHub by following origin remote",
+    requiresSetup: false,
     parameters: sessionMigrateBackendCommandParams,
     execute: withErrorLogging(
       "session.migrate-backend",
@@ -285,6 +286,7 @@ export function createSessionMigrateCommand(getDeps: LazySessionDeps): CommandDe
     category: CommandCategory.SESSION,
     name: "migrate",
     description: "Migrate legacy session IDs to UUID format",
+    requiresSetup: false,
     parameters: sessionMigrateCommandParams,
     execute: withErrorLogging("session.migrate", async (params: Record<string, unknown>) => {
       const deps = await getDeps();

--- a/src/domain/configuration/guard.test.ts
+++ b/src/domain/configuration/guard.test.ts
@@ -10,6 +10,13 @@ const FAKE_REPO = "/fake/repo";
 const CONFIG_YAML = `${FAKE_REPO}/.minsky/config.yaml`;
 const CONFIG_LOCAL_YAML = `${FAKE_REPO}/.minsky/config.local.yaml`;
 
+const SESSION_REPO = "/home/user/.local/state/minsky/sessions/d4be5fee-86a3-4235-89b8-9a8bbf54c610";
+const SESSION_CONFIG_YAML = `${SESSION_REPO}/.minsky/config.yaml`;
+
+// Error message constants to avoid magic string duplication
+const ERR_NOT_INITIALIZED = "This project hasn't been initialized. Run `minsky init` first.";
+const ERR_SETUP_INCOMPLETE = "Developer setup incomplete. Run `minsky setup` first.";
+
 /**
  * Create a minimal mock existsSync that returns true only for paths in the given set.
  */
@@ -21,9 +28,7 @@ describe("checkProjectSetup", () => {
   it("throws ValidationError with minsky init guidance when config.yaml is missing", () => {
     const deps = { existsSync: makeExistsSync(new Set()) };
     expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ValidationError);
-    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(
-      "This project hasn't been initialized. Run `minsky init` first."
-    );
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ERR_NOT_INITIALIZED);
   });
 
   it("throws ValidationError with minsky setup guidance when config.yaml exists but config.local.yaml is missing", () => {
@@ -31,9 +36,7 @@ describe("checkProjectSetup", () => {
       existsSync: makeExistsSync(new Set([CONFIG_YAML])),
     };
     expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ValidationError);
-    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(
-      "Developer setup incomplete. Run `minsky setup` first."
-    );
+    expect(() => checkProjectSetup(FAKE_REPO, deps)).toThrow(ERR_SETUP_INCOMPLETE);
   });
 
   it("does not throw when both config.yaml and config.local.yaml exist", () => {
@@ -41,6 +44,21 @@ describe("checkProjectSetup", () => {
       existsSync: makeExistsSync(new Set([CONFIG_YAML, CONFIG_LOCAL_YAML])),
     };
     expect(() => checkProjectSetup(FAKE_REPO, deps)).not.toThrow();
+  });
+
+  it("does not throw in a session directory even when config.local.yaml is missing", () => {
+    // Session directories have config.yaml (checked in) but not config.local.yaml (gitignored)
+    const deps = {
+      existsSync: makeExistsSync(new Set([SESSION_CONFIG_YAML])),
+    };
+    expect(() => checkProjectSetup(SESSION_REPO, deps)).not.toThrow();
+  });
+
+  it("still requires config.yaml in session directories", () => {
+    // Missing config.yaml in a session directory should still throw
+    const deps = { existsSync: makeExistsSync(new Set()) };
+    expect(() => checkProjectSetup(SESSION_REPO, deps)).toThrow(ValidationError);
+    expect(() => checkProjectSetup(SESSION_REPO, deps)).toThrow(ERR_NOT_INITIALIZED);
   });
 });
 
@@ -59,7 +77,7 @@ describe("guardProjectSetup", () => {
   it("throws for non-exempt commands when project is not initialized", () => {
     expect(() => guardProjectSetup("tasks.list", FAKE_REPO, missingDeps)).toThrow(ValidationError);
     expect(() => guardProjectSetup("tasks.list", FAKE_REPO, missingDeps)).toThrow(
-      "This project hasn't been initialized. Run `minsky init` first."
+      ERR_NOT_INITIALIZED
     );
   });
 

--- a/src/domain/configuration/guard.ts
+++ b/src/domain/configuration/guard.ts
@@ -24,11 +24,21 @@ export interface GuardDeps {
 }
 
 /**
+ * Detect whether `repoPath` is a Minsky session directory.
+ *
+ * Session directories are isolated git clones that don't have `.minsky/config.local.yaml`
+ * (it's gitignored), so the local config check must be skipped for them.
+ */
+function isSessionDirectory(repoPath: string): boolean {
+  return repoPath.includes("/.local/state/minsky/sessions/");
+}
+
+/**
  * Check whether the project at `repoPath` has been properly initialized.
  *
  * - Missing `.minsky/config.yaml` → error with "minsky init" guidance
- * - Missing `.minsky/config.local.yaml` (when config.yaml exists) → error with "minsky setup" guidance
- * - Both files present → no error
+ * - Missing `.minsky/config.local.yaml` (when config.yaml exists and not in session) → error with "minsky setup" guidance
+ * - Both files present (or in a session directory) → no error
  *
  * @param repoPath - Path to the project root
  * @param deps     - Injectable dependencies (defaults to real fs)
@@ -42,7 +52,9 @@ export function checkProjectSetup(repoPath: string, deps: GuardDeps = { existsSy
     throw new ValidationError("This project hasn't been initialized. Run `minsky init` first.");
   }
 
-  if (!deps.existsSync(localConfigPath)) {
+  // Skip the local config check when running inside a session directory.
+  // Session directories are isolated git clones where config.local.yaml is gitignored.
+  if (!isSessionDirectory(repoPath) && !deps.existsSync(localConfigPath)) {
     throw new ValidationError("Developer setup incomplete. Run `minsky setup` first.");
   }
 }

--- a/src/domain/setup.ts
+++ b/src/domain/setup.ts
@@ -53,7 +53,7 @@ export async function performSetup(
   options: SetupOptions,
   fileSystem: FsLike = createRealFs()
 ): Promise<SetupResult> {
-  const { repoPath, client = "cursor", overwrite = false } = options;
+  const { repoPath, client = "cursor", overwrite = true } = options;
 
   // 1. Check .minsky/config.yaml exists — error if not
   const configPath = path.join(repoPath, ".minsky", "config.yaml");


### PR DESCRIPTION
## Summary

Fixes three bugs in the setup-required guard (mt#858) that caused false positives:

1. **Session directories**: Guard no longer fires for `config.local.yaml` inside session directories (`~/.local/state/minsky/sessions/`) since that file is gitignored and won't exist in clones
2. **Infrastructure commands**: Added `requiresSetup: false` to persistence, session migrate, debug, and config commands
3. **Setup idempotency**: `performSetup()` now defaults `overwrite` to `true` so re-running `minsky setup` always succeeds

## Test plan

- [x] Guard tests pass including new session directory tests
- [x] `persistence migrate --dry-run` no longer triggers guard
- [x] `minsky setup` succeeds even when `.cursor/mcp.json` already exists