### PR TITLE
feat(mt#898): add READY status as planning completeness gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,20 +117,22 @@ When a PR removes a feature, module, or backend, symbol-level grep ("is the dele
 ## Task Lifecycle
 
 ```
-TODO → PLANNING → IN-PROGRESS → IN-REVIEW → DONE
-       (mandatory)  (session_start)  (pr_create)   (verify + merge)
+TODO → PLANNING → READY → IN-PROGRESS → IN-REVIEW → DONE
+       (investigate) (gate)  (session_start) (pr_create)  (verify + merge)
 
-Also: BLOCKED (from PLANNING or IN-PROGRESS), CLOSED (from any state)
+Also: BLOCKED (from PLANNING, READY, or IN-PROGRESS), CLOSED (from any state)
 ```
 
 **Status transitions are enforced in the domain layer.** Invalid transitions are rejected with descriptive errors listing valid transitions from the current state.
 
 - **TODO → PLANNING**: Agent picks up the task. Set status to PLANNING before any investigation or session work.
 - **PLANNING** (no session): Read and verify the spec (pre-flight). Investigate the codebase if needed. Persist findings to the spec. No session exists — no code changes yet.
-- **PLANNING → IN-PROGRESS**: Only via `session_start` (cannot be set directly). `session_start` blocks from TODO — the task must be in PLANNING first.
+- **PLANNING → READY**: Agent declares planning complete. Set status to READY when investigation is done and spec is up to date.
+- **READY → IN-PROGRESS**: Only via `session_start` (cannot be set directly). `session_start` blocks from TODO and PLANNING.
 - **IN-PROGRESS → IN-REVIEW**: PR created.
 - **IN-REVIEW → DONE**: Spec verified, PR merged.
 - **IN-PROGRESS → PLANNING**: Go back for more investigation if scope was wrong.
+- **READY → PLANNING**: Go back if more investigation is needed before starting.
 
 ## Task Completion Protocol
 

--- a/src/adapters/mcp/schemas/task-parameters.ts
+++ b/src/adapters/mcp/schemas/task-parameters.ts
@@ -28,7 +28,8 @@ export const TaskTitleSchema = z.string().min(1, "Task title cannot be empty");
  * Uses the centralized TaskStatus enum
  */
 export const TaskStatusSchema = z.enum(TaskStatus, {
-  error: "Status must be one of: TODO, PLANNING, IN-PROGRESS, IN-REVIEW, DONE, BLOCKED, CLOSED",
+  error:
+    "Status must be one of: TODO, PLANNING, READY, IN-PROGRESS, IN-REVIEW, DONE, BLOCKED, CLOSED",
 });
 
 /**

--- a/src/adapters/shared/common-parameters.ts
+++ b/src/adapters/shared/common-parameters.ts
@@ -290,7 +290,16 @@ export const TaskParameters = {
    * Task status parameter
    */
   status: {
-    schema: z.enum(["TODO", "PLANNING", "IN-PROGRESS", "IN-REVIEW", "DONE", "BLOCKED", "CLOSED"]),
+    schema: z.enum([
+      "TODO",
+      "PLANNING",
+      "READY",
+      "IN-PROGRESS",
+      "IN-REVIEW",
+      "DONE",
+      "BLOCKED",
+      "CLOSED",
+    ]),
     description: "Task status",
     required: false,
   } as CommandParameterDefinition,

--- a/src/domain/session-auto-task-creation.test.ts
+++ b/src/domain/session-auto-task-creation.test.ts
@@ -66,7 +66,7 @@ describe("Session Auto-Task Creation", () => {
 
     // Mock task service using FakeTaskService with proper task creation mock
     const fakeTaskService = new FakeTaskService({
-      initialTasks: [{ id: "md#001", title: "Test Task", status: "PLANNING" }],
+      initialTasks: [{ id: "md#001", title: "Test Task", status: "READY" }],
       workspacePath: "/test/workspace",
     });
     fakeTaskService.createTaskFromTitleAndSpec = createTaskSpy;

--- a/src/domain/session-git-clone-bug-regression.test.ts
+++ b/src/domain/session-git-clone-bug-regression.test.ts
@@ -51,7 +51,7 @@ describe("Session Git Clone Bug Regression Test", () => {
     const mockGitService = fakeGitService1;
 
     const mockTaskService = new FakeTaskService({
-      initialTasks: [{ id: "md#160", title: "Test Task", status: "PLANNING" }],
+      initialTasks: [{ id: "md#160", title: "Test Task", status: "READY" }],
     });
 
     // Create workspace utils mock with all required methods
@@ -114,7 +114,7 @@ describe("Session Git Clone Bug Regression Test", () => {
     const mockGitService = fakeGitService2;
 
     const mockTaskService = new FakeTaskService({
-      initialTasks: [{ id: "md#160", title: "Test Task", status: "PLANNING" }],
+      initialTasks: [{ id: "md#160", title: "Test Task", status: "READY" }],
     });
 
     // Create workspace utils mock with all required methods

--- a/src/domain/session-start-consistency.test.ts
+++ b/src/domain/session-start-consistency.test.ts
@@ -46,7 +46,7 @@ describe("Session Start Consistency Tests", () => {
       Promise.resolve({ workdir: TEST_PATHS.SESSION_MD_160, branch: "task/md-160" });
 
     mockTaskService = new FakeTaskService({
-      initialTasks: [{ id: "md#160", title: "Test Task", status: "PLANNING" }],
+      initialTasks: [{ id: "md#160", title: "Test Task", status: "READY" }],
     });
 
     mockWorkspaceUtils = {

--- a/src/domain/session/session-start-operations.test.ts
+++ b/src/domain/session/session-start-operations.test.ts
@@ -24,7 +24,7 @@ function createDeps(repoUrl: string): StartSessionDependencies & {
   }));
 
   const taskService = new FakeTaskService();
-  taskService.getTaskStatus = vi.fn(async () => "PLANNING");
+  taskService.getTaskStatus = vi.fn(async () => "READY");
   taskService.setTaskStatus = vi.fn(async () => {});
   taskService.createTaskFromTitleAndSpec = vi.fn(async (t: string, d: string) => ({
     id: "md#999",

--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -164,8 +164,9 @@ Need help? Run 'minsky sessions list' to see all available sessions.`);
         taskSpec.description
       );
       taskId = createdTask.id;
-      // Auto-created tasks start in PLANNING so session_start can transition them
+      // Auto-created tasks skip planning and go straight to READY
       await deps.taskService.setTaskStatus(taskId, TASK_STATUS.PLANNING);
+      await deps.taskService.setTaskStatus(taskId, TASK_STATUS.READY);
       if (!quiet) {
         // Display the task ID (taskId is already in the correct format from TaskService)
         log.cli(`Created task ${taskId}: ${taskSpec.title}`);
@@ -374,9 +375,17 @@ Error: ${getErrorMessage(installError)}`
           );
         }
 
-        if (currentStatus === TASK_STATUS.IN_PROGRESS || currentStatus === TASK_STATUS.PLANNING) {
-          // If transitioning from PLANNING, warn about any unchecked success criteria
-          if (currentStatus === TASK_STATUS.PLANNING) {
+        if (currentStatus === TASK_STATUS.PLANNING) {
+          throw new ValidationError(
+            "Planning is not yet marked as complete. Set status to READY when investigation is done.",
+            undefined,
+            undefined
+          );
+        }
+
+        if (currentStatus === TASK_STATUS.READY || currentStatus === TASK_STATUS.IN_PROGRESS) {
+          // If transitioning from READY, warn about any unchecked success criteria
+          if (currentStatus === TASK_STATUS.READY) {
             try {
               const specResult = await deps.taskService.getTaskSpecContent(taskId);
               if (specResult) {

--- a/src/domain/storage/migrations/pg/0019_add_ready_status.sql
+++ b/src/domain/storage/migrations/pg/0019_add_ready_status.sql
@@ -1,0 +1,3 @@
+-- Add READY to the task_status enum
+-- READY is the planning completeness gate before IN-PROGRESS (session_start)
+ALTER TYPE "public"."task_status" ADD VALUE IF NOT EXISTS 'READY' BEFORE 'IN-PROGRESS';

--- a/src/domain/task-status-bug-regression.test.ts
+++ b/src/domain/task-status-bug-regression.test.ts
@@ -44,7 +44,15 @@ describe("Task Status Bug Regression Tests", () => {
 
   describe("Integration test with task status functionality", () => {
     test("should handle all status transitions without variable naming errors", () => {
-      const statuses = ["TODO", "PLANNING", "IN-PROGRESS", "IN-REVIEW", "DONE", "BLOCKED"] as const;
+      const statuses = [
+        "TODO",
+        "PLANNING",
+        "READY",
+        "IN-PROGRESS",
+        "IN-REVIEW",
+        "DONE",
+        "BLOCKED",
+      ] as const;
 
       // This should not throw any "status is not defined" errors
       expect(() => {

--- a/src/domain/tasks/status-transitions.test.ts
+++ b/src/domain/tasks/status-transitions.test.ts
@@ -36,8 +36,24 @@ describe("status-transitions", () => {
       expect(() => validateStatusTransition(TaskStatus.PLANNING, TaskStatus.BLOCKED)).not.toThrow();
     });
 
+    test("PLANNING → READY is valid", () => {
+      expect(() => validateStatusTransition(TaskStatus.PLANNING, TaskStatus.READY)).not.toThrow();
+    });
+
     test("PLANNING → CLOSED is valid", () => {
       expect(() => validateStatusTransition(TaskStatus.PLANNING, TaskStatus.CLOSED)).not.toThrow();
+    });
+
+    test("READY → PLANNING is valid (go back for more investigation)", () => {
+      expect(() => validateStatusTransition(TaskStatus.READY, TaskStatus.PLANNING)).not.toThrow();
+    });
+
+    test("READY → BLOCKED is valid", () => {
+      expect(() => validateStatusTransition(TaskStatus.READY, TaskStatus.BLOCKED)).not.toThrow();
+    });
+
+    test("READY → CLOSED is valid", () => {
+      expect(() => validateStatusTransition(TaskStatus.READY, TaskStatus.CLOSED)).not.toThrow();
     });
 
     test("IN_PROGRESS → IN_REVIEW is valid", () => {
@@ -70,6 +86,10 @@ describe("status-transitions", () => {
 
     test("BLOCKED → PLANNING is valid", () => {
       expect(() => validateStatusTransition(TaskStatus.BLOCKED, TaskStatus.PLANNING)).not.toThrow();
+    });
+
+    test("BLOCKED → READY is valid", () => {
+      expect(() => validateStatusTransition(TaskStatus.BLOCKED, TaskStatus.READY)).not.toThrow();
     });
 
     test("BLOCKED → TODO is valid", () => {
@@ -105,10 +125,17 @@ describe("status-transitions", () => {
       );
     });
 
-    // Special case: PLANNING → IN-PROGRESS reserved for session_start
-    test("PLANNING → IN-PROGRESS via direct status set is rejected with session_start guidance", () => {
+    // Special case: READY → IN-PROGRESS reserved for session_start
+    test("READY → IN-PROGRESS via direct status set is rejected with session_start guidance", () => {
+      expect(() => validateStatusTransition(TaskStatus.READY, TaskStatus.IN_PROGRESS)).toThrow(
+        /Use session_start to transition from READY to IN-PROGRESS/
+      );
+    });
+
+    // Special case: PLANNING → IN-PROGRESS must go through READY
+    test("PLANNING → IN-PROGRESS via direct status set is rejected", () => {
       expect(() => validateStatusTransition(TaskStatus.PLANNING, TaskStatus.IN_PROGRESS)).toThrow(
-        /Use session_start to transition from PLANNING to IN-PROGRESS/
+        /Cannot transition directly from PLANNING to IN-PROGRESS.*Set status to READY first/
       );
     });
 

--- a/src/domain/tasks/status-transitions.ts
+++ b/src/domain/tasks/status-transitions.ts
@@ -11,12 +11,13 @@ import { ValidationError } from "../../errors/index";
 /**
  * Valid status transitions for each status.
  *
- * Note: PLANNING → IN-PROGRESS is intentionally excluded here — that transition
- * can only occur via `session_start`, not via direct `tasks_status_set`.
+ * Note: PLANNING → IN-PROGRESS and READY → IN-PROGRESS are intentionally excluded here —
+ * those transitions can only occur via `session_start`, not via direct `tasks_status_set`.
  */
 export const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
   [TaskStatus.TODO]: [TaskStatus.PLANNING, TaskStatus.CLOSED],
-  [TaskStatus.PLANNING]: [TaskStatus.TODO, TaskStatus.BLOCKED, TaskStatus.CLOSED],
+  [TaskStatus.PLANNING]: [TaskStatus.READY, TaskStatus.TODO, TaskStatus.BLOCKED, TaskStatus.CLOSED],
+  [TaskStatus.READY]: [TaskStatus.PLANNING, TaskStatus.BLOCKED, TaskStatus.CLOSED],
   [TaskStatus.IN_PROGRESS]: [
     TaskStatus.IN_REVIEW,
     TaskStatus.BLOCKED,
@@ -30,23 +31,32 @@ export const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
     TaskStatus.CLOSED,
   ],
   [TaskStatus.DONE]: [TaskStatus.CLOSED],
-  [TaskStatus.BLOCKED]: [TaskStatus.TODO, TaskStatus.PLANNING, TaskStatus.CLOSED],
+  [TaskStatus.BLOCKED]: [TaskStatus.TODO, TaskStatus.PLANNING, TaskStatus.READY, TaskStatus.CLOSED],
   [TaskStatus.CLOSED]: [TaskStatus.TODO],
 };
 
 /**
  * Validate that a status transition is allowed.
  *
- * Special case: PLANNING → IN-PROGRESS is not a valid direct transition via
- * `tasks_status_set`. It can only happen implicitly via `session_start`.
+ * Special cases: PLANNING → IN-PROGRESS and READY → IN-PROGRESS are not valid
+ * direct transitions via `tasks_status_set`. They can only happen via `session_start`.
  *
  * @throws {ValidationError} if the transition is not allowed
  */
 export function validateStatusTransition(from: TaskStatus, to: TaskStatus): void {
-  // Special case: PLANNING → IN-PROGRESS is reserved for session_start
+  // Special case: READY → IN-PROGRESS is reserved for session_start
+  if (from === TaskStatus.READY && to === TaskStatus.IN_PROGRESS) {
+    throw new ValidationError(
+      "Use session_start to transition from READY to IN-PROGRESS",
+      undefined,
+      undefined
+    );
+  }
+
+  // Special case: PLANNING → IN-PROGRESS must go through READY first
   if (from === TaskStatus.PLANNING && to === TaskStatus.IN_PROGRESS) {
     throw new ValidationError(
-      "Use session_start to transition from PLANNING to IN-PROGRESS",
+      "Cannot transition directly from PLANNING to IN-PROGRESS. Set status to READY first, then use session_start.",
       undefined,
       undefined
     );

--- a/src/domain/tasks/taskConstants.test.ts
+++ b/src/domain/tasks/taskConstants.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./taskConstants";
 
 const TEST_VALUE = 123;
-const TEST_ARRAY_SIZE = 7;
+const TEST_ARRAY_SIZE = 8;
 
 describe("Task Constants and Utilities", () => {
   describe("Basic Constants", () => {
@@ -17,6 +17,7 @@ describe("Task Constants and Utilities", () => {
       expect(Object.keys(TASK_STATUS)).toEqual([
         "TODO",
         "PLANNING",
+        "READY",
         "IN_PROGRESS",
         "IN_REVIEW",
         "DONE",
@@ -29,6 +30,7 @@ describe("Task Constants and Utilities", () => {
       // Test status to checkbox mapping
       expect(TASK_STATUS_CHECKBOX[TASK_STATUS.TODO]).toBe(" ");
       expect(TASK_STATUS_CHECKBOX[TASK_STATUS.PLANNING]).toBe("?");
+      expect(TASK_STATUS_CHECKBOX[TASK_STATUS.READY]).toBe("=");
       expect(TASK_STATUS_CHECKBOX[TASK_STATUS.IN_PROGRESS]).toBe("+");
       expect(TASK_STATUS_CHECKBOX[TASK_STATUS.IN_REVIEW]).toBe("-");
       expect(TASK_STATUS_CHECKBOX[TASK_STATUS.DONE]).toBe("x");
@@ -38,6 +40,7 @@ describe("Task Constants and Utilities", () => {
       // Test checkbox to status mapping
       expect(CHECKBOX_TO_STATUS[" "]).toBe(TASK_STATUS.TODO);
       expect(CHECKBOX_TO_STATUS["?"]).toBe(TASK_STATUS.PLANNING);
+      expect(CHECKBOX_TO_STATUS["="]).toBe(TASK_STATUS.READY);
       expect(CHECKBOX_TO_STATUS["+"]).toBe(TASK_STATUS.IN_PROGRESS);
       expect(CHECKBOX_TO_STATUS["-"]).toBe(TASK_STATUS.IN_REVIEW);
       expect(CHECKBOX_TO_STATUS["x"]).toBe(TASK_STATUS.DONE);

--- a/src/domain/tasks/taskConstants.ts
+++ b/src/domain/tasks/taskConstants.ts
@@ -12,6 +12,7 @@ import { isQualifiedTaskId } from "./task-id";
 export enum TaskStatus {
   TODO = "TODO",
   PLANNING = "PLANNING",
+  READY = "READY",
   IN_PROGRESS = "IN-PROGRESS",
   IN_REVIEW = "IN-REVIEW",
   DONE = "DONE",
@@ -36,6 +37,7 @@ export const TASK_STATUS_VALUES = Object.values(TaskStatus);
 export const TASK_STATUS_CHECKBOX: Record<TaskStatus, string> = {
   [TASK_STATUS.TODO]: " ",
   [TASK_STATUS.PLANNING]: "?",
+  [TASK_STATUS.READY]: "=",
   [TASK_STATUS.IN_PROGRESS]: "+",
   [TASK_STATUS.IN_REVIEW]: "-",
   [TASK_STATUS.DONE]: "x",
@@ -49,6 +51,7 @@ export const TASK_STATUS_CHECKBOX: Record<TaskStatus, string> = {
 export const CHECKBOX_TO_STATUS: Record<string, TaskStatus> = {
   " ": TASK_STATUS.TODO,
   "?": TASK_STATUS.PLANNING,
+  "=": TASK_STATUS.READY,
   "+": TASK_STATUS.IN_PROGRESS,
   "-": TASK_STATUS.IN_REVIEW,
   x: TASK_STATUS.DONE,
@@ -63,6 +66,7 @@ export const CHECKBOX_TO_STATUS: Record<string, TaskStatus> = {
 export const STATUS_TO_CHECKBOX: Record<string, string> = {
   TODO: " ",
   PLANNING: "?",
+  READY: "=",
   "IN-PROGRESS": "+",
   "IN-REVIEW": "-",
   DONE: "x",

--- a/src/schemas/tasks.ts
+++ b/src/schemas/tasks.ts
@@ -11,6 +11,7 @@ import { TASK_STATUS_VALUES } from "../domain/tasks/taskConstants";
 export const _TASK_STATUS = {
   TODO: "TODO",
   PLANNING: "PLANNING",
+  READY: "READY",
   DONE: "DONE",
   IN_PROGRESS: "IN-PROGRESS",
   IN_REVIEW: "IN-REVIEW",


### PR DESCRIPTION
## Summary

- Adds READY as the planning completeness gate between PLANNING and IN-PROGRESS
- Agent must explicitly set status to READY when investigation is done, before session_start works
- Provides cross-conversation safety: Agent B sees READY vs PLANNING to know if planning is complete
- Resists throughput bias: structural gate that can't be skipped

## Changes

- `taskConstants.ts`: READY added to enum with `=` checkbox character
- `status-transitions.ts`: PLANNING → READY valid, READY → IN-PROGRESS only via session_start
- `start-session-operations.ts`: session_start blocks from PLANNING with guidance message
- `0019_add_ready_status.sql`: Postgres enum migration
- Schema updates in 3 files, CLAUDE.md lifecycle updated
- 15 files changed, 105 insertions, 28 deletions

## Test plan

- [x] All 1754 tests pass
- [x] READY transition validation tests added
- [x] session_start from PLANNING blocked with "set to READY" message
- [x] session_start from READY proceeds to IN-PROGRESS
- [x] Auto-created tasks go TODO → PLANNING → READY automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)