### PR TITLE
refactor(mt#897): thread container through MCP registration chain (batch 2)

### DIFF
--- a/src/adapters/mcp/changeset.ts
+++ b/src/adapters/mcp/changeset.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers changeset tools with the MCP command mapper
  */
-export function registerChangesetTools(commandMapper: CommandMapper): void {
+export function registerChangesetTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering changeset commands with MCP");
 
   // Use the bridge integration to automatically register all changeset commands
   registerChangesetCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "changeset.list": {

--- a/src/adapters/mcp/config.ts
+++ b/src/adapters/mcp/config.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers config tools with the MCP command mapper
  */
-export function registerConfigTools(commandMapper: CommandMapper): void {
+export function registerConfigTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering config commands via shared command integration");
 
   // Use the bridge integration to automatically register all config commands
   registerConfigCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "config.list": {

--- a/src/adapters/mcp/debug.ts
+++ b/src/adapters/mcp/debug.ts
@@ -9,11 +9,15 @@ import { log } from "../../utils/logger";
  * Registers debug tools with the MCP command mapper
  * These tools are primarily for development and debugging purposes
  */
-export function registerDebugTools(commandMapper: CommandMapper): void {
+export function registerDebugTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering debug commands via shared command integration");
 
   // Use the bridge integration to automatically register all debug commands
   registerDebugCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "debug.listMethods": {

--- a/src/adapters/mcp/git.ts
+++ b/src/adapters/mcp/git.ts
@@ -21,10 +21,14 @@ import { log } from "../../utils/logger";
  * - git.rebase: Use session commands for rebasing
  * - git.branch: Use session commands for branch creation
  */
-export function registerGitTools(commandMapper: CommandMapper): void {
+export function registerGitTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering git commands via shared command integration");
 
   registerGitCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       // Hide session-scoped or less useful git operations from main workspace MCP

--- a/src/adapters/mcp/init.ts
+++ b/src/adapters/mcp/init.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers initialization tools with the MCP command mapper
  */
-export function registerInitTools(commandMapper: CommandMapper): void {
+export function registerInitTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering init commands via shared command integration");
 
   // Use the bridge integration to automatically register all init commands
   registerInitCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       init: {

--- a/src/adapters/mcp/mcp-commands.ts
+++ b/src/adapters/mcp/mcp-commands.ts
@@ -8,10 +8,14 @@ import { log } from "../../utils/logger";
 /**
  * Registers MCP management tools with the MCP command mapper
  */
-export function registerMcpManagementTools(commandMapper: CommandMapper): void {
+export function registerMcpManagementTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering MCP management commands via shared command integration");
 
   registerMcpCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "mcp.register": {

--- a/src/adapters/mcp/persistence.ts
+++ b/src/adapters/mcp/persistence.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers persistence tools with the MCP command mapper
  */
-export function registerPersistenceTools(commandMapper: CommandMapper): void {
+export function registerPersistenceTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering persistence commands via shared command integration");
 
   // Use the bridge integration to automatically register all persistence commands
   registerPersistenceCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "persistence.migrate": {
@@ -30,7 +34,10 @@ export function registerPersistenceTools(commandMapper: CommandMapper): void {
 /**
  * Legacy sessiondb tools registration (for backward compatibility)
  */
-export function registerSessiondbTools(commandMapper: CommandMapper): void {
+export function registerSessiondbTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   // Forward to persistence tools for backward compatibility
-  registerPersistenceTools(commandMapper);
+  registerPersistenceTools(commandMapper, container);
 }

--- a/src/adapters/mcp/rules.ts
+++ b/src/adapters/mcp/rules.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers rules tools with the MCP command mapper
  */
-export function registerRulesTools(commandMapper: CommandMapper): void {
+export function registerRulesTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering rules commands via shared command integration");
 
   // Use the bridge integration to automatically register all rules commands
   registerRulesCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "rules.list": {

--- a/src/adapters/mcp/session-edit-tools.ts
+++ b/src/adapters/mcp/session-edit-tools.ts
@@ -36,8 +36,14 @@ type SearchReplaceArgs = SessionSearchReplace;
 /**
  * Registers session-aware file editing tools with the MCP command mapper
  */
-export function registerSessionEditTools(commandMapper: CommandMapper): void {
-  const pathResolver = new SessionPathResolver();
+export function registerSessionEditTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
+  const sessionProvider = container?.has("sessionProvider")
+    ? container.get("sessionProvider")
+    : undefined;
+  const pathResolver = new SessionPathResolver(sessionProvider);
 
   // Session edit file tool
   commandMapper.addCommand({

--- a/src/adapters/mcp/session-files.ts
+++ b/src/adapters/mcp/session-files.ts
@@ -21,15 +21,23 @@ import { createSuccessResponse, createErrorResponse } from "../../domain/schemas
 /**
  * Create a new session path resolver instance
  */
-function createPathResolver(): SessionPathResolver {
-  return new SessionPathResolver();
+function createPathResolver(
+  container?: import("../../composition/types").AppContainerInterface
+): SessionPathResolver {
+  const sessionProvider = container?.has("sessionProvider")
+    ? container.get("sessionProvider")
+    : undefined;
+  return new SessionPathResolver(sessionProvider);
 }
 
 /**
  * Registers session file operation tools with the MCP command mapper
  */
-export function registerSessionFileTools(commandMapper: CommandMapper): void {
-  const pathResolver = createPathResolver();
+export function registerSessionFileTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
+  const pathResolver = createPathResolver(container);
 
   // Session read file tool with line range support
   // Session move file tool

--- a/src/adapters/mcp/session-workspace.ts
+++ b/src/adapters/mcp/session-workspace.ts
@@ -92,15 +92,23 @@ function processFileContentWithLineRange(
 /**
  * Create a new session path resolver instance
  */
-function createPathResolver(): SessionPathResolver {
-  return new SessionPathResolver();
+function createPathResolver(
+  container?: import("../../composition/types").AppContainerInterface
+): SessionPathResolver {
+  const sessionProvider = container?.has("sessionProvider")
+    ? container.get("sessionProvider")
+    : undefined;
+  return new SessionPathResolver(sessionProvider);
 }
 
 /**
  * Registers session workspace tools with the MCP command mapper
  */
-export function registerSessionWorkspaceTools(commandMapper: CommandMapper): void {
-  const pathResolver = createPathResolver();
+export function registerSessionWorkspaceTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
+  const pathResolver = createPathResolver(container);
 
   // Session read file tool
   commandMapper.addCommand({

--- a/src/adapters/mcp/session.ts
+++ b/src/adapters/mcp/session.ts
@@ -8,11 +8,15 @@ import { log } from "../../utils/logger";
 /**
  * Registers session tools with the MCP command mapper
  */
-export function registerSessionTools(commandMapper: CommandMapper): void {
+export function registerSessionTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug("Registering session commands with MCP");
 
   // Use the bridge integration to automatically register all session commands
   registerSessionCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "session.list": {

--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -108,6 +108,8 @@ export interface McpSharedCommandConfig {
   >;
   /** Whether to enable debug logging */
   debug?: boolean;
+  /** DI container — passed from MCP startup, avoids getAppContainer() Service Locator */
+  container?: import("../../composition/types").AppContainerInterface;
 }
 
 /**
@@ -153,21 +155,11 @@ export function registerSharedCommandsWithMcp(
 
           try {
             // Create execution context for shared command
-            // Get the app container set by the composition root (mt#761).
-            let appContainer;
-            try {
-              const { getAppContainer } = await import(
-                "../shared/bridges/cli/command-generator-core"
-              );
-              appContainer = getAppContainer();
-            } catch {
-              // Container not available — backward compatibility
-            }
             const context: CommandExecutionContext = {
               interface: "mcp",
               debug: Boolean(args?.debug),
-              format: args?.json === "true" ? "json" : "text", // Use json format only when explicitly requested
-              container: appContainer,
+              format: args?.json === "true" ? "json" : "text",
+              container: config.container,
             };
             log.debug(`[MCP] Created execution context: ${command.id}`, { context });
 

--- a/src/adapters/mcp/task-edit-tools.ts
+++ b/src/adapters/mcp/task-edit-tools.ts
@@ -67,20 +67,19 @@ type TaskSearchReplaceArgs = z.infer<typeof TaskSearchReplaceSchema>;
 /**
  * Registers task-aware editing tools with the MCP command mapper
  */
-function getTaskDeps(): TaskServiceDeps {
-  try {
-    const { getAppContainer } = require("../shared/bridges/cli/command-generator-core");
-    const container = getAppContainer();
-    if (container?.has("persistence")) {
-      return { persistenceProvider: container.get("persistence") };
-    }
-    return {};
-  } catch {
-    return {};
+function getTaskDeps(
+  container?: import("../../composition/types").AppContainerInterface
+): TaskServiceDeps {
+  if (container?.has("persistence")) {
+    return { persistenceProvider: container.get("persistence") };
   }
+  return {};
 }
 
-export function registerTaskEditTools(commandMapper: CommandMapper): void {
+export function registerTaskEditTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   // Task edit file tool - works like session.edit_file but for task specs
   commandMapper.addCommand({
     name: "tasks.edit_file",
@@ -126,7 +125,7 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
               session: typedArgs.session,
               backend: typedArgs.backend,
             },
-            getTaskDeps()
+            getTaskDeps(container)
           );
           if (specResult?.content) {
             originalContent = specResult.content;
@@ -189,11 +188,16 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
             session: typedArgs.session,
             backend: typedArgs.backend,
           },
-          getTaskDeps()
+          getTaskDeps(container)
         );
 
         // Fire-and-forget embedding re-index after spec update
-        autoIndexTaskEmbedding(typedArgs.taskId);
+        autoIndexTaskEmbedding(
+          typedArgs.taskId,
+          container?.has("persistence")
+            ? { getPersistenceProvider: () => container!.get("persistence") }
+            : undefined
+        );
 
         log.debug("Task edit_file operation completed", { taskId: typedArgs.taskId });
 
@@ -246,7 +250,7 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
             session: typedArgs.session,
             backend: typedArgs.backend,
           },
-          getTaskDeps()
+          getTaskDeps(container)
         );
 
         if (!specResult?.content) {
@@ -283,11 +287,16 @@ Make edits to a task spec in a single edit_file call instead of multiple edit_fi
             session: typedArgs.session,
             backend: typedArgs.backend,
           },
-          getTaskDeps()
+          getTaskDeps(container)
         );
 
         // Fire-and-forget embedding re-index after spec update
-        autoIndexTaskEmbedding(typedArgs.taskId);
+        autoIndexTaskEmbedding(
+          typedArgs.taskId,
+          container?.has("persistence")
+            ? { getPersistenceProvider: () => container!.get("persistence") }
+            : undefined
+        );
 
         log.debug("Task search_replace operation completed", {
           taskId: typedArgs.taskId,

--- a/src/adapters/mcp/tasks.ts
+++ b/src/adapters/mcp/tasks.ts
@@ -9,7 +9,10 @@ import { log } from "../../utils/logger";
 /**
  * Registers task tools with the MCP command mapper
  */
-export function registerTaskTools(commandMapper: CommandMapper): void {
+export function registerTaskTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   log.debug(
     "Exposing task commands via shared command integration (commands already registered during CLI init)"
   );
@@ -21,6 +24,7 @@ export function registerTaskTools(commandMapper: CommandMapper): void {
   // Note: Shared commands are already registered during CLI initialization,
   // so we just need to expose them via MCP without re-registering
   registerTaskCommandsWithMcp(commandMapper, {
+    container,
     debug: true,
     commandOverrides: {
       "tasks.list": {

--- a/src/adapters/mcp/tasks.ts
+++ b/src/adapters/mcp/tasks.ts
@@ -18,7 +18,7 @@ export function registerTaskTools(
   );
 
   // Register new task-specific editing tools (tasks.edit_file, tasks.search_replace)
-  registerTaskEditTools(commandMapper);
+  registerTaskEditTools(commandMapper, container);
 
   // Use the bridge integration to expose already-registered task commands
   // Note: Shared commands are already registered during CLI initialization,

--- a/src/adapters/mcp/validate.ts
+++ b/src/adapters/mcp/validate.ts
@@ -7,8 +7,12 @@ import { registerToolsCommandsWithMcp } from "./shared-command-integration";
 /**
  * Registers validate tools (lint, typecheck) with the MCP command mapper
  */
-export function registerValidateTools(commandMapper: CommandMapper): void {
+export function registerValidateTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   registerToolsCommandsWithMcp(commandMapper, {
+    container,
     commandOverrides: {
       "validate.lint": {
         description: "Run ESLint and return structured results",

--- a/src/adapters/shared/commands/session/file-commands.ts
+++ b/src/adapters/shared/commands/session/file-commands.ts
@@ -101,6 +101,7 @@ async function callSessionEditFileMcpTool(args: {
   content: string;
   dryRun: boolean;
   createDirs: boolean;
+  sessionProvider?: import("../../../../domain/session/index").SessionProviderInterface;
 }): Promise<Record<string, unknown>> {
   const { writeFile, stat } = await import("fs/promises");
   const { dirname } = await import("path");
@@ -109,7 +110,7 @@ async function callSessionEditFileMcpTool(args: {
   const { generateUnifiedDiff, generateDiffSummary } = await import("../../../../utils/diff");
   const { createSuccessResponse } = await import("../../../../domain/schemas");
 
-  const pathResolver = new SessionPathResolver();
+  const pathResolver = new SessionPathResolver(args.sessionProvider);
   const resolvedPath = await pathResolver.resolvePath(args.sessionId, args.path);
 
   let fileExists = false;
@@ -257,6 +258,7 @@ export function createSessionEditFileCommand(getDeps: LazySessionDeps): CommandD
           content,
           dryRun: typedParams.dryRun || false,
           createDirs: typedParams.createDirs !== false,
+          sessionProvider: deps.sessionProvider,
         });
 
         return formatResult(mcpResult, typedParams);

--- a/src/adapters/shared/commands/tasks/auto-index-embedding.ts
+++ b/src/adapters/shared/commands/tasks/auto-index-embedding.ts
@@ -2,11 +2,12 @@ import { log } from "../../../../utils/logger";
 import type { BasePersistenceProvider } from "../../../../domain/persistence/types";
 
 /**
- * Dependencies that can be injected for testing.
+ * Dependencies that can be injected for testing or DI threading.
+ * All fields are optional; missing ones fall back to dynamic imports.
  */
 export interface AutoIndexDeps {
-  getConfiguration: () => { embeddings?: { autoIndex?: boolean } };
-  createTaskSimilarityService: (
+  getConfiguration?: () => { embeddings?: { autoIndex?: boolean } };
+  createTaskSimilarityService?: (
     provider: BasePersistenceProvider
   ) => Promise<{ indexTask: (id: string) => Promise<boolean> }>;
   getPersistenceProvider?: () => BasePersistenceProvider;
@@ -36,13 +37,8 @@ export function autoIndexTaskEmbedding(taskId: string, deps?: AutoIndexDeps): vo
       if (deps?.getPersistenceProvider) {
         persistenceProvider = deps.getPersistenceProvider();
       } else {
-        const { getAppContainer } = await import("../../bridges/cli/command-generator-core");
-        const container = getAppContainer();
-        if (!container?.has("persistence")) {
-          log.debug(`Auto-index skipped for ${taskId}: DI container not initialized`);
-          return;
-        }
-        persistenceProvider = container.get("persistence");
+        log.debug(`Auto-index skipped for ${taskId}: no persistence provider available`);
+        return;
       }
 
       const service = await createTaskSimilarityService(persistenceProvider);

--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -543,7 +543,12 @@ export class TasksCreateCommand extends BaseTaskCommand<TasksCreateParams> {
       }
 
       // Fire-and-forget embedding indexing for the newly created task
-      autoIndexTaskEmbedding(result.id);
+      autoIndexTaskEmbedding(
+        result.id,
+        this.getPersistenceProvider
+          ? { getPersistenceProvider: this.getPersistenceProvider }
+          : undefined
+      );
 
       // Build success message
       let message = `Task ${result.id} created: "${result.title}"`;

--- a/src/adapters/shared/commands/tasks/edit-commands.ts
+++ b/src/adapters/shared/commands/tasks/edit-commands.ts
@@ -255,7 +255,12 @@ export class TasksEditCommand extends BaseTaskCommand<TasksEditParams> {
 
       // Fire-and-forget embedding re-index if content that affects embeddings changed
       if (updates.title || updates.spec) {
-        autoIndexTaskEmbedding(validatedTaskId);
+        autoIndexTaskEmbedding(
+          validatedTaskId,
+          this.getPersistenceProvider
+            ? { getPersistenceProvider: this.getPersistenceProvider }
+            : undefined
+        );
       }
 
       const message = this.buildUpdateMessage(updates, validatedTaskId);

--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -34,32 +34,35 @@ const INSPECTOR_PORT = 5173;
 /**
  * Register all MCP tool adapters on the given command mapper.
  */
-function registerAllTools(commandMapper: CommandMapper): void {
+function registerAllTools(
+  commandMapper: CommandMapper,
+  container?: import("../../composition/types").AppContainerInterface
+): void {
   // Register debug tools first to ensure they're available for debugging
-  registerDebugTools(commandMapper);
+  registerDebugTools(commandMapper, container);
 
   // Register main application tools
   log.debug("[MCP] About to register task tools");
-  registerTaskTools(commandMapper);
+  registerTaskTools(commandMapper, container);
   log.debug("[MCP] About to register session tools");
-  registerSessionTools(commandMapper);
-  registerSessionWorkspaceTools(commandMapper);
+  registerSessionTools(commandMapper, container);
+  registerSessionWorkspaceTools(commandMapper); // no container needed
 
-  registerSessionFileTools(commandMapper);
-  registerSessionEditTools(commandMapper);
+  registerSessionFileTools(commandMapper); // no container needed
+  registerSessionEditTools(commandMapper); // no container needed
 
   // Register persistence tools for agent querying
   log.debug("[MCP] About to register persistence tools");
-  registerPersistenceTools(commandMapper);
+  registerPersistenceTools(commandMapper, container);
 
-  registerGitTools(commandMapper);
+  registerGitTools(commandMapper, container);
 
-  registerInitTools(commandMapper);
-  registerRulesTools(commandMapper);
-  registerConfigTools(commandMapper);
-  registerChangesetTools(commandMapper);
-  registerValidateTools(commandMapper);
-  registerMcpManagementTools(commandMapper);
+  registerInitTools(commandMapper, container);
+  registerRulesTools(commandMapper, container);
+  registerConfigTools(commandMapper, container);
+  registerChangesetTools(commandMapper, container);
+  registerValidateTools(commandMapper, container);
+  registerMcpManagementTools(commandMapper, container);
 }
 
 /**
@@ -235,7 +238,11 @@ export function createStartCommand(): Command {
 
         // Register tools via adapter-based approach
         const commandMapper = new CommandMapper(server, server.getProjectContext());
-        registerAllTools(commandMapper);
+        const { getAppContainer } = await import(
+          "../../adapters/shared/bridges/cli/command-generator-core"
+        );
+        const container = getAppContainer();
+        registerAllTools(commandMapper, container);
 
         // Launch inspector if requested
         if (options.withInspector) {
@@ -286,12 +293,8 @@ export function createStartCommand(): Command {
         }
 
         // Fire-and-forget background embedding sweep for missing tasks
-        Promise.all([
-          import("../../adapters/shared/commands/tasks/startup-embedding-sweep"),
-          import("../../adapters/shared/bridges/cli/command-generator-core"),
-        ])
-          .then(([{ triggerStartupEmbeddingSweep }, { getAppContainer }]) => {
-            const container = getAppContainer();
+        import("../../adapters/shared/commands/tasks/startup-embedding-sweep")
+          .then(({ triggerStartupEmbeddingSweep }) => {
             const persistence = container?.has("persistence")
               ? container.get("persistence")
               : undefined;

--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -46,10 +46,9 @@ function registerAllTools(
   registerTaskTools(commandMapper, container);
   log.debug("[MCP] About to register session tools");
   registerSessionTools(commandMapper, container);
-  registerSessionWorkspaceTools(commandMapper); // no container needed
-
-  registerSessionFileTools(commandMapper); // no container needed
-  registerSessionEditTools(commandMapper); // no container needed
+  registerSessionWorkspaceTools(commandMapper, container);
+  registerSessionFileTools(commandMapper, container);
+  registerSessionEditTools(commandMapper, container);
 
   // Register persistence tools for agent querying
   log.debug("[MCP] About to register persistence tools");

--- a/src/domain/session/session-path-resolver.ts
+++ b/src/domain/session/session-path-resolver.ts
@@ -223,24 +223,7 @@ export class SessionPathResolver {
     sessionProvider?: import("./index").SessionProviderInterface
   ): Promise<string> {
     const { resolveSessionDirectory } = await import("./resolve-session-directory");
-    let provider = sessionProvider ?? this.sessionProvider;
-
-    // Lazy resolution: if no provider was injected, try the DI container
-    if (!provider) {
-      try {
-        const { getAppContainer } = await import(
-          "../../adapters/shared/bridges/cli/command-generator-core"
-        );
-        const container = getAppContainer();
-        if (container) {
-          provider = container.get("sessionProvider");
-          // Cache for subsequent calls
-          this.sessionProvider = provider;
-        }
-      } catch {
-        // Container not available
-      }
-    }
+    const provider = sessionProvider ?? this.sessionProvider;
 
     if (!provider) {
       throw new Error(

--- a/src/domain/session/session-workspace-service.ts
+++ b/src/domain/session/session-workspace-service.ts
@@ -29,7 +29,7 @@ export class SessionWorkspaceService {
 
   constructor(sessionProvider: SessionProviderInterface, workspaceBackend?: WorkspaceBackend) {
     this.sessionProvider = sessionProvider;
-    this.pathResolver = new SessionPathResolver();
+    this.pathResolver = new SessionPathResolver(sessionProvider);
     this.workspaceBackend = workspaceBackend || new LocalWorkspaceBackend();
   }
 


### PR DESCRIPTION
## Summary

Eliminates all remaining `getAppContainer()` service-locator calls outside the bootstrap entry point (`start-command.ts`), completing the DI threading campaign started in batch 1.

### Files changed

- **`auto-index-embedding.ts`**: Remove `getAppContainer` fallback; skip silently when no `getPersistenceProvider` dep is injected. Make `AutoIndexDeps` fields all optional so callers can pass just `{ getPersistenceProvider }` without satisfying the full test-only interface.
- **`task-edit-tools.ts`**: Thread `container` into `registerTaskEditTools` and `getTaskDeps`; pass persistence deps to `autoIndexTaskEmbedding` calls.
- **`tasks.ts`**: Forward `container` to `registerTaskEditTools`.
- **`crud-commands.ts`**: Pass `this.getPersistenceProvider` as `autoIndexTaskEmbedding` deps.
- **`edit-commands.ts`**: Pass `this.getPersistenceProvider` as `autoIndexTaskEmbedding` deps.
- **`session-path-resolver.ts`**: Remove lazy `getAppContainer` fallback in `getSessionWorkspacePath`; throw an explicit error if no provider is available.
- **`session-workspace.ts`**, **`session-files.ts`**, **`session-edit-tools.ts`**: Thread `container` parameter; extract `sessionProvider` and pass to `SessionPathResolver`.
- **`start-command.ts`**: Pass `container` to the three session tool registrations.
- **`session-workspace-service.ts`**: Pass `sessionProvider` to `SessionPathResolver` constructor.
- **`session/file-commands.ts`**: Thread `sessionProvider` through `callSessionEditFileMcpTool`.

### Post-change verification

```
grep -rn 'getAppContainer' src/ --include='*.ts' | grep -v command-generator-core | grep -v test
```

Results: only a comment in `shared-command-integration.ts` and the legitimate bootstrap in `start-command.ts`. Zero service-locator calls outside bootstrap.

---

## Coherence Verification

**Files re-read**: auto-index-embedding.ts, task-edit-tools.ts, tasks.ts, session-path-resolver.ts, session-workspace.ts, session-files.ts, session-edit-tools.ts, start-command.ts, session-workspace-service.ts, session/file-commands.ts, crud-commands.ts, edit-commands.ts

**Q1 single purpose**: pass

**Q2 comment honesty**: pass — removed stale `// no container needed` comment in start-command.ts

**Q3 naming honesty**: pass

**Q4 redundant siblings**: pass

**Q5 dead exports**: pass — `AutoIndexDeps` made fully optional (backward compatible); verified getAppContainer grep returns zero non-bootstrap results

**Q6 orphan code**: pass — old `require()` call in `getTaskDeps` removed entirely

**Q7 stray artifacts**: pass

**Items fixed beyond original scope**:
- `session-workspace-service.ts`: pass `sessionProvider` to resolver constructor (would have thrown at runtime on any `getSessionWorkspacePath` call)
- `session/file-commands.ts`: thread `sessionProvider` through CLI adapter (same runtime fix)

**Items deferred**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)