### PR TITLE
feat(mt#871): Extract fix-skipped-tests skill from no-skipped-tests rule

### DIFF
--- a/.claude/skills/fix-skipped-tests/SKILL.md
+++ b/.claude/skills/fix-skipped-tests/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: fix-skipped-tests
+description: >-
+  Fix or remove skipped tests: zero tolerance for .skip(), test.todo(), or
+  placeholder assertions. Use when encountering skipped tests, placeholder tests,
+  or when asked to clean up the test suite.
+user-invocable: true
+---
+
+# Fix Skipped Tests
+
+Zero-tolerance enforcement for skipped and placeholder tests. Every test must pass or be deleted.
+
+## Arguments
+
+Optional: file path or pattern (e.g., `/fix-skipped-tests src/domain/`). If omitted, scans the full test suite.
+
+## Process
+
+### 1. Identify skipped tests
+
+Search for:
+
+- `test.skip(` / `it.skip(` / `describe.skip(`
+- `test.todo(` / `it.todo(`
+- `expect(true).toBe(true)` or similar placeholder assertions
+- `// @ts-ignore` hiding test failures
+
+### 2. Investigate the reason
+
+For each skipped test, determine why it was skipped:
+
+- **Real operations**: Test uses filesystem, git, network, or database directly
+- **Integration complexity**: Test depends on external services
+- **Legacy code**: Test covers code that may be obsolete
+- **"Too complex"**: Someone gave up
+
+### 3. Fix or delete
+
+| Reason                 | Action                                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| Real operations        | Mock with dependency injection — use `createMock()`, `createMockLogger()`, `createMockFileSystem()` |
+| Integration complexity | Mock external dependencies, break into smaller testable units                                       |
+| Obsolete code          | Delete the test AND the dead code it tests                                                          |
+| "Too complex"          | Break down into manageable steps and fix. Complexity is never a valid reason to skip.               |
+
+### 4. Verify
+
+- Run the specific test file: `bun test path/to/file.test.ts`
+- Run the full test suite to check for regressions
+- Confirm zero skipped tests remain
+
+## The "too complex" violation
+
+**NEVER claim any test is "too complex to fix."**
+
+When facing a complex test:
+
+1. **Reject the premise** — no problem is too complex to decompose
+2. **Break it down** — identify the specific dependency or setup that's difficult
+3. **Fix incrementally** — mock one dependency at a time
+4. **Verify** — run after each change
+
+Approaches for common "complex" scenarios:
+
+- **Command registry issues** → Mock the command registry
+- **Complex dependencies** → Use dependency injection
+- **Integration complexity** → Break into isolated unit tests
+- **Setup complexity** → Create proper test fixtures and helpers
+
+## Key principles
+
+- **A skipped test is a broken test we're ignoring.** It provides zero value and false confidence.
+- **Every test must pass or the code it tests must not exist.** No middle ground.
+- **Complexity is not an excuse.** Break down, mock, inject, fix.
+- **Delete is better than skip.** If a test is truly obsolete, remove it entirely.

--- a/.cursor/rules/no-skipped-tests.mdc
+++ b/.cursor/rules/no-skipped-tests.mdc
@@ -5,79 +5,13 @@ tags: [testing]
 
 # No Skipped Tests Policy
 
-## Core Principle
+**ZERO SKIPPED TESTS ALLOWED.** Every test must either PASS or BE DELETED.
 
-**CRITICAL RULE: NO SKIPPED TESTS ALLOWED**
+Never use `.skip()`, `test.todo()`, or placeholder assertions like `expect(true).toBe(true)`.
 
-Every test in the codebase MUST either:
-1. **PASS** - Function correctly with proper mocking/setup
-2. **BE DELETED** - If testing obsolete/unused code
+No problem is "too complex to fix." Break it down, mock dependencies, and fix it.
 
-**NEVER SKIP TESTS** - Skipped tests provide zero value and create false confidence.
+## See also
 
-## Enforcement Protocol
-
-When encountering skipped tests:
-
-1. **Investigate the reason** for skipping
-2. **If code is still used**: Fix the test with proper mocking/DI
-3. **If code is obsolete**: Delete the test entirely
-4. **If unsure**: Ask for clarification, but NEVER leave it skipped
-
-## Common Patterns to Fix, Not Skip
-
-- **"Real operations"** → Use dependency injection and mocking
-- **"Integration tests"** → Mock external dependencies (filesystem, git, APIs)
-- **"Legacy code"** → Either fix the test or remove obsolete code entirely
-- **"Complex scenarios"** → Break down into mockable components
-
-## Examples of Proper Fixes
-
-```typescript
-// ❌ WRONG: Skipping because it uses real git operations
-test.skip("should detect conflicts in real git repository", () => {
-
-// ✅ RIGHT: Mock the git operations
-test("should detect conflicts in git repository", () => {
-  const mockGitService = createMockGitService();
-  // ... proper test with mocks
-});
-```
-
-## Success Metrics
-
-- **Current skipped tests**: Must trend to 0
-- **New tests**: NEVER allowed to be skipped
-- **Test suite health**: 100% pass rate with 0 skips
-
-## Rationale
-
-- Skipped tests rot and become useless over time
-- They provide false confidence in test coverage
-- They hide real issues that should be addressed
-- They violate the principle that "if it's worth testing, it's worth fixing"
-
-**Remember: A skipped test is a broken test that we're ignoring.**
-
-## Critical Violation: "Too Complex to Fix"
-
-**NEVER claim any test is "too complex to fix"**
-
-### Documented Failure Pattern
-**Pattern**: Claiming tests are "too complex to fix" and deleting them instead of fixing
-**User Signal**: "there is no such thing as 'too complex to fix', you must NEVER SAY THAT AGAIN"
-**Root Cause**: Process Error - giving up instead of systematically solving problems
-
-### Required Response
-1. **Stop making complexity excuses immediately**
-2. **NEVER delete or skip tests because they seem "complex"**
-3. **Break down complex problems into manageable steps**
-4. **Fix EVERYTHING, no matter how complex**
-
-### Problem-Solving Approach
-- **Command registry issues** → Mock the command registry properly
-- **Complex dependencies** → Use dependency injection and mocking
-- **Integration complexity** → Break down into isolated unit tests
-- **Setup complexity** → Create proper test fixtures and helpers
-
-**CRITICAL**: No problem is too complex to fix. Every test must pass or the code it tests must not exist.
+- `fix-skipped-tests` skill for the enforcement protocol and fix strategies
+- `debug-tests` skill for systematic test failure investigation


### PR DESCRIPTION
## Summary
- Creates `fix-skipped-tests` skill with enforcement protocol, fix strategies, too-complex violation handling
- Trims `no-skipped-tests.mdc` to 12-line declarative mandate
## Test plan
- [ ] Skill triggers on skipped test prompts
- [ ] Source rule trimmed to constraint only