### PR TITLE
feat(mt#888): Add skill references to generated subagent prompts

### DIFF
--- a/src/domain/session/prompt-generation.ts
+++ b/src/domain/session/prompt-generation.ts
@@ -29,6 +29,24 @@ const SCOPE_WARNING_THRESHOLD = 40;
 const BATCH_SIZE = 30;
 export const PROMPT_WATERMARK = "<!-- minsky:prompt:v1 -->";
 
+const SKILL_REFERENCES: Record<PromptType, string[]> = {
+  implementation: ["implement-task", "prepare-pr", "testing-guide", "error-handling"],
+  refactor: ["code-organization", "testing-guide"],
+  review: ["review-pr"],
+  cleanup: ["code-organization", "fix-skipped-tests"],
+  audit: [],
+};
+
+function renderSkillReferences(type: PromptType): string {
+  const skills = SKILL_REFERENCES[type];
+  if (skills.length === 0) return "";
+  return `
+## Recommended Skills
+
+The following Claude Code skills are available and relevant to this work. Use \`/skill-name\` to invoke:
+${skills.map((s) => `- \`/${s}\``).join("\n")}`;
+}
+
 function renderCommonHeader(params: GeneratePromptParams): string {
   return `You are working in Minsky session at ${params.sessionDir}. All file paths MUST be absolute paths under this directory.
 
@@ -85,6 +103,11 @@ function generateSinglePrompt(
     sections.push(`${header}\n\n**Batch ${batchIndex} of ${totalBatches}**`);
   } else {
     sections.push(header);
+  }
+
+  const skillRefs = renderSkillReferences(type);
+  if (skillRefs) {
+    sections.push(skillRefs);
   }
 
   if (effectiveScope && effectiveScope.length > 0) {

--- a/tests/domain/session/prompt-generation.test.ts
+++ b/tests/domain/session/prompt-generation.test.ts
@@ -186,6 +186,44 @@ describe("generateSubagentPrompt", () => {
     });
   });
 
+  describe("skill references", () => {
+    it("includes implement-task and prepare-pr skills for implementation type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation" });
+      expect(result.prompt).toContain("/implement-task");
+      expect(result.prompt).toContain("/prepare-pr");
+    });
+
+    it("includes code-organization skill for refactor type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "refactor" });
+      expect(result.prompt).toContain("/code-organization");
+    });
+
+    it("includes review-pr skill for review type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "review" });
+      expect(result.prompt).toContain("/review-pr");
+    });
+
+    it("includes fix-skipped-tests skill for cleanup type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "cleanup" });
+      expect(result.prompt).toContain("/fix-skipped-tests");
+    });
+
+    it("does not include skill references for audit type", () => {
+      const result = generateSubagentPrompt({ ...baseParams, type: "audit" });
+      expect(result.prompt).not.toContain("Recommended Skills");
+    });
+
+    it("skill references appear before scope constraints", () => {
+      const scope = ["src/foo.ts"];
+      const result = generateSubagentPrompt({ ...baseParams, type: "implementation", scope });
+      const skillsIdx = result.prompt.indexOf("Recommended Skills");
+      const scopeIdx = result.prompt.indexOf("Scope Constraints");
+      expect(skillsIdx).toBeGreaterThan(-1);
+      expect(scopeIdx).toBeGreaterThan(-1);
+      expect(skillsIdx).toBeLessThan(scopeIdx);
+    });
+  });
+
   describe("scope handling", () => {
     it("lists files in the prompt when scope is provided", () => {
       const scope = ["src/foo.ts", "src/bar.ts"];


### PR DESCRIPTION
## Summary

- Adds a `SKILL_REFERENCES` mapping from prompt type to relevant skills in `prompt-generation.ts`
- `generate_prompt` now injects a "Recommended Skills" section into generated prompts
- Skill references appear between the header and scope sections
- Mapping:
  - `implementation` → implement-task, prepare-pr, testing-guide, error-handling
  - `refactor` → code-organization, testing-guide
  - `review` → review-pr
  - `cleanup` → code-organization, fix-skipped-tests
  - `audit` → (none)
- 6 new tests covering skill references for each prompt type and ordering

## Test plan

- [ ] `bun test tests/domain/session/prompt-generation.test.ts` passes (6 new tests)
- [ ] Generated prompts contain skill references for non-audit types
- [ ] Audit prompts have no skill references section
- [ ] Skill references appear before scope constraints in the prompt