### PR TITLE
refactor(mt#879): delete dead singletons and complete @injectable coverage

### DIFF
--- a/src/adapters/shared/commands/tasks/migrate-backend-command.ts
+++ b/src/adapters/shared/commands/tasks/migrate-backend-command.ts
@@ -11,7 +11,7 @@ import { BaseTaskCommand } from "./base-task-command";
 import { log } from "../../../../utils/logger";
 import { createConfiguredTaskService } from "../../../../domain/tasks/taskService";
 import {
-  _backendDetectionService,
+  DefaultBackendDetectionService,
   TaskBackend,
 } from "../../../../domain/configuration/backend-detection";
 import { updateSessionTaskAssociation } from "../../../../domain/session/session-task-association";
@@ -233,7 +233,7 @@ export class TasksMigrateBackendCommand extends BaseTaskCommand<MigrateBackendPa
 
   private async detectCurrentBackend(workspacePath: string): Promise<string> {
     // Use the backend detection service
-    const detectedBackend = await _backendDetectionService.detectBackend(workspacePath);
+    const detectedBackend = await new DefaultBackendDetectionService().detectBackend(workspacePath);
     return detectedBackend as string;
   }
 

--- a/src/domain/ai/tokenizer-service.ts
+++ b/src/domain/ai/tokenizer-service.ts
@@ -321,8 +321,3 @@ export class DefaultTokenizerService implements TokenizerService {
     return this.createTiktokenTokenizer("cl100k_base");
   }
 }
-
-/**
- * Global instance for convenience
- */
-export const defaultTokenizerService = new DefaultTokenizerService();

--- a/src/domain/changeset/adapters/bitbucket-adapter.ts
+++ b/src/domain/changeset/adapters/bitbucket-adapter.ts
@@ -5,6 +5,7 @@
  * This shows the extensible architecture for additional platforms.
  */
 
+import { injectable } from "tsyringe";
 import type {
   ChangesetAdapter,
   ChangesetAdapterConfig,
@@ -29,6 +30,7 @@ import { MinskyError } from "../../../errors/index";
  * Bitbucket changeset adapter for Pull Requests
  * TODO: Implement using Bitbucket API
  */
+@injectable()
 export class BitbucketChangesetAdapter implements ChangesetAdapter {
   readonly platform: ChangesetPlatform = "bitbucket-pr";
   readonly name = "Bitbucket Pull Requests";
@@ -98,6 +100,7 @@ export class BitbucketChangesetAdapter implements ChangesetAdapter {
 /**
  * Factory for creating Bitbucket changeset adapters
  */
+@injectable()
 export class BitbucketChangesetAdapterFactory implements ChangesetAdapterFactory {
   readonly platform: ChangesetPlatform = "bitbucket-pr";
 

--- a/src/domain/changeset/adapters/github-adapter.ts
+++ b/src/domain/changeset/adapters/github-adapter.ts
@@ -5,6 +5,7 @@
  * the existing GitHub repository backend and GitHub API.
  */
 
+import { injectable } from "tsyringe";
 import type {
   ChangesetAdapter,
   ChangesetAdapterConfig,
@@ -45,6 +46,7 @@ type OctokitPR =
 /**
  * GitHub changeset adapter that maps GitHub PRs to changeset abstraction
  */
+@injectable()
 export class GitHubChangesetAdapter implements ChangesetAdapter {
   readonly platform: ChangesetPlatform = "github-pr";
   readonly name = "GitHub Pull Requests";
@@ -627,6 +629,7 @@ export class GitHubChangesetAdapter implements ChangesetAdapter {
 /**
  * Factory for creating GitHub changeset adapters
  */
+@injectable()
 export class GitHubChangesetAdapterFactory implements ChangesetAdapterFactory {
   readonly platform: ChangesetPlatform = "github-pr";
 

--- a/src/domain/changeset/adapters/gitlab-adapter.ts
+++ b/src/domain/changeset/adapters/gitlab-adapter.ts
@@ -23,12 +23,14 @@ import type {
   ChangesetPlatform,
 } from "../types";
 
+import { injectable } from "tsyringe";
 import { MinskyError } from "../../../errors/index";
 
 /**
  * GitLab changeset adapter for Merge Requests
  * TODO: Implement using GitLab API
  */
+@injectable()
 export class GitLabChangesetAdapter implements ChangesetAdapter {
   readonly platform: ChangesetPlatform = "gitlab-mr";
   readonly name = "GitLab Merge Requests";
@@ -97,6 +99,7 @@ export class GitLabChangesetAdapter implements ChangesetAdapter {
 /**
  * Factory for creating GitLab changeset adapters
  */
+@injectable()
 export class GitLabChangesetAdapterFactory implements ChangesetAdapterFactory {
   readonly platform: ChangesetPlatform = "gitlab-mr";
 

--- a/src/domain/changeset/repository-backend-integration.ts
+++ b/src/domain/changeset/repository-backend-integration.ts
@@ -232,9 +232,3 @@ export class MultiRepositoryChangesetService {
     log.debug(`Removed repository from multi-repo changeset service: ${repositoryUrl}`);
   }
 }
-
-/**
- * Global multi-repository changeset service instance
- * Useful for indexing and searching across multiple repositories
- */
-export const globalChangesetService = new MultiRepositoryChangesetService();

--- a/src/domain/configuration/backend-detection.ts
+++ b/src/domain/configuration/backend-detection.ts
@@ -41,6 +41,3 @@ export class DefaultBackendDetectionService implements BackendDetectionService {
     return false;
   }
 }
-
-// Export singleton instance
-export const _backendDetectionService = new DefaultBackendDetectionService();

--- a/src/domain/configuration/config-validator.ts
+++ b/src/domain/configuration/config-validator.ts
@@ -297,6 +297,3 @@ export class DefaultConfigValidator implements ConfigValidator {
     return postgresRegex.test(connectionString);
   }
 }
-
-// Export singleton instance
-export const configValidator = new DefaultConfigValidator();

--- a/src/domain/configuration/credential-resolver.ts
+++ b/src/domain/configuration/credential-resolver.ts
@@ -167,6 +167,3 @@ export class DefaultCredentialResolver implements CredentialResolver {
     return filePath;
   }
 }
-
-// Export singleton instance
-export const _credentialResolver = new DefaultCredentialResolver();

--- a/src/domain/tasks/multi-backend-errors.ts
+++ b/src/domain/tasks/multi-backend-errors.ts
@@ -147,9 +147,6 @@ export class ConsoleMultiBackendLogger implements MultiBackendLogger {
   }
 }
 
-// Default logger instance for multi-backend operations
-export const logger = new ConsoleMultiBackendLogger();
-
 // Error recovery utilities
 export class ErrorRecovery {
   /**

--- a/src/domain/tasks/task-similarity-service.ts
+++ b/src/domain/tasks/task-similarity-service.ts
@@ -200,11 +200,12 @@ export class TaskSimilarityService {
       const buffer: number = typeof caps.buffer === "number" ? caps.buffer : 192;
       if (typeof maxTokens === "number" && maxTokens > 0) {
         const effective = Math.max(1, maxTokens - buffer);
-        const { defaultTokenizerService } = await import("../ai/tokenizer-service");
-        const tokens = await defaultTokenizerService.tokenize(content, model, provider);
+        const { DefaultTokenizerService } = await import("../ai/tokenizer-service");
+        const tokenizerService = new DefaultTokenizerService();
+        const tokens = await tokenizerService.tokenize(content, model, provider);
         if (tokens.length > effective) {
           const trimmed = tokens.slice(0, effective);
-          content = await defaultTokenizerService.detokenize(trimmed, model, provider);
+          content = await tokenizerService.detokenize(trimmed, model, provider);
         }
       }
     } catch {


### PR DESCRIPTION
## Summary

Final cleanup for Phase E (DI lockdown):

- **Deleted 5 dead singletons**: `globalChangesetService`, `_credentialResolver`, `configValidator`, `logger` (multi-backend), `_backendDetectionService`
- **Fixed 1-consumer singletons**: `defaultTokenizerService` → local instance in task-similarity-service; `_backendDetectionService` → local instance in migrate-backend-command
- **Added @injectable()** to 6 adapter classes: GitHub, GitLab, Bitbucket adapters + their factories
- **100% @injectable coverage** on all service/adapter/storage classes (zero undecorated)

### Post-change audit:
- Zero domain singletons (remaining module-level instances are config bootstrap, logger proxies, and operation registries — infrastructure, not services)
- Zero undecorated service classes
- Zero `defaultInstance`, `resolveProvider`, `getAppContainer` references