### PR TITLE
docs(mt#879): update stale DI comments and architecture doc counts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,9 +356,9 @@ Service classes use tsyringe decorators:
 - `@injectable()` — marks a class for DI participation
 - `@inject("tokenName")` — injects a dependency by token on a constructor parameter
 
-Eight core services are currently decorated. Services with primitive constructor params
-(e.g., `workspacePath: string`) use `@injectable()` only; services whose constructor
-params match registered tokens also use `@inject()`.
+All service, adapter, and storage classes in `src/domain/` are decorated. Services with
+primitive constructor params (e.g., `workspacePath: string`) use `@injectable()` only;
+services whose constructor params match registered tokens also use `@inject()`.
 
 **Polyfill requirement**: `import "reflect-metadata"` must be loaded before any decorated
 class. It appears at the top of `src/cli.ts` (runtime) and `tests/setup.ts` (test preload).

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -48,11 +48,7 @@ export interface CommandExecutionContext {
   format?: string;
   /** Workspace path for the current context */
   workspacePath?: string;
-  /**
-   * DI container — provides access to services without singleton reach-ins.
-   * Available after container.initialize() has been called (i.e., during command execution).
-   * Optional for backward compatibility during the migration period (mt#761).
-   */
+  /** DI container — provides access to services via typed dependency resolution. */
   container?: import("../../composition/types").AppContainerInterface;
 }
 

--- a/src/domain/session/session-provider-cache.ts
+++ b/src/domain/session/session-provider-cache.ts
@@ -1,9 +1,10 @@
 /**
- * Shared session provider cache — canonical lazy singleton.
+ * Shared session provider cache — test infrastructure only.
  *
- * @deprecated All production code should use container.get("sessionProvider")
- * instead. This module survives only for test seams and will be removed once
- * all reach-ins are eliminated.
+ * @deprecated Zero production callers remain. This module exists solely for
+ * test seams (setSharedSessionProvider/resetSharedSessionProvider) used by
+ * taskCommands.test.ts. Can be removed once that test migrates to the test
+ * container (createTestContainer).
  */
 import { createSessionProvider, type SessionProviderInterface } from "./session-db-adapter";
 import type { PersistenceProvider } from "../persistence/types";
@@ -17,8 +18,7 @@ export const _cache: { provider: SessionProviderInterface | null } = { provider:
 
 /**
  * @deprecated Use container.get("sessionProvider") instead.
- * This lazy singleton survives only for callers that have not yet migrated
- * to container-based DI. Will be removed once all reach-ins are eliminated.
+ * Zero production callers remain — kept only for test seam compatibility.
  */
 export async function getSharedSessionProvider(
   persistenceProvider?: PersistenceProvider


### PR DESCRIPTION
## Summary

Final Phase E cleanup — update stale comments and documentation that referenced the old DI state.

### Changes:
- **docs/architecture.md**: "Eight core services" → "All service, adapter, and storage classes" (was 8, now 38+)
- **command-registry.ts**: Removed stale "migration period" comment on container field
- **session-provider-cache.ts**: Updated comments to reflect zero production callers (test infrastructure only)

### Remaining known items (acceptable/deferred):
- `createSessionDeps()` factory (session.ts:373) — convenience function for code without container access. Removing requires deeper migration of session command paths.
- `session-provider-cache` module — exists only for 1 test file's seams. Can be removed when that test migrates to createTestContainer.
- `TaskGraphService` instantiated directly in ~10 adapter commands — acceptable pattern (creates service with runtime db instance from container-provided persistence).
- `createConfiguredTaskService()` called in ~10 places — acceptable (factory using container-provided persistence).