### PR TITLE
feat(mt#175): add tasks.decompose, tasks.estimate, tasks.analyze commands

### DIFF
--- a/src/adapters/shared/commands/tasks/context-commands.ts
+++ b/src/adapters/shared/commands/tasks/context-commands.ts
@@ -1,0 +1,188 @@
+/**
+ * Task Context Commands (decompose, estimate, analyze)
+ *
+ * Context-gathering MCP tools for AI-assisted task management.
+ * Each command gathers structured context and generates a prompt
+ * pairing context with intent. Works in both agent-present and
+ * standalone-future contexts.
+ */
+import { z } from "zod";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { PersistenceProvider } from "../../../../domain/persistence/types";
+import { type CommandParameterMap, type InferParams } from "../../command-registry";
+import {
+  type TaskContext,
+  type TaskPromptType,
+  generateDecomposePrompt,
+  generateEstimatePrompt,
+  generateAnalyzePrompt,
+} from "../../../../domain/tasks/task-prompt-generation";
+import { log } from "../../../../utils/logger";
+
+const taskContextParams = {
+  taskId: {
+    schema: z.string(),
+    description: "Task ID to gather context for",
+    required: true,
+  },
+  similarLimit: {
+    schema: z.number().default(5),
+    description: "Maximum number of similar tasks to include",
+    required: false,
+  },
+} satisfies CommandParameterMap;
+
+/**
+ * Gather full context for a task: spec, children, deps, similar tasks.
+ * Shared by all context commands.
+ */
+async function gatherTaskContext(
+  taskId: string,
+  similarLimit: number,
+  getPersistenceProvider: () => PersistenceProvider
+): Promise<TaskContext> {
+  const persistence = getPersistenceProvider();
+
+  // Get task details
+  const { createConfiguredTaskService } = await import("../../../../domain/tasks/taskService");
+  const taskService = await createConfiguredTaskService({
+    workspacePath: process.cwd(),
+    persistenceProvider: persistence,
+  });
+
+  const task = await taskService.getTask(taskId);
+  const title = task?.title ?? "(unknown)";
+  const status = task?.status ?? "UNKNOWN";
+
+  // Get spec
+  let spec: string | undefined;
+  try {
+    const { getTaskSpecContentFromParams } = await import(
+      "../../../../domain/tasks/commands/query-commands"
+    );
+    const specResult = await getTaskSpecContentFromParams({
+      taskId,
+      workspace: process.cwd(),
+    });
+    spec = specResult.content;
+  } catch {
+    // Spec not available
+  }
+
+  // Get graph info (children, deps, parent)
+  const children: TaskContext["children"] = [];
+  let dependencies: string[] = [];
+  let dependents: string[] = [];
+  let parent: string | undefined;
+
+  const hasSql = persistence.capabilities.sql;
+  if (hasSql) {
+    const db = (await persistence.getDatabaseConnection?.()) as PostgresJsDatabase;
+    const { TaskGraphService } = await import("../../../../domain/tasks/task-graph-service");
+    const service = new TaskGraphService(db);
+
+    // Children
+    const childIds = await service.listChildren(taskId);
+    for (const childId of childIds) {
+      try {
+        const childTask = await taskService.getTask(childId);
+        children.push({
+          id: childId,
+          title: childTask?.title ?? "(unknown)",
+          status: childTask?.status ?? "UNKNOWN",
+        });
+      } catch {
+        children.push({ id: childId, title: "(unknown)", status: "UNKNOWN" });
+      }
+    }
+
+    // Dependencies and dependents
+    dependencies = await service.listDependencies(taskId);
+    dependents = await service.listDependents(taskId);
+
+    // Parent
+    parent = (await service.getParent(taskId)) ?? undefined;
+  }
+
+  // Similar tasks — skipped in context gathering (requires DI-wired
+  // TaskSimilarityService). The generated prompt directs the agent to
+  // call tasks_similar separately if needed.
+  const similarTasks: TaskContext["similarTasks"] = [];
+
+  return {
+    taskId,
+    title,
+    status,
+    spec,
+    children,
+    dependencies,
+    dependents,
+    parent,
+    similarTasks,
+  };
+}
+
+function createContextCommand(
+  type: TaskPromptType,
+  description: string,
+  getPersistenceProvider: () => PersistenceProvider
+) {
+  return {
+    id: `tasks.${type}`,
+    name: type,
+    description,
+    parameters: taskContextParams,
+    execute: async (params: InferParams<typeof taskContextParams>) => {
+      const taskId = params.taskId as string;
+      const similarLimit = (params.similarLimit as number) ?? 5;
+
+      log.debug(`[tasks.${type}] Gathering context`, { taskId });
+
+      const context = await gatherTaskContext(taskId, similarLimit, getPersistenceProvider);
+
+      const generators = {
+        decompose: generateDecomposePrompt,
+        estimate: generateEstimatePrompt,
+        analyze: generateAnalyzePrompt,
+      };
+
+      const result = generators[type](context);
+
+      log.debug(`[tasks.${type}] Prompt generated`, {
+        taskId,
+        promptLength: result.prompt.length,
+        childrenCount: context.children.length,
+        similarCount: context.similarTasks.length,
+      });
+
+      return {
+        success: true,
+        ...result,
+      };
+    },
+  };
+}
+
+export function createTasksDecomposeCommand(getPersistenceProvider: () => PersistenceProvider) {
+  return createContextCommand(
+    "decompose",
+    "Gather task context and generate a decomposition prompt for creating subtasks",
+    getPersistenceProvider
+  );
+}
+
+export function createTasksEstimateCommand(getPersistenceProvider: () => PersistenceProvider) {
+  return createContextCommand(
+    "estimate",
+    "Gather task context and generate an estimation prompt for complexity/effort",
+    getPersistenceProvider
+  );
+}
+
+export function createTasksAnalyzeCommand(getPersistenceProvider: () => PersistenceProvider) {
+  return createContextCommand(
+    "analyze",
+    "Gather task context and generate an analysis prompt for spec completeness and readiness",
+    getPersistenceProvider
+  );
+}

--- a/src/adapters/shared/commands/tasks/registry-setup.ts
+++ b/src/adapters/shared/commands/tasks/registry-setup.ts
@@ -68,6 +68,11 @@ export function createAllTaskCommands(container?: AppContainerInterface) {
   const { createTasksAvailableCommand, createTasksRouteCommand } = require("./routing-commands");
   const { createTasksDispatchCommand } = require("./dispatch-command");
   const { createTasksOrchestrateCommand } = require("./orchestrate-command");
+  const {
+    createTasksDecomposeCommand,
+    createTasksEstimateCommand,
+    createTasksAnalyzeCommand,
+  } = require("./context-commands");
 
   return [
     createTasksStatusGetCommand(getPersistenceProvider),
@@ -100,5 +105,9 @@ export function createAllTaskCommands(container?: AppContainerInterface) {
     createTasksDispatchCommand(getPersistenceProvider, getSessionProvider),
     // Orchestrate (find dispatchable subtasks for a parent)
     createTasksOrchestrateCommand(getPersistenceProvider),
+    // Context commands (decompose, estimate, analyze)
+    createTasksDecomposeCommand(getPersistenceProvider),
+    createTasksEstimateCommand(getPersistenceProvider),
+    createTasksAnalyzeCommand(getPersistenceProvider),
   ];
 }

--- a/src/domain/tasks/task-prompt-generation.ts
+++ b/src/domain/tasks/task-prompt-generation.ts
@@ -1,0 +1,218 @@
+/**
+ * Task Prompt Generation
+ *
+ * Generates context-rich prompts for AI-assisted task operations.
+ * Follows the session/prompt-generation.ts pattern: gather context,
+ * pair it with intent, return a prompt that works whether executed
+ * by an agent harness or Minsky's own agent loop.
+ */
+
+export type TaskPromptType = "decompose" | "estimate" | "analyze";
+
+export interface TaskContext {
+  taskId: string;
+  title: string;
+  status: string;
+  spec?: string;
+  children: Array<{ id: string; title: string; status: string }>;
+  dependencies: string[];
+  dependents: string[];
+  parent?: string;
+  similarTasks: Array<{ id: string; title: string; status: string; score: number }>;
+}
+
+export interface TaskPromptResult {
+  context: TaskContext;
+  prompt: string;
+  suggestedModel: string;
+  promptType: TaskPromptType;
+}
+
+export const TASK_PROMPT_WATERMARK = "<!-- minsky:task-prompt:v1 -->";
+
+function renderContext(ctx: TaskContext): string {
+  const sections: string[] = [];
+
+  sections.push(`## Task: ${ctx.taskId}`);
+  sections.push(`**Title:** ${ctx.title}`);
+  sections.push(`**Status:** ${ctx.status}`);
+  if (ctx.parent) {
+    sections.push(`**Parent:** ${ctx.parent}`);
+  }
+
+  if (ctx.spec) {
+    sections.push("");
+    sections.push("### Specification");
+    sections.push(ctx.spec);
+  } else {
+    sections.push("");
+    sections.push("### Specification");
+    sections.push("*(No spec content available)*");
+  }
+
+  if (ctx.children.length > 0) {
+    sections.push("");
+    sections.push("### Existing Subtasks");
+    for (const child of ctx.children) {
+      sections.push(`- ${child.id}: ${child.title} [${child.status}]`);
+    }
+  }
+
+  if (ctx.dependencies.length > 0) {
+    sections.push("");
+    sections.push(`### Dependencies (${ctx.taskId} depends on)`);
+    sections.push(ctx.dependencies.map((d) => `- ${d}`).join("\n"));
+  }
+
+  if (ctx.dependents.length > 0) {
+    sections.push("");
+    sections.push(`### Dependents (depend on ${ctx.taskId})`);
+    sections.push(ctx.dependents.map((d) => `- ${d}`).join("\n"));
+  }
+
+  if (ctx.similarTasks.length > 0) {
+    sections.push("");
+    sections.push("### Similar Tasks (for reference)");
+    for (const sim of ctx.similarTasks) {
+      sections.push(`- ${sim.id}: ${sim.title} [${sim.status}]`);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+export function generateDecomposePrompt(ctx: TaskContext): TaskPromptResult {
+  const contextText = renderContext(ctx);
+
+  const prompt = `# Task Decomposition
+
+${contextText}
+
+## Intent
+
+Decompose this task into subtasks. Each subtask should be:
+- A concrete, independently implementable piece of work
+- Small enough for one session/PR (aim for 2-4 hours each)
+- Clearly scoped with its own success criteria
+
+${ctx.children.length > 0 ? `This task already has ${ctx.children.length} subtask(s). Review them and determine if additional decomposition is needed, or if existing subtasks need refinement.` : "This task has no subtasks yet."}
+
+## How to Create Subtasks
+
+For each subtask, use:
+\`\`\`
+mcp__minsky__tasks_create(
+  title: "<subtask title>",
+  parent: "${ctx.taskId}",
+  spec: "<brief spec with success criteria>"
+)
+\`\`\`
+
+After creating subtasks, add dependency edges between them if ordering matters:
+\`\`\`
+mcp__minsky__tasks_deps_add(task: "<later-task>", dependsOn: "<earlier-task>")
+\`\`\`
+
+## Guidelines
+
+- Name subtasks by deliverable, not by activity ("Add parent-child edges" not "Work on graph")
+- Each subtask should be testable — include success criteria in the spec
+- Consider: what can be parallelized? What must be sequential?
+- If the task spec is vague, note what needs clarification before decomposing
+- For reference, find similar completed tasks: \`mcp__minsky__tasks_similar(taskId: "${ctx.taskId}")\`
+
+${TASK_PROMPT_WATERMARK}`;
+
+  return {
+    context: ctx,
+    prompt,
+    suggestedModel: "opus",
+    promptType: "decompose",
+  };
+}
+
+export function generateEstimatePrompt(ctx: TaskContext): TaskPromptResult {
+  const contextText = renderContext(ctx);
+
+  const prompt = `# Task Estimation
+
+${contextText}
+
+## Intent
+
+Estimate the complexity and effort for this task.
+
+## Framework
+
+Rate on this scale:
+- **XS** (< 1 hour): Single-file change, mechanical fix
+- **S** (1-2 hours): Small feature, 2-3 files, clear approach
+- **M** (2-4 hours): Multi-file change, some design decisions
+- **L** (4-8 hours): Significant feature, needs decomposition if not already done
+- **XL** (8+ hours): Major effort, should definitely be decomposed into subtasks
+
+## Consider
+
+- How many files will be touched?
+- Are there design decisions to make, or is the approach clear?
+- Are there dependencies that need to be resolved first?
+- How similar is this to the reference tasks listed above?
+${ctx.children.length > 0 ? `- This task has ${ctx.children.length} subtask(s) — estimate the remaining work, not the total.` : ""}
+
+Provide your estimate with a brief rationale.
+
+${TASK_PROMPT_WATERMARK}`;
+
+  return {
+    context: ctx,
+    prompt,
+    suggestedModel: "sonnet",
+    promptType: "estimate",
+  };
+}
+
+export function generateAnalyzePrompt(ctx: TaskContext): TaskPromptResult {
+  const contextText = renderContext(ctx);
+
+  const hasSpec = !!ctx.spec;
+  const specLength = ctx.spec?.length ?? 0;
+  const hasSuccessCriteria = ctx.spec?.includes("Success Criteria") ?? false;
+  const hasAcceptanceTests = ctx.spec?.includes("Acceptance Test") ?? false;
+  const hasScope = ctx.spec?.includes("Scope") ?? false;
+
+  const prompt = `# Task Analysis
+
+${contextText}
+
+## Intent
+
+Analyze this task for completeness, readiness, and potential issues.
+
+## Spec Quality Check
+
+| Section | Present |
+|---|---|
+| Spec content | ${hasSpec ? `Yes (${specLength} chars)` : "**MISSING**"} |
+| Success Criteria | ${hasSuccessCriteria ? "Yes" : "**MISSING**"} |
+| Acceptance Tests | ${hasAcceptanceTests ? "Yes" : "**MISSING**"} |
+| Scope | ${hasScope ? "Yes" : "**MISSING**"} |
+
+## Analyze For
+
+1. **Completeness** — Is the spec detailed enough to implement without ambiguity?
+2. **Staleness** — Does the spec reference files, APIs, or patterns that no longer exist?
+3. **Readiness** — Are all dependencies met? Are there unstated prerequisites?
+4. **Scope** — Is the task appropriately sized? Should it be decomposed?
+5. **Risk** — What could go wrong? Are there edge cases the spec doesn't address?
+
+Provide your analysis with specific findings and recommendations.
+
+${TASK_PROMPT_WATERMARK}`;
+
+  return {
+    context: ctx,
+    prompt,
+    suggestedModel: "sonnet",
+    promptType: "analyze",
+  };
+}


### PR DESCRIPTION
## Summary

Context-gathering MCP tools for AI-assisted task management. Each command gathers structured context (spec, subtask tree, dependency graph) and generates a prompt pairing context with intent.

Follows the `session.generate_prompt` pattern: the tool provides structure and context, the intelligence comes from whoever executes the prompt — whether that's an agent harness (Claude Code, Cursor) or Minsky's own future agent loop (mt#216/mt#441).

### New commands

- **`tasks.decompose`** — Gathers task context + generates a decomposition prompt with `tasks_create --parent` instructions
- **`tasks.estimate`** — Gathers task context + generates an estimation prompt (XS/S/M/L/XL framework)
- **`tasks.analyze`** — Gathers task context + generates an analysis prompt (completeness, staleness, readiness)

### Architecture

```
tasks.decompose(taskId: "mt#441")
  → gathers: spec, children, deps, parent
  → generates: prompt with decomposition intent + MCP tool calls
  → returns: { context, prompt, suggestedModel }
```

The prompt is the interface contract between context and intelligence. It works in both directions.

### New files

- `src/domain/tasks/task-prompt-generation.ts` — Prompt generators (decompose/estimate/analyze)
- `src/adapters/shared/commands/tasks/context-commands.ts` — Shared context gathering + command factories

## Spec verification

**Task:** mt#175

| Criterion | Status | Evidence |
|---|---|---|
| tasks.decompose gathers context + generates prompt | Met | context-commands.ts + task-prompt-generation.ts |
| tasks.estimate gathers context + generates prompt | Met | Same architecture |
| tasks.analyze gathers context + generates prompt | Met | Same, with spec quality check table |
| Returns { context, prompt, suggestedModel } | Met | TaskPromptResult interface |
| Prompts include MCP tool calls | Met | Decompose prompt includes tasks_create --parent |
| Works for agent-present and standalone-future | Met | Prompt is the interface contract |

🤖 Generated with [Claude Code](https://claude.com/claude-code)