### PR TITLE
feat(mt#902): implement knowledge base foundation

### DIFF
--- a/src/domain/configuration/schemas/index.ts
+++ b/src/domain/configuration/schemas/index.ts
@@ -31,6 +31,11 @@ import { embeddingsConfigSchema, type EmbeddingsConfig } from "./embeddings";
 import { workspaceConfigSchema, type WorkspaceConfig } from "./workspace";
 import { rulesConfigSchema, type RulesConfig } from "./rules";
 import { mcpConfigSchema, type McpConfig } from "./mcp";
+import {
+  knowledgeBasesConfigSchema,
+  type KnowledgeBasesConfig,
+  type KnowledgeBaseEntry,
+} from "./knowledge-bases";
 
 /**
  * Complete application configuration schema
@@ -74,6 +79,9 @@ export const configurationSchema = z.looseObject({
 
   // MCP transport configuration (project-level invariants set during minsky init)
   mcp: mcpConfigSchema,
+
+  // Knowledge base sources configuration
+  knowledgeBases: knowledgeBasesConfigSchema,
 }); // looseObject allows extra properties (equivalent to passthrough)
 
 /**
@@ -248,6 +256,8 @@ export type {
   WorkspaceConfig,
   RulesConfig,
   McpConfig,
+  KnowledgeBasesConfig,
+  KnowledgeBaseEntry,
 };
 
 // Re-export schemas for external use
@@ -264,6 +274,7 @@ export {
   workspaceConfigSchema,
   rulesConfigSchema,
   mcpConfigSchema,
+  knowledgeBasesConfigSchema,
 };
 
 // Export the main schema as default

--- a/src/domain/configuration/schemas/knowledge-bases.ts
+++ b/src/domain/configuration/schemas/knowledge-bases.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+/**
+ * Authentication configuration for a knowledge source
+ */
+const knowledgeSourceAuthSchema = z.object({
+  /** Environment variable containing the API token */
+  tokenEnvVar: z.string(),
+  /** Optional environment variable for email (used by some providers like Confluence) */
+  emailEnvVar: z.string().optional(),
+});
+
+/**
+ * Sync schedule and behavior configuration
+ */
+const knowledgeSyncConfigSchema = z.object({
+  /** Cron-based schedule for automatic sync */
+  schedule: z.enum(["hourly", "daily", "weekly"]).optional(),
+  /** Maximum depth to traverse in hierarchical sources */
+  maxDepth: z.number().int().positive().optional(),
+  /** Glob patterns for pages/documents to exclude from sync */
+  excludePatterns: z.array(z.string()).optional(),
+});
+
+/**
+ * Schema for a single knowledge base source entry.
+ * Uses .passthrough() to allow type-specific fields (e.g., Notion workspace ID,
+ * Confluence space key, Google Drive folder ID) without requiring them in the base schema.
+ */
+export const knowledgeBaseEntrySchema = z
+  .object({
+    /** Human-readable name for this knowledge source */
+    name: z.string(),
+    /** Provider type (determines which connector to use) */
+    type: z.enum(["notion", "confluence", "google-docs"]),
+    /** Authentication credentials */
+    auth: knowledgeSourceAuthSchema,
+    /** Optional sync behavior configuration */
+    sync: knowledgeSyncConfigSchema.optional(),
+  })
+  .passthrough();
+
+/**
+ * Schema for the knowledgeBases config array
+ */
+export const knowledgeBasesConfigSchema = z.array(knowledgeBaseEntrySchema).default([]);
+
+export type KnowledgeBaseEntry = z.infer<typeof knowledgeBaseEntrySchema>;
+export type KnowledgeBasesConfig = z.infer<typeof knowledgeBasesConfigSchema>;

--- a/src/domain/configuration/schemas/knowledge-bases.ts
+++ b/src/domain/configuration/schemas/knowledge-bases.ts
@@ -14,8 +14,8 @@ const knowledgeSourceAuthSchema = z.object({
  * Sync schedule and behavior configuration
  */
 const knowledgeSyncConfigSchema = z.object({
-  /** Cron-based schedule for automatic sync */
-  schedule: z.enum(["hourly", "daily", "weekly"]).optional(),
+  /** When to sync: on-demand (explicit only), startup (session start), or daily */
+  schedule: z.enum(["on-demand", "startup", "daily"]).default("on-demand"),
   /** Maximum depth to traverse in hierarchical sources */
   maxDepth: z.number().int().positive().optional(),
   /** Glob patterns for pages/documents to exclude from sync */

--- a/src/domain/knowledge/index.ts
+++ b/src/domain/knowledge/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Knowledge Domain
+ *
+ * Exports all public types and interfaces for the knowledge base system.
+ */
+
+export type {
+  KnowledgeDocument,
+  ListOptions,
+  KnowledgeSourceProvider,
+  KnowledgeSourceConfig,
+  SyncReport,
+} from "./types";

--- a/src/domain/knowledge/types.ts
+++ b/src/domain/knowledge/types.ts
@@ -83,8 +83,8 @@ export interface KnowledgeSourceConfig {
   };
   /** Optional sync configuration */
   sync?: {
-    /** Cron schedule for automatic sync */
-    schedule?: "hourly" | "daily" | "weekly";
+    /** When to sync: on-demand (explicit only), startup (session start), or daily */
+    schedule?: "on-demand" | "startup" | "daily";
     /** Maximum depth to traverse */
     maxDepth?: number;
     /** Glob patterns for pages/documents to exclude */

--- a/src/domain/knowledge/types.ts
+++ b/src/domain/knowledge/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Knowledge Domain Types
+ *
+ * Core types for the knowledge base system, supporting document retrieval,
+ * provider abstractions, and sync reporting across knowledge sources.
+ */
+
+/**
+ * A document retrieved from a knowledge source
+ */
+export interface KnowledgeDocument {
+  /** Unique identifier for the document within its source */
+  id: string;
+  /** Human-readable title of the document */
+  title: string;
+  /** Full text content of the document */
+  content: string;
+  /** URL or URI pointing to the original document */
+  url: string;
+  /** Optional parent document ID for hierarchical sources */
+  parentId?: string;
+  /** Timestamp of last modification */
+  lastModified: Date;
+  /** Arbitrary source-specific metadata */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Options for listing documents from a knowledge source
+ */
+export interface ListOptions {
+  /** Maximum depth to traverse in hierarchical sources */
+  maxDepth?: number;
+  /** Optional filter string or pattern */
+  filter?: string;
+  /** Only return documents modified since this date */
+  modifiedSince?: Date;
+}
+
+/**
+ * Interface for knowledge source providers
+ *
+ * Implementations handle the specifics of each knowledge platform
+ * (Notion, Confluence, Google Docs, etc.)
+ */
+export interface KnowledgeSourceProvider {
+  /** Unique type identifier for this provider */
+  sourceType: string;
+  /** Human-readable name for this provider instance */
+  sourceName: string;
+
+  /**
+   * List all documents available from this source
+   * Returns an async iterable to support streaming large document sets
+   */
+  listDocuments(options?: ListOptions): AsyncIterable<KnowledgeDocument>;
+
+  /**
+   * Fetch a single document by its ID
+   */
+  fetchDocument(id: string): Promise<KnowledgeDocument>;
+
+  /**
+   * Get documents that have changed since a given date
+   */
+  getChangedSince(since: Date, options?: ListOptions): AsyncIterable<KnowledgeDocument>;
+}
+
+/**
+ * Configuration for a knowledge source connection
+ */
+export interface KnowledgeSourceConfig {
+  /** Human-readable name for this knowledge source */
+  name: string;
+  /** Provider type (determines which connector to use) */
+  type: "notion" | "confluence" | "google-docs";
+  /** Authentication credentials for the source */
+  auth: {
+    /** Environment variable containing the API token */
+    tokenEnvVar: string;
+    /** Optional environment variable for email (used by some providers) */
+    emailEnvVar?: string;
+  };
+  /** Optional sync configuration */
+  sync?: {
+    /** Cron schedule for automatic sync */
+    schedule?: "hourly" | "daily" | "weekly";
+    /** Maximum depth to traverse */
+    maxDepth?: number;
+    /** Glob patterns for pages/documents to exclude */
+    excludePatterns?: string[];
+  };
+}
+
+/**
+ * Report produced after a sync operation
+ */
+export interface SyncReport {
+  /** Name of the source that was synced */
+  sourceName: string;
+  /** Number of documents added */
+  added: number;
+  /** Number of documents updated */
+  updated: number;
+  /** Number of documents skipped (unchanged) */
+  skipped: number;
+  /** Number of documents removed */
+  removed: number;
+  /** Any errors encountered during sync */
+  errors: Array<{ documentId?: string; message: string }>;
+  /** Total duration in milliseconds */
+  duration: number;
+}

--- a/src/domain/storage/migrations/pg/0020_knowledge_embeddings.sql
+++ b/src/domain/storage/migrations/pg/0020_knowledge_embeddings.sql
@@ -1,0 +1,12 @@
+-- Create knowledge_embeddings table for storing document embeddings from knowledge sources
+CREATE TABLE IF NOT EXISTS "knowledge_embeddings" (
+	"document_id" text PRIMARY KEY NOT NULL,
+	"vector" vector(1536),
+	"metadata" jsonb,
+	"content_hash" text,
+	"indexed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_knowledge_embeddings_hnsw" ON "knowledge_embeddings" USING hnsw ("vector" vector_l2_ops);

--- a/src/domain/storage/migrations/pg/meta/_journal.json
+++ b/src/domain/storage/migrations/pg/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776412800000,
       "tag": "0017_task_relationship_types",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1745020800000,
+      "tag": "0020_knowledge_embeddings",
+      "breakpoints": true
     }
   ]
 }

--- a/src/domain/storage/schemas/knowledge-embeddings.ts
+++ b/src/domain/storage/schemas/knowledge-embeddings.ts
@@ -1,0 +1,19 @@
+import { createEmbeddingsTable } from "./embeddings-schema-factory";
+
+// Knowledge embeddings configuration following standardized patterns
+const KNOWLEDGE_EMBEDDINGS_CONFIG = {
+  tableName: "knowledge_embeddings",
+  idColumn: "document_id",
+  vectorColumn: "vector",
+  indexedAtColumn: "indexed_at",
+  // No domain-specific columns for now - use metadata JSONB for filtering
+  // domainColumns: {},
+};
+
+// Drizzle schema for knowledge embeddings (vectors only)
+// Uses standardized embeddings schema factory for consistency with tasks_embeddings and rules_embeddings
+// Uses metadata JSONB for filtering instead of separate domain columns
+export const knowledgeEmbeddingsTable = createEmbeddingsTable(KNOWLEDGE_EMBEDDINGS_CONFIG);
+
+// Export configuration for use in services
+export { KNOWLEDGE_EMBEDDINGS_CONFIG };


### PR DESCRIPTION
## Summary

- Add knowledge domain types (`src/domain/knowledge/types.ts`): `KnowledgeDocument`, `ListOptions`, `KnowledgeSourceProvider`, `KnowledgeSourceConfig`, `SyncReport`
- Add barrel export (`src/domain/knowledge/index.ts`)
- Add `knowledge_embeddings` Drizzle schema using `createEmbeddingsTable` factory (`src/domain/storage/schemas/knowledge-embeddings.ts`)
- Add database migration `0020_knowledge_embeddings.sql` creating the table and HNSW index; update `meta/_journal.json`
- Add `knowledgeBases` Zod config schema with `.passthrough()` for type-specific fields (`src/domain/configuration/schemas/knowledge-bases.ts`)
- Integrate `knowledgeBases` into root configuration schema (`src/domain/configuration/schemas/index.ts`)

## Test plan

- [ ] TypeScript typecheck passes (verified: 0 errors)
- [ ] Migration SQL is syntactically correct and consistent with other embeddings migrations
- [ ] `knowledgeBases` config schema validates entries with `notion`, `confluence`, and `google-docs` types
- [ ] `KnowledgeSourceProvider` interface covers async iteration for large document sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)