### PR TITLE
feat(mt#900): Implement Codex and OpenHands registrars, fix Junie detection

### DIFF
--- a/src/domain/mcp/registration.test.ts
+++ b/src/domain/mcp/registration.test.ts
@@ -12,6 +12,8 @@ import {
   VSCodeRegistrar,
   WindsurfRegistrar,
   JunieRegistrar,
+  CodexRegistrar,
+  OpenHandsRegistrar,
   getRegistrar,
   registerWithClient,
 } from "./registration";
@@ -267,6 +269,96 @@ describe("JunieRegistrar", () => {
   });
 });
 
+describe("CodexRegistrar", () => {
+  const registrar = new CodexRegistrar();
+
+  describe("generateConfig", () => {
+    test("stdio transport produces valid TOML with [mcp_servers.minsky-server] header", () => {
+      const content = registrar.generateConfig("stdio");
+
+      expect(content).toContain("[mcp_servers.minsky-server]");
+      expect(content).toContain('command = "minsky"');
+      expect(content).toContain('"mcp"');
+      expect(content).toContain('"start"');
+    });
+
+    test("httpStream transport includes --http-stream in args", () => {
+      const content = registrar.generateConfig("httpStream", 3000, "localhost");
+
+      expect(content).toContain("[mcp_servers.minsky-server]");
+      expect(content).toContain('"--http-stream"');
+      expect(content).toContain('"3000"');
+      expect(content).toContain('"localhost"');
+    });
+
+    test("sse transport includes --sse in args", () => {
+      const content = registrar.generateConfig("sse", 4000, "0.0.0.0");
+
+      expect(content).toContain('"--sse"');
+      expect(content).toContain('"4000"');
+      expect(content).toContain('"0.0.0.0"');
+    });
+  });
+
+  describe("configPath", () => {
+    test("returns .codex/config.toml under project root", () => {
+      expect(registrar.configPath("/project")).toBe(path.join("/project", ".codex", "config.toml"));
+    });
+  });
+
+  test("mergeConfig is true (Codex config has other settings)", () => {
+    expect(registrar.mergeConfig).toBe(true);
+  });
+
+  test("is NOT an instance of McpServersJsonRegistrar", () => {
+    expect(registrar).not.toBeInstanceOf(McpServersJsonRegistrar);
+  });
+});
+
+describe("OpenHandsRegistrar", () => {
+  const registrar = new OpenHandsRegistrar();
+
+  describe("generateConfig", () => {
+    test("stdio transport produces TOML with [mcp] section and stdio_servers array", () => {
+      const content = registrar.generateConfig("stdio");
+
+      expect(content).toContain("[mcp]");
+      expect(content).toContain("stdio_servers");
+      expect(content).toContain('"minsky-server"');
+      expect(content).toContain('"minsky"');
+    });
+
+    test("httpStream transport produces TOML with shttp_servers and URL", () => {
+      const content = registrar.generateConfig("httpStream", 3000, "localhost");
+
+      expect(content).toContain("[mcp]");
+      expect(content).toContain("shttp_servers");
+      expect(content).toContain("http://localhost:3000/mcp");
+    });
+
+    test("sse transport produces TOML with shttp_servers", () => {
+      const content = registrar.generateConfig("sse", 4000, "0.0.0.0");
+
+      expect(content).toContain("shttp_servers");
+      expect(content).toContain("http://0.0.0.0:4000/mcp");
+    });
+  });
+
+  describe("configPath", () => {
+    test("returns config.toml at project root", () => {
+      expect(registrar.configPath("/project")).toBe(path.join("/project", "config.toml"));
+    });
+  });
+
+  test("mergeConfig is true (OpenHands config has other settings)", () => {
+    expect(registrar.mergeConfig).toBe(true);
+  });
+
+  test("is NOT an instance of McpServersJsonRegistrar", () => {
+    expect(registrar).not.toBeInstanceOf(McpServersJsonRegistrar);
+  });
+});
+
 describe("McpServersJsonRegistrar (abstract base)", () => {
   test("CursorRegistrar is an instance of McpServersJsonRegistrar", () => {
     expect(new CursorRegistrar()).toBeInstanceOf(McpServersJsonRegistrar);
@@ -308,9 +400,21 @@ describe("getRegistrar", () => {
     expect(r.name).toBe("junie");
   });
 
-  test("throws descriptive error for unsupported client", () => {
+  test("returns CodexRegistrar for 'codex'", () => {
+    const r = getRegistrar("codex");
+    expect(r).toBeInstanceOf(CodexRegistrar);
+    expect(r.name).toBe("codex");
+  });
+
+  test("returns OpenHandsRegistrar for 'openhands'", () => {
+    const r = getRegistrar("openhands");
+    expect(r).toBeInstanceOf(OpenHandsRegistrar);
+    expect(r.name).toBe("openhands");
+  });
+
+  test("throws descriptive error for unsupported client listing all 7 clients", () => {
     expect(() => getRegistrar("unknown")).toThrow(
-      'MCP client "unknown" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie'
+      'MCP client "unknown" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie, codex, openhands'
     );
   });
 });

--- a/src/domain/mcp/registration.ts
+++ b/src/domain/mcp/registration.ts
@@ -238,6 +238,72 @@ export class VSCodeRegistrar implements ClientRegistrar {
 }
 
 /**
+ * Registrar for the Codex MCP client.
+ *
+ * Codex uses TOML format with [mcp_servers.<name>] sections.
+ * Config is project-scoped at .codex/config.toml.
+ */
+export class CodexRegistrar implements ClientRegistrar {
+  readonly name = "codex";
+  readonly mergeConfig = true; // Codex config has other settings
+
+  generateConfig(transport: string, port?: number, host?: string): string {
+    // Codex uses TOML format: [mcp_servers.<name>] with command/args/env
+    const resolvedPort = port || DEFAULT_DEV_PORT;
+    const resolvedHost = host || "localhost";
+
+    const args = ['"mcp"', '"start"'];
+    if (transport === "sse") {
+      args.push('"--sse"', `"--port"`, `"${resolvedPort}"`, `"--host"`, `"${resolvedHost}"`);
+    } else if (transport === "httpStream") {
+      args.push(
+        '"--http-stream"',
+        `"--port"`,
+        `"${resolvedPort}"`,
+        `"--host"`,
+        `"${resolvedHost}"`
+      );
+    }
+
+    return `[mcp_servers.minsky-server]\ncommand = "minsky"\nargs = [${args.join(", ")}]\nenv = {}\nenabled = true\n`;
+  }
+
+  configPath(projectRoot: string): string {
+    // Project-scoped by default
+    return path.join(projectRoot, ".codex", "config.toml");
+  }
+}
+
+/**
+ * Registrar for the OpenHands MCP client.
+ *
+ * OpenHands uses TOML format with [mcp] section containing stdio_servers or shttp_servers.
+ * Config is project-scoped at config.toml.
+ */
+export class OpenHandsRegistrar implements ClientRegistrar {
+  readonly name = "openhands";
+  readonly mergeConfig = true; // OpenHands config has other settings
+
+  generateConfig(transport: string, port?: number, host?: string): string {
+    // OpenHands uses [mcp] section with stdio_servers array for stdio,
+    // or shttp_servers for HTTP transport
+    const resolvedPort = port || DEFAULT_DEV_PORT;
+    const resolvedHost = host || "localhost";
+
+    if (transport === "stdio") {
+      return `[mcp]\nstdio_servers = [\n  {name = "minsky-server", command = "minsky", args = ["mcp", "start"]}\n]\n`;
+    }
+    // For HTTP transports, use shttp_servers
+    const url = `http://${resolvedHost}:${resolvedPort}/mcp`;
+    return `[mcp]\nshttp_servers = [\n  {url = "${url}"}\n]\n`;
+  }
+
+  configPath(projectRoot: string): string {
+    return path.join(projectRoot, "config.toml");
+  }
+}
+
+/**
  * Returns the registrar for the given client name.
  * Throws a descriptive error for unrecognized clients.
  */
@@ -253,9 +319,13 @@ export function getRegistrar(client: string): ClientRegistrar {
       return new WindsurfRegistrar();
     case "junie":
       return new JunieRegistrar();
+    case "codex":
+      return new CodexRegistrar();
+    case "openhands":
+      return new OpenHandsRegistrar();
     default:
       throw new Error(
-        `MCP client "${client}" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie`
+        `MCP client "${client}" is not yet supported. Supported clients: cursor, claude-desktop, vscode, windsurf, junie, codex, openhands`
       );
   }
 }

--- a/src/domain/runtime/harness-detection.test.ts
+++ b/src/domain/runtime/harness-detection.test.ts
@@ -116,7 +116,15 @@ describe("detectInstalledClients", () => {
   });
 
   test("returned values are all ManagedClient members", () => {
-    const validClients = new Set(["cursor", "claude-desktop", "vscode"]);
+    const validClients = new Set([
+      "cursor",
+      "claude-desktop",
+      "vscode",
+      "windsurf",
+      "junie",
+      "codex",
+      "openhands",
+    ]);
     const clients = detectInstalledClients();
     for (const c of clients) {
       expect(validClients.has(c)).toBe(true);

--- a/src/domain/runtime/harness-detection.ts
+++ b/src/domain/runtime/harness-detection.ts
@@ -16,7 +16,14 @@ export type AgentHarness = "claude-code" | "cursor" | "standalone";
  * The set of MCP client applications that Minsky can register itself with.
  * Extend this union as new clients are implemented.
  */
-export type ManagedClient = "cursor" | "claude-desktop" | "vscode" | "windsurf" | "junie";
+export type ManagedClient =
+  | "cursor"
+  | "claude-desktop"
+  | "vscode"
+  | "windsurf"
+  | "junie"
+  | "codex"
+  | "openhands";
 
 /**
  * Detect the current agent harness from environment signals.
@@ -94,8 +101,18 @@ export function detectInstalledClients(): ManagedClient[] {
     clients.push("windsurf");
   }
 
-  // Junie (JetBrains): skip auto-detection — JetBrains detection is unreliable.
-  // Users can specify --client junie explicitly to register with Junie.
+  // Junie (JetBrains): check for ~/.junie/ directory (created by Junie CLI)
+  if (existsSync(path.join(homedir(), ".junie"))) {
+    clients.push("junie");
+  }
+
+  // Codex: check for ~/.codex/ directory
+  if (existsSync(path.join(homedir(), ".codex"))) {
+    clients.push("codex");
+  }
+
+  // OpenHands: skip auto-detection — use --client openhands explicitly
+  // OpenHands is an agent framework, not typically installed as a user app.
 
   return clients;
 }

--- a/src/domain/session/session-approval-operations.ts
+++ b/src/domain/session/session-approval-operations.ts
@@ -9,7 +9,6 @@ import { log } from "../../utils/logger";
 import { ValidationError, ResourceNotFoundError } from "../../errors/index";
 import { type SessionProviderInterface } from "./session-db-adapter";
 import { extractGitHubInfoFromUrl } from "./repository-backend-detection";
-import { resolveBackendType } from "./session-utils";
 import {
   createRepositoryBackend,
   RepositoryBackendType,

--- a/src/domain/session/session-pr-operations.ts
+++ b/src/domain/session/session-pr-operations.ts
@@ -13,7 +13,6 @@ import {
   getRepositoryBackendFromConfig,
   extractGitHubInfoFromUrl,
 } from "./repository-backend-detection";
-import { resolveBackendType } from "./session-utils";
 import {
   createRepositoryBackend,
   RepositoryBackendType,


### PR DESCRIPTION
## Summary

- **CodexRegistrar**: TOML format (`[mcp_servers.minsky-server]`), project-scoped at `.codex/config.toml`, `mergeConfig = true`
- **OpenHandsRegistrar**: TOML format (`[mcp]` with `stdio_servers`/`shttp_servers`), project-scoped at `config.toml`, `mergeConfig = true`
- **Junie detection fixed**: Now checks `~/.junie/` directory (was previously skipped as "unreliable")
- **Codex detection added**: Checks `~/.codex/` directory
- `ManagedClient` type extended with `"codex"` and `"openhands"`
- `getRegistrar` factory supports all 7 clients
- Also fixes pre-existing unused `resolveBackendType` imports in session ops files

## Test plan

- [x] CodexRegistrar generates valid TOML for stdio/sse/httpStream
- [x] OpenHandsRegistrar generates valid TOML with stdio_servers/shttp_servers
- [x] getRegistrar("codex") and getRegistrar("openhands") return correct instances
- [x] Harness detection test updated for all 7 client types
- [x] All 1741 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)