### PR TITLE
refactor(mt#893): Extract McpServersJsonRegistrar base class and add ClaudeDesktopRegistrar

### DIFF
--- a/src/adapters/shared/commands/mcp/register-command.ts
+++ b/src/adapters/shared/commands/mcp/register-command.ts
@@ -1,7 +1,7 @@
 /**
  * Shared MCP Register Command
  *
- * Registers Minsky as an MCP server with a supported client (e.g., Cursor).
+ * Registers Minsky as an MCP server with a supported client (e.g., Cursor, Claude Desktop).
  * Reads the project's MCP config from `.minsky/config.yaml` and generates
  * the appropriate harness-specific config file.
  */
@@ -33,7 +33,7 @@ const mcpRegisterParams = composeParams(
   {
     client: {
       schema: z.string().optional(),
-      description: "The MCP client to register with (e.g., cursor)",
+      description: "The MCP client to register with (e.g., cursor, claude-desktop)",
       required: false,
     },
   }

--- a/src/domain/mcp/registration.test.ts
+++ b/src/domain/mcp/registration.test.ts
@@ -4,7 +4,14 @@
 
 import { describe, test, expect, beforeEach } from "bun:test";
 import * as path from "path";
-import { CursorRegistrar, getRegistrar, registerWithClient } from "./registration";
+import * as os from "os";
+import {
+  CursorRegistrar,
+  ClaudeDesktopRegistrar,
+  McpServersJsonRegistrar,
+  getRegistrar,
+  registerWithClient,
+} from "./registration";
 import { createMockFs } from "../interfaces/mock-fs";
 import type { MockFs } from "../interfaces/mock-fs";
 
@@ -79,6 +86,70 @@ describe("CursorRegistrar", () => {
       );
     });
   });
+
+  test("mergeConfig is false (owns its file)", () => {
+    expect(registrar.mergeConfig).toBe(false);
+  });
+});
+
+describe("ClaudeDesktopRegistrar", () => {
+  const registrar = new ClaudeDesktopRegistrar();
+
+  describe("generateConfig — inherits McpServersJsonRegistrar logic", () => {
+    test("stdio transport produces correct JSON", () => {
+      const content = registrar.generateConfig("stdio");
+      const parsed = JSON.parse(content);
+
+      expect(parsed.mcpServers["minsky-server"].command).toBe("minsky");
+      expect(parsed.mcpServers["minsky-server"].args).toEqual(["mcp", "start"]);
+    });
+
+    test("httpStream transport includes correct args", () => {
+      const content = registrar.generateConfig("httpStream", 3000, "localhost");
+      const parsed = JSON.parse(content);
+
+      expect(parsed.mcpServers["minsky-server"].args).toEqual([
+        "mcp",
+        "start",
+        "--http-stream",
+        "--port",
+        "3000",
+        "--host",
+        "localhost",
+      ]);
+    });
+  });
+
+  describe("configPath", () => {
+    test("returns OS-appropriate path (does not include projectRoot)", () => {
+      const configPath = registrar.configPath("/any-project-root");
+      // Should be under the user's home directory, not under the project root
+      expect(configPath).not.toContain("/any-project-root");
+      expect(configPath).toContain("claude_desktop_config.json");
+      expect(configPath).toContain("Claude");
+      // Should be an absolute path under homedir
+      expect(configPath.startsWith(os.homedir())).toBe(true);
+    });
+
+    test("config path ends with claude_desktop_config.json", () => {
+      const configPath = registrar.configPath("/irrelevant");
+      expect(configPath.endsWith("claude_desktop_config.json")).toBe(true);
+    });
+  });
+
+  test("mergeConfig is true (shares global config file)", () => {
+    expect(registrar.mergeConfig).toBe(true);
+  });
+});
+
+describe("McpServersJsonRegistrar (abstract base)", () => {
+  test("CursorRegistrar is an instance of McpServersJsonRegistrar", () => {
+    expect(new CursorRegistrar()).toBeInstanceOf(McpServersJsonRegistrar);
+  });
+
+  test("ClaudeDesktopRegistrar is an instance of McpServersJsonRegistrar", () => {
+    expect(new ClaudeDesktopRegistrar()).toBeInstanceOf(McpServersJsonRegistrar);
+  });
 });
 
 describe("getRegistrar", () => {
@@ -88,15 +159,15 @@ describe("getRegistrar", () => {
     expect(r.name).toBe("cursor");
   });
 
-  test("throws descriptive error for unsupported client", () => {
-    expect(() => getRegistrar("unknown")).toThrow(
-      'MCP client "unknown" is not yet supported. Supported clients: cursor'
-    );
+  test("returns ClaudeDesktopRegistrar for 'claude-desktop'", () => {
+    const r = getRegistrar("claude-desktop");
+    expect(r).toBeInstanceOf(ClaudeDesktopRegistrar);
+    expect(r.name).toBe("claude-desktop");
   });
 
-  test("throws descriptive error for 'claude-desktop'", () => {
-    expect(() => getRegistrar("claude-desktop")).toThrow(
-      'MCP client "claude-desktop" is not yet supported. Supported clients: cursor'
+  test("throws descriptive error for unsupported client", () => {
+    expect(() => getRegistrar("unknown")).toThrow(
+      'MCP client "unknown" is not yet supported. Supported clients: cursor, claude-desktop'
     );
   });
 });
@@ -142,5 +213,70 @@ describe("registerWithClient", () => {
     const content = mockFs.files.get(path.join("/my-project", ".cursor", "mcp.json"))!;
     const parsed = JSON.parse(content);
     expect(parsed.mcpServers["minsky-server"].args).toContain("--sse");
+  });
+
+  describe("claude-desktop config merging", () => {
+    const registrar = new ClaudeDesktopRegistrar();
+
+    test("creates new file if config file does not exist", async () => {
+      await registerWithClient("/any-root", { transport: "stdio" }, "claude-desktop", mockFs);
+
+      const configPath = registrar.configPath("/any-root");
+      expect(mockFs.files.has(configPath)).toBe(true);
+      const parsed = JSON.parse(mockFs.files.get(configPath)!);
+      expect(parsed.mcpServers["minsky-server"]).toBeDefined();
+    });
+
+    test("merges minsky-server into existing config preserving other servers", async () => {
+      const configPath = registrar.configPath("/any-root");
+      const existingConfig = JSON.stringify({
+        mcpServers: {
+          "other-server": {
+            command: "other",
+            args: ["run"],
+          },
+        },
+        someOtherKey: "preserved",
+      });
+      mockFs.files.set(configPath, existingConfig);
+      // Ensure the parent directory is recognized
+      mockFs.directories.add(path.dirname(configPath));
+
+      await registerWithClient("/any-root", { transport: "stdio" }, "claude-desktop", mockFs);
+
+      const parsed = JSON.parse(mockFs.files.get(configPath)!);
+      // Existing server preserved
+      expect(parsed.mcpServers["other-server"]).toBeDefined();
+      // Minsky server added
+      expect(parsed.mcpServers["minsky-server"]).toBeDefined();
+      expect(parsed.mcpServers["minsky-server"].command).toBe("minsky");
+      // Other top-level keys preserved
+      expect(parsed.someOtherKey).toBe("preserved");
+    });
+
+    test("overwrites existing minsky-server entry when merging", async () => {
+      const configPath = registrar.configPath("/any-root");
+      const existingConfig = JSON.stringify({
+        mcpServers: {
+          "minsky-server": {
+            command: "old-command",
+            args: ["old-args"],
+          },
+        },
+      });
+      mockFs.files.set(configPath, existingConfig);
+      mockFs.directories.add(path.dirname(configPath));
+
+      await registerWithClient(
+        "/any-root",
+        { transport: "httpStream", port: 4242 },
+        "claude-desktop",
+        mockFs
+      );
+
+      const parsed = JSON.parse(mockFs.files.get(configPath)!);
+      expect(parsed.mcpServers["minsky-server"].args).toContain("--http-stream");
+      expect(parsed.mcpServers["minsky-server"].args).toContain("4242");
+    });
   });
 });

--- a/src/domain/mcp/registration.ts
+++ b/src/domain/mcp/registration.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { homedir } from "os";
 import { DEFAULT_DEV_PORT } from "../../utils/constants";
 import type { FsLike } from "../interfaces/fs-like";
 import { createRealFs } from "../interfaces/real-fs";
@@ -13,14 +14,27 @@ export interface ClientRegistrar {
   name: string;
   generateConfig(transport: string, port?: number, host?: string): string;
   configPath(projectRoot: string): string;
+  /**
+   * Whether registration should merge the new server entry into an existing
+   * config file rather than overwriting the entire file.
+   *
+   * Clients that own their config file (e.g. Cursor's `.cursor/mcp.json`)
+   * set this to false. Clients that share a global config file (e.g. Claude
+   * Desktop's `claude_desktop_config.json`) set this to true.
+   */
+  readonly mergeConfig: boolean;
 }
 
 /**
- * Registrar for the Cursor editor MCP client.
- * Produces `.cursor/mcp.json` content and path.
+ * Base registrar for clients that use the standard mcpServers JSON format.
+ * Subclasses only need to provide name, configPath, and optionally mergeConfig.
  */
-export class CursorRegistrar implements ClientRegistrar {
-  readonly name = "cursor";
+export abstract class McpServersJsonRegistrar implements ClientRegistrar {
+  abstract readonly name: string;
+  abstract configPath(projectRoot: string): string;
+
+  /** Override to true in subclasses that share a global config file. */
+  readonly mergeConfig: boolean = false;
 
   generateConfig(transport: string, port?: number, host?: string): string {
     const resolvedPort = port || DEFAULT_DEV_PORT;
@@ -101,9 +115,55 @@ export class CursorRegistrar implements ClientRegistrar {
       2
     );
   }
+}
+
+/**
+ * Registrar for the Cursor editor MCP client.
+ * Produces `.cursor/mcp.json` content and path.
+ */
+export class CursorRegistrar extends McpServersJsonRegistrar {
+  readonly name = "cursor";
 
   configPath(projectRoot: string): string {
     return path.join(projectRoot, ".cursor", "mcp.json");
+  }
+}
+
+/**
+ * Registrar for the Claude Desktop MCP client.
+ *
+ * Claude Desktop uses a global (user-level) config file rather than a
+ * per-project one, so registration merges the minsky-server entry into any
+ * existing config rather than overwriting it.
+ *
+ * Config file locations:
+ * - macOS:   ~/Library/Application Support/Claude/claude_desktop_config.json
+ * - Windows: %APPDATA%\Claude\claude_desktop_config.json
+ * - Linux:   ~/.config/Claude/claude_desktop_config.json
+ */
+export class ClaudeDesktopRegistrar extends McpServersJsonRegistrar {
+  readonly name = "claude-desktop";
+  override readonly mergeConfig = true;
+
+  configPath(_projectRoot: string): string {
+    const home = homedir();
+    if (process.platform === "darwin") {
+      return path.join(
+        home,
+        "Library",
+        "Application Support",
+        "Claude",
+        "claude_desktop_config.json"
+      );
+    } else if (process.platform === "win32") {
+      return path.join(
+        process.env.APPDATA || path.join(home, "AppData", "Roaming"),
+        "Claude",
+        "claude_desktop_config.json"
+      );
+    }
+    // Linux
+    return path.join(home, ".config", "Claude", "claude_desktop_config.json");
   }
 }
 
@@ -115,14 +175,21 @@ export function getRegistrar(client: string): ClientRegistrar {
   switch (client) {
     case "cursor":
       return new CursorRegistrar();
+    case "claude-desktop":
+      return new ClaudeDesktopRegistrar();
     default:
-      throw new Error(`MCP client "${client}" is not yet supported. Supported clients: cursor`);
+      throw new Error(
+        `MCP client "${client}" is not yet supported. Supported clients: cursor, claude-desktop`
+      );
   }
 }
 
 /**
  * Orchestrates registering Minsky as an MCP server with the given client.
- * Gets the registrar, generates the config, and writes it to the correct path.
+ *
+ * For clients with mergeConfig=true (e.g. Claude Desktop), reads the existing
+ * config, merges the minsky-server entry into mcpServers, and writes it back.
+ * For other clients, creates or overwrites the config file outright.
  */
 export async function registerWithClient(
   projectRoot: string,
@@ -132,7 +199,30 @@ export async function registerWithClient(
   overwrite = false
 ): Promise<void> {
   const registrar = getRegistrar(client);
-  const content = registrar.generateConfig(mcpConfig.transport, mcpConfig.port, mcpConfig.host);
+  const newConfigJson = registrar.generateConfig(
+    mcpConfig.transport,
+    mcpConfig.port,
+    mcpConfig.host
+  );
   const filePath = registrar.configPath(projectRoot);
-  await createFileIfNotExists(filePath, content, overwrite, fileSystem);
+
+  if (registrar.mergeConfig && (await fileSystem.exists(filePath))) {
+    // Merge: read existing config, update the minsky-server entry, write back
+    const existing = await fileSystem.readFile(filePath, "utf-8");
+    const existingParsed = JSON.parse(existing) as Record<string, unknown>;
+    const newParsed = JSON.parse(newConfigJson) as {
+      mcpServers: Record<string, unknown>;
+    };
+
+    const merged = {
+      ...existingParsed,
+      mcpServers: {
+        ...(existingParsed.mcpServers as Record<string, unknown> | undefined),
+        ...newParsed.mcpServers,
+      },
+    };
+    await fileSystem.writeFile(filePath, JSON.stringify(merged, undefined, 2));
+  } else {
+    await createFileIfNotExists(filePath, newConfigJson, overwrite, fileSystem);
+  }
 }

--- a/src/domain/runtime/harness-detection.ts
+++ b/src/domain/runtime/harness-detection.ts
@@ -56,7 +56,7 @@ export function hasNativeSubagentSupport(): boolean {
  *
  * Detection heuristics:
  * - cursor: ~/.cursor/ directory exists
- * - claude-desktop: TODO (~/Library/Application Support/Claude/ on macOS)
+ * - claude-desktop: config directory exists (platform-specific)
  * - vscode: TODO
  */
 export function detectInstalledClients(): ManagedClient[] {
@@ -67,7 +67,23 @@ export function detectInstalledClients(): ManagedClient[] {
     clients.push("cursor");
   }
 
-  // TODO: claude-desktop — check ~/Library/Application Support/Claude/ on macOS
+  // Claude Desktop: check for platform-specific config directory
+  const home = homedir();
+  let claudeConfigDir: string;
+  if (process.platform === "darwin") {
+    claudeConfigDir = path.join(home, "Library", "Application Support", "Claude");
+  } else if (process.platform === "win32") {
+    claudeConfigDir = path.join(
+      process.env.APPDATA || path.join(home, "AppData", "Roaming"),
+      "Claude"
+    );
+  } else {
+    claudeConfigDir = path.join(home, ".config", "Claude");
+  }
+  if (existsSync(claudeConfigDir)) {
+    clients.push("claude-desktop");
+  }
+
   // TODO: vscode — check ~/.vscode/ or platform-specific VS Code config dirs
 
   return clients;


### PR DESCRIPTION
## Summary

- Extracts `McpServersJsonRegistrar` abstract base class from `CursorRegistrar` — moves the shared `mcpServers` JSON config generation logic into the base class
- `CursorRegistrar` simplified to just `name` + `configPath` (inherits config generation)
- Implements `ClaudeDesktopRegistrar` with OS-aware config path (macOS/Windows/Linux) and `mergeConfig = true`
- Adds `mergeConfig` field to `ClientRegistrar` interface — when true, `registerWithClient()` merges into existing config instead of overwriting
- Updates `detectInstalledClients()` with Claude Desktop detection (platform-specific config dir check)
- Updates `getRegistrar()` to support `"claude-desktop"` client name

## Test plan

- [x] Existing CursorRegistrar tests pass unchanged (regression)
- [x] ClaudeDesktopRegistrar generates correct config
- [x] ClaudeDesktopRegistrar returns OS-appropriate config path
- [x] Config merging preserves existing servers when adding minsky-server
- [x] `getRegistrar("claude-desktop")` returns correct instance
- [x] All 1714 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)