### PR TITLE
feat(mt#895): implement WindsurfRegistrar and JunieRegistrar

### DIFF
--- a/src/domain/mcp/registration.test.ts
+++ b/src/domain/mcp/registration.test.ts
@@ -10,6 +10,8 @@ import {
   ClaudeDesktopRegistrar,
   McpServersJsonRegistrar,
   VSCodeRegistrar,
+  WindsurfRegistrar,
+  JunieRegistrar,
   getRegistrar,
   registerWithClient,
 } from "./registration";
@@ -212,6 +214,59 @@ describe("VSCodeRegistrar", () => {
   });
 });
 
+describe("WindsurfRegistrar", () => {
+  const registrar = new WindsurfRegistrar();
+
+  describe("generateConfig — inherits McpServersJsonRegistrar logic", () => {
+    test("stdio transport produces correct mcpServers JSON", () => {
+      const content = registrar.generateConfig("stdio");
+      const parsed = JSON.parse(content);
+
+      expect(parsed.mcpServers["minsky-server"].command).toBe("minsky");
+      expect(parsed.mcpServers["minsky-server"].args).toEqual(["mcp", "start"]);
+    });
+  });
+
+  describe("configPath", () => {
+    test("returns path under ~/.codeium/windsurf/ (ignores projectRoot)", () => {
+      const configPath = registrar.configPath("/unused");
+      expect(configPath).not.toContain("/unused");
+      expect(configPath.startsWith(os.homedir())).toBe(true);
+      expect(configPath).toContain(".codeium");
+      expect(configPath).toContain("windsurf");
+      expect(configPath.endsWith("mcp_config.json")).toBe(true);
+    });
+  });
+
+  test("mergeConfig is true (global config, may have other servers)", () => {
+    expect(registrar.mergeConfig).toBe(true);
+  });
+
+  test("is an instance of McpServersJsonRegistrar", () => {
+    expect(registrar).toBeInstanceOf(McpServersJsonRegistrar);
+  });
+});
+
+describe("JunieRegistrar", () => {
+  const registrar = new JunieRegistrar();
+
+  describe("configPath", () => {
+    test("returns .junie/mcp/mcp.json under the project root", () => {
+      expect(registrar.configPath("/project")).toBe(
+        path.join("/project", ".junie", "mcp", "mcp.json")
+      );
+    });
+  });
+
+  test("mergeConfig is false (project-scoped)", () => {
+    expect(registrar.mergeConfig).toBe(false);
+  });
+
+  test("is an instance of McpServersJsonRegistrar", () => {
+    expect(registrar).toBeInstanceOf(McpServersJsonRegistrar);
+  });
+});
+
 describe("McpServersJsonRegistrar (abstract base)", () => {
   test("CursorRegistrar is an instance of McpServersJsonRegistrar", () => {
     expect(new CursorRegistrar()).toBeInstanceOf(McpServersJsonRegistrar);
@@ -241,9 +296,21 @@ describe("getRegistrar", () => {
     expect(r.name).toBe("vscode");
   });
 
+  test("returns WindsurfRegistrar for 'windsurf'", () => {
+    const r = getRegistrar("windsurf");
+    expect(r).toBeInstanceOf(WindsurfRegistrar);
+    expect(r.name).toBe("windsurf");
+  });
+
+  test("returns JunieRegistrar for 'junie'", () => {
+    const r = getRegistrar("junie");
+    expect(r).toBeInstanceOf(JunieRegistrar);
+    expect(r.name).toBe("junie");
+  });
+
   test("throws descriptive error for unsupported client", () => {
     expect(() => getRegistrar("unknown")).toThrow(
-      'MCP client "unknown" is not yet supported. Supported clients: cursor, claude-desktop, vscode'
+      'MCP client "unknown" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie'
     );
   });
 });

--- a/src/domain/mcp/registration.ts
+++ b/src/domain/mcp/registration.ts
@@ -168,6 +168,36 @@ export class ClaudeDesktopRegistrar extends McpServersJsonRegistrar {
 }
 
 /**
+ * Registrar for the Windsurf editor MCP client.
+ *
+ * Windsurf stores MCP config globally at ~/.codeium/windsurf/mcp_config.json,
+ * so registration merges into any existing config rather than overwriting.
+ */
+export class WindsurfRegistrar extends McpServersJsonRegistrar {
+  readonly name = "windsurf";
+  override readonly mergeConfig = true; // global config, may have other servers
+
+  configPath(_projectRoot: string): string {
+    // Windsurf stores config globally at ~/.codeium/windsurf/mcp_config.json
+    return path.join(homedir(), ".codeium", "windsurf", "mcp_config.json");
+  }
+}
+
+/**
+ * Registrar for the Junie (JetBrains) MCP client.
+ *
+ * Junie stores MCP config at the project level: .junie/mcp/mcp.json.
+ */
+export class JunieRegistrar extends McpServersJsonRegistrar {
+  readonly name = "junie";
+
+  configPath(projectRoot: string): string {
+    // Junie stores project-level MCP config at .junie/mcp/mcp.json
+    return path.join(projectRoot, ".junie", "mcp", "mcp.json");
+  }
+}
+
+/**
  * Registrar for the VS Code editor MCP client.
  *
  * VS Code uses a "servers" root key (not "mcpServers") in its MCP config.
@@ -219,9 +249,13 @@ export function getRegistrar(client: string): ClientRegistrar {
       return new ClaudeDesktopRegistrar();
     case "vscode":
       return new VSCodeRegistrar();
+    case "windsurf":
+      return new WindsurfRegistrar();
+    case "junie":
+      return new JunieRegistrar();
     default:
       throw new Error(
-        `MCP client "${client}" is not yet supported. Supported clients: cursor, claude-desktop, vscode`
+        `MCP client "${client}" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie`
       );
   }
 }

--- a/src/domain/runtime/harness-detection.ts
+++ b/src/domain/runtime/harness-detection.ts
@@ -16,7 +16,7 @@ export type AgentHarness = "claude-code" | "cursor" | "standalone";
  * The set of MCP client applications that Minsky can register itself with.
  * Extend this union as new clients are implemented.
  */
-export type ManagedClient = "cursor" | "claude-desktop" | "vscode";
+export type ManagedClient = "cursor" | "claude-desktop" | "vscode" | "windsurf" | "junie";
 
 /**
  * Detect the current agent harness from environment signals.
@@ -88,6 +88,14 @@ export function detectInstalledClients(): ManagedClient[] {
   if (existsSync(path.join(homedir(), ".vscode"))) {
     clients.push("vscode");
   }
+
+  // Windsurf: check for ~/.codeium/ directory
+  if (existsSync(path.join(homedir(), ".codeium"))) {
+    clients.push("windsurf");
+  }
+
+  // Junie (JetBrains): skip auto-detection — JetBrains detection is unreliable.
+  // Users can specify --client junie explicitly to register with Junie.
 
   return clients;
 }


### PR DESCRIPTION
## Summary

- Adds `WindsurfRegistrar` extending `McpServersJsonRegistrar` with global config at `~/.codeium/windsurf/mcp_config.json` and `mergeConfig = true`
- Adds `JunieRegistrar` extending `McpServersJsonRegistrar` with project-scoped config at `.junie/mcp/mcp.json` and `mergeConfig = false` (default)
- Updates `getRegistrar` factory to handle `"windsurf"` and `"junie"` cases and updates error message to list all supported clients
- Updates `ManagedClient` type union in `harness-detection.ts` to include `"windsurf"` and `"junie"`
- Adds Windsurf auto-detection via `~/.codeium/` directory; Junie skipped (JetBrains detection unreliable — users use `--client junie` explicitly)
- Adds comprehensive tests covering `configPath`, `mergeConfig`, `generateConfig` inheritance, `getRegistrar` factory, and `McpServersJsonRegistrar` instanceof checks

## Test plan

- [ ] `WindsurfRegistrar.generateConfig("stdio")` produces correct `mcpServers` JSON
- [ ] `WindsurfRegistrar.configPath("/unused")` returns path under `~/.codeium/windsurf/`
- [ ] `WindsurfRegistrar.mergeConfig` is `true`
- [ ] `JunieRegistrar.configPath("/project")` returns `/project/.junie/mcp/mcp.json`
- [ ] `JunieRegistrar.mergeConfig` is `false`
- [ ] `getRegistrar("windsurf")` and `getRegistrar("junie")` return correct instances
- [ ] Both are instances of `McpServersJsonRegistrar`
- [ ] Error message for unsupported client lists all 5 supported clients
- [ ] All 1757 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)