### PR TITLE
feat(mt#903): implement NotionKnowledgeProvider with block rendering and tests

### DIFF
--- a/src/domain/knowledge/providers/notion-provider.test.ts
+++ b/src/domain/knowledge/providers/notion-provider.test.ts
@@ -1,0 +1,700 @@
+import { describe, it, expect } from "bun:test";
+import { NotionKnowledgeProvider } from "./notion-provider";
+import type { FetchFn } from "./notion-provider";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makePage(
+  id: string,
+  title: string,
+  parentId?: string,
+  lastEdited?: string
+): Record<string, unknown> {
+  return {
+    id,
+    object: "page",
+    url: `https://www.notion.so/${id.replace(/-/g, "")}`,
+    last_edited_time: lastEdited ?? "2024-01-01T00:00:00.000Z",
+    created_time: "2024-01-01T00:00:00.000Z",
+    parent: parentId
+      ? { type: "page_id", page_id: parentId }
+      : { type: "workspace", workspace: true },
+    properties: {
+      title: {
+        type: "title",
+        title: [{ type: "text", plain_text: title, annotations: {} }],
+      },
+    },
+  };
+}
+
+function makeChildPageBlock(id: string, title: string): Record<string, unknown> {
+  return { id, type: "child_page", child_page: { title }, has_children: true };
+}
+
+function makeParagraphBlock(text: string): Record<string, unknown> {
+  return {
+    id: `para-${text.slice(0, 8)}`,
+    type: "paragraph",
+    paragraph: {
+      rich_text: [{ type: "text", plain_text: text, annotations: {}, href: null }],
+    },
+    has_children: false,
+  };
+}
+
+function makeBlocksResponse(
+  blocks: unknown[],
+  hasMore = false,
+  nextCursor: string | null = null
+): Record<string, unknown> {
+  return { object: "list", results: blocks, has_more: hasMore, next_cursor: nextCursor };
+}
+
+/**
+ * Build a simple fetch mock that routes by URL pattern.
+ * Routes is an array of [pattern, responseBody] where pattern is a string match.
+ * Responses are returned as 200 OK JSON.
+ */
+function buildFetchMock(
+  routes: Array<{ match: (url: string, body?: string) => boolean; response: unknown }>
+): FetchFn {
+  return async (url: string, init?: RequestInit): Promise<Response> => {
+    const bodyStr = typeof init?.body === "string" ? init.body : undefined;
+    for (const route of routes) {
+      if (route.match(url, bodyStr)) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return route.response;
+          },
+          async text() {
+            return JSON.stringify(route.response);
+          },
+          headers: new Headers(),
+        } as Response;
+      }
+    }
+    throw new Error(`Unmocked fetch: ${url}`);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: fetchDocument
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider.fetchDocument", () => {
+  it("fetches a single page and returns a KnowledgeDocument", async () => {
+    const pageId = "page-001";
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${pageId}`),
+        response: makePage(pageId, "My Page"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${pageId}/children`),
+        response: makeBlocksResponse([makeParagraphBlock("Hello world")]),
+      },
+    ]);
+
+    const provider = new NotionKnowledgeProvider("root-id", "test-token", "test-source", {
+      fetch: fetchMock,
+    });
+    const doc = await provider.fetchDocument(pageId);
+
+    expect(doc.id).toBe(pageId);
+    expect(doc.title).toBe("My Page");
+    expect(doc.content).toContain("Hello world");
+    expect(doc.url).toContain(pageId.replace(/-/g, ""));
+    expect(doc.lastModified).toBeInstanceOf(Date);
+    expect(doc.metadata["sourceType"]).toBe("notion");
+    expect(doc.metadata["sourceName"]).toBe("test-source");
+  });
+
+  it("sets parentId when page has a page parent", async () => {
+    const pageId = "child-page";
+    const parentPageId = "parent-page";
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${pageId}`),
+        response: makePage(pageId, "Child", parentPageId),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${pageId}/children`),
+        response: makeBlocksResponse([]),
+      },
+    ]);
+
+    const provider = new NotionKnowledgeProvider("root-id", "test-token", "test-source", {
+      fetch: fetchMock,
+    });
+    const doc = await provider.fetchDocument(pageId);
+
+    expect(doc.parentId).toBe(parentPageId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: listDocuments - tree traversal
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider.listDocuments", () => {
+  it("yields root page and child pages", async () => {
+    const rootId = "root";
+    const child1Id = "child-1";
+
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${rootId}`),
+        response: makePage(rootId, "Root Page"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${rootId}/children`),
+        response: makeBlocksResponse([
+          makeParagraphBlock("Root content"),
+          makeChildPageBlock(child1Id, "Child 1"),
+        ]),
+      },
+      {
+        match: (url) => url.includes(`/pages/${child1Id}`),
+        response: makePage(child1Id, "Child 1", rootId),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${child1Id}/children`),
+        response: makeBlocksResponse([makeParagraphBlock("Child content")]),
+      },
+    ]);
+
+    const provider = new NotionKnowledgeProvider(rootId, "test-token", "test-source", {
+      fetch: fetchMock,
+    });
+
+    const docs: Array<{ id: string; title: string }> = [];
+    for await (const doc of provider.listDocuments()) {
+      docs.push({ id: doc.id, title: doc.title });
+    }
+
+    expect(docs).toHaveLength(2);
+    expect(docs[0]?.title).toBe("Root Page");
+    expect(docs[1]?.title).toBe("Child 1");
+  });
+
+  it("respects maxDepth option — stops recursion at depth 0", async () => {
+    const rootId = "root";
+    const child1Id = "child-1";
+
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${rootId}`),
+        response: makePage(rootId, "Root Page"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${rootId}/children`),
+        response: makeBlocksResponse([makeChildPageBlock(child1Id, "Child 1")]),
+      },
+      // child pages should NOT be requested at depth 0
+    ]);
+
+    const provider = new NotionKnowledgeProvider(rootId, "test-token", "test-source", {
+      fetch: fetchMock,
+    });
+
+    const docs: string[] = [];
+    for await (const doc of provider.listDocuments({ maxDepth: 0 })) {
+      docs.push(doc.id);
+    }
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0]).toBe(rootId);
+  });
+
+  it("respects maxDepth — traverses exactly one level deep at depth 1", async () => {
+    const rootId = "root";
+    const child1Id = "child-1";
+    const grandchildId = "grandchild-1";
+
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${rootId}`),
+        response: makePage(rootId, "Root"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${rootId}/children`),
+        response: makeBlocksResponse([makeChildPageBlock(child1Id, "Child")]),
+      },
+      {
+        match: (url) => url.includes(`/pages/${child1Id}`),
+        response: makePage(child1Id, "Child", rootId),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${child1Id}/children`),
+        response: makeBlocksResponse([makeChildPageBlock(grandchildId, "Grandchild")]),
+      },
+      // grandchild should NOT be requested
+    ]);
+
+    const provider = new NotionKnowledgeProvider(rootId, "test-token", "test-source", {
+      fetch: fetchMock,
+    });
+
+    const docs: string[] = [];
+    for await (const doc of provider.listDocuments({ maxDepth: 1 })) {
+      docs.push(doc.id);
+    }
+
+    expect(docs).toHaveLength(2);
+    expect(docs).toContain(rootId);
+    expect(docs).toContain(child1Id);
+    expect(docs).not.toContain(grandchildId);
+  });
+
+  it("filters out pages matching excludePatterns", async () => {
+    const rootId = "root";
+    const child1Id = "draft-page";
+    const child2Id = "real-page";
+
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${rootId}`),
+        response: makePage(rootId, "Root"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${rootId}/children`),
+        response: makeBlocksResponse([
+          makeChildPageBlock(child1Id, "Draft Page"),
+          makeChildPageBlock(child2Id, "Real Page"),
+        ]),
+      },
+      {
+        match: (url) => url.includes(`/pages/${child1Id}`),
+        response: makePage(child1Id, "Draft Page", rootId),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${child1Id}/children`),
+        response: makeBlocksResponse([]),
+      },
+      {
+        match: (url) => url.includes(`/pages/${child2Id}`),
+        response: makePage(child2Id, "Real Page", rootId),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${child2Id}/children`),
+        response: makeBlocksResponse([]),
+      },
+    ]);
+
+    const provider = new NotionKnowledgeProvider(rootId, "test-token", "test-source", {
+      excludePatterns: ["Draft*"],
+      fetch: fetchMock,
+    });
+
+    const docs: string[] = [];
+    for await (const doc of provider.listDocuments()) {
+      docs.push(doc.title);
+    }
+
+    expect(docs).not.toContain("Draft Page");
+    expect(docs).toContain("Real Page");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: block rendering
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider block rendering", () => {
+  async function renderBlocks(blocks: unknown[]): Promise<string> {
+    const pageId = "test-page";
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes(`/pages/${pageId}`),
+        response: makePage(pageId, "Test Page"),
+      },
+      {
+        match: (url) => url.includes(`/blocks/${pageId}/children`),
+        response: makeBlocksResponse(blocks),
+      },
+    ]);
+    const provider = new NotionKnowledgeProvider("root", "token", "test", {
+      fetch: fetchMock,
+    });
+    const doc = await provider.fetchDocument(pageId);
+    return doc.content;
+  }
+
+  it("renders paragraph blocks", async () => {
+    const content = await renderBlocks([makeParagraphBlock("Hello world")]);
+    expect(content).toBe("Hello world");
+  });
+
+  it("renders heading blocks", async () => {
+    const makeHeading = (level: 1 | 2 | 3, text: string) => ({
+      id: `h${level}`,
+      type: `heading_${level}`,
+      [`heading_${level}`]: {
+        rich_text: [{ type: "text", plain_text: text, annotations: {}, href: null }],
+      },
+    });
+
+    const content = await renderBlocks([
+      makeHeading(1, "Title"),
+      makeHeading(2, "Subtitle"),
+      makeHeading(3, "Section"),
+    ]);
+    expect(content).toContain("# Title");
+    expect(content).toContain("## Subtitle");
+    expect(content).toContain("### Section");
+  });
+
+  it("renders bulleted list items", async () => {
+    const makeItem = (text: string) => ({
+      id: `item-${text}`,
+      type: "bulleted_list_item",
+      bulleted_list_item: {
+        rich_text: [{ type: "text", plain_text: text, annotations: {}, href: null }],
+      },
+    });
+    const content = await renderBlocks([makeItem("First"), makeItem("Second")]);
+    expect(content).toContain("- First");
+    expect(content).toContain("- Second");
+  });
+
+  it("renders numbered list items with sequential numbers", async () => {
+    const makeItem = (text: string) => ({
+      id: `item-${text}`,
+      type: "numbered_list_item",
+      numbered_list_item: {
+        rich_text: [{ type: "text", plain_text: text, annotations: {}, href: null }],
+      },
+    });
+    const content = await renderBlocks([makeItem("First"), makeItem("Second")]);
+    expect(content).toContain("1. First");
+    expect(content).toContain("2. Second");
+  });
+
+  it("renders code blocks with language", async () => {
+    const codeBlock = {
+      id: "code-1",
+      type: "code",
+      code: {
+        language: "typescript",
+        rich_text: [{ type: "text", plain_text: "const x = 1;", annotations: {}, href: null }],
+      },
+    };
+    const content = await renderBlocks([codeBlock]);
+    expect(content).toContain("```typescript");
+    expect(content).toContain("const x = 1;");
+    expect(content).toContain("```");
+  });
+
+  it("renders quote blocks", async () => {
+    const quoteBlock = {
+      id: "quote-1",
+      type: "quote",
+      quote: {
+        rich_text: [
+          { type: "text", plain_text: "To be or not to be", annotations: {}, href: null },
+        ],
+      },
+    };
+    const content = await renderBlocks([quoteBlock]);
+    expect(content).toContain("> To be or not to be");
+  });
+
+  it("renders callout blocks with emoji icon", async () => {
+    const calloutBlock = {
+      id: "callout-1",
+      type: "callout",
+      callout: {
+        icon: { type: "emoji", emoji: "💡" },
+        rich_text: [{ type: "text", plain_text: "Important note", annotations: {}, href: null }],
+      },
+    };
+    const content = await renderBlocks([calloutBlock]);
+    expect(content).toContain("> 💡 Important note");
+  });
+
+  it("renders divider blocks", async () => {
+    const dividerBlock = { id: "div-1", type: "divider", divider: {} };
+    const content = await renderBlocks([dividerBlock]);
+    expect(content).toContain("---");
+  });
+
+  it("renders unsupported blocks with placeholder", async () => {
+    const unknownBlock = { id: "unk-1", type: "embed", embed: { url: "https://example.com" } };
+    const content = await renderBlocks([unknownBlock]);
+    expect(content).toContain("[Unsupported: embed]");
+  });
+
+  it("renders inline bold, italic, code, strikethrough formatting", async () => {
+    const paragraphWithFormatting = {
+      id: "para-fmt",
+      type: "paragraph",
+      paragraph: {
+        rich_text: [
+          {
+            type: "text",
+            plain_text: "bold",
+            annotations: { bold: true, italic: false, code: false, strikethrough: false },
+            href: null,
+          },
+          {
+            type: "text",
+            plain_text: " italic",
+            annotations: { bold: false, italic: true, code: false, strikethrough: false },
+            href: null,
+          },
+          {
+            type: "text",
+            plain_text: " code",
+            annotations: { bold: false, italic: false, code: true, strikethrough: false },
+            href: null,
+          },
+          {
+            type: "text",
+            plain_text: " strike",
+            annotations: { bold: false, italic: false, code: false, strikethrough: true },
+            href: null,
+          },
+        ],
+      },
+    };
+    const content = await renderBlocks([paragraphWithFormatting]);
+    expect(content).toContain("**bold**");
+    expect(content).toContain("* italic*");
+    expect(content).toContain("` code`");
+    expect(content).toContain("~~ strike~~");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: pagination handling
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider pagination", () => {
+  it("fetches all pages when has_more is true", async () => {
+    const pageId = "paged-page";
+    let callCount = 0;
+
+    const fetchFn: FetchFn = async (url: string): Promise<Response> => {
+      if (url.includes(`/pages/${pageId}`)) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return makePage(pageId, "Paged Page");
+          },
+          async text() {
+            return JSON.stringify(makePage(pageId, "Paged Page"));
+          },
+          headers: new Headers(),
+        } as Response;
+      }
+
+      if (url.includes(`/blocks/${pageId}/children`)) {
+        callCount++;
+        const isFirstPage = !url.includes("start_cursor");
+        if (isFirstPage) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return makeBlocksResponse([makeParagraphBlock("Page 1 content")], true, "cursor-abc");
+            },
+            async text() {
+              return "";
+            },
+            headers: new Headers(),
+          } as Response;
+        } else {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            async json() {
+              return makeBlocksResponse([makeParagraphBlock("Page 2 content")], false, null);
+            },
+            async text() {
+              return "";
+            },
+            headers: new Headers(),
+          } as Response;
+        }
+      }
+
+      throw new Error(`Unmocked: ${url}`);
+    };
+
+    const provider = new NotionKnowledgeProvider("root", "token", "test", { fetch: fetchFn });
+    const doc = await provider.fetchDocument(pageId);
+
+    expect(callCount).toBe(2);
+    expect(doc.content).toContain("Page 1 content");
+    expect(doc.content).toContain("Page 2 content");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: getChangedSince date filtering
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider.getChangedSince", () => {
+  it("yields only documents modified after the given date", async () => {
+    const recentPageId = "recent-page";
+    const oldPageId = "old-page";
+    const since = new Date("2024-06-01T00:00:00Z");
+
+    const searchResponse = {
+      object: "list",
+      results: [
+        {
+          ...makePage(recentPageId, "Recent Page"),
+          last_edited_time: "2024-07-01T00:00:00.000Z",
+        },
+        {
+          ...makePage(oldPageId, "Old Page"),
+          last_edited_time: "2024-05-01T00:00:00.000Z",
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    };
+
+    const fetchMock = buildFetchMock([
+      {
+        match: (url) => url.includes("/search"),
+        response: searchResponse,
+      },
+      {
+        match: (url) => url.includes(`/pages/${recentPageId}`),
+        response: {
+          ...makePage(recentPageId, "Recent Page"),
+          last_edited_time: "2024-07-01T00:00:00.000Z",
+        },
+      },
+      {
+        match: (url) => url.includes(`/blocks/${recentPageId}/children`),
+        response: makeBlocksResponse([makeParagraphBlock("Recent content")]),
+      },
+    ]);
+
+    const provider = new NotionKnowledgeProvider("root", "token", "test", { fetch: fetchMock });
+
+    const docs: string[] = [];
+    for await (const doc of provider.getChangedSince(since)) {
+      docs.push(doc.id);
+    }
+
+    expect(docs).toContain(recentPageId);
+    expect(docs).not.toContain(oldPageId);
+  });
+
+  it("stops iterating when result timestamp is not newer than since", async () => {
+    const since = new Date("2024-06-01T00:00:00Z");
+    let fetchCallCount = 0;
+
+    const searchResponse = {
+      object: "list",
+      results: [
+        // All results are older than since — should stop after seeing first
+        {
+          ...makePage("old-1", "Old 1"),
+          last_edited_time: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    };
+
+    const fetchFn: FetchFn = async (url: string): Promise<Response> => {
+      fetchCallCount++;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        async json() {
+          return searchResponse;
+        },
+        async text() {
+          return "";
+        },
+        headers: new Headers(),
+      } as Response;
+    };
+
+    const provider = new NotionKnowledgeProvider("root", "token", "test", { fetch: fetchFn });
+
+    const docs: string[] = [];
+    for await (const doc of provider.getChangedSince(since)) {
+      docs.push(doc.id);
+    }
+
+    // No pages should be yielded
+    expect(docs).toHaveLength(0);
+    // Only one fetch for the search call
+    expect(fetchCallCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: rate limiting
+// ---------------------------------------------------------------------------
+
+describe("NotionKnowledgeProvider rate limiting", () => {
+  it("spaces out requests to avoid exceeding 3 req/sec", async () => {
+    const pageId = "rate-test-page";
+    const callTimes: number[] = [];
+
+    const fetchFn: FetchFn = async (url: string): Promise<Response> => {
+      callTimes.push(Date.now());
+
+      if (url.includes(`/pages/${pageId}`)) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return makePage(pageId, "Rate Test Page");
+          },
+          async text() {
+            return "";
+          },
+          headers: new Headers(),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        async json() {
+          return makeBlocksResponse([]);
+        },
+        async text() {
+          return "";
+        },
+        headers: new Headers(),
+      } as Response;
+    };
+
+    const provider = new NotionKnowledgeProvider("root", "token", "test", { fetch: fetchFn });
+
+    await provider.fetchDocument(pageId);
+
+    // fetchDocument makes 2 requests (page + blocks)
+    // With rate limiting at 3 req/sec (333ms interval), 2 requests should take ~333ms
+    expect(callTimes).toHaveLength(2);
+    // At minimum, the second request should be delayed
+    if (callTimes.length >= 2) {
+      const gap = (callTimes[1] ?? 0) - (callTimes[0] ?? 0);
+      // Should be at least ~300ms (rate limiter minimum interval)
+      expect(gap).toBeGreaterThanOrEqual(300);
+    }
+  });
+});

--- a/src/domain/knowledge/providers/notion-provider.ts
+++ b/src/domain/knowledge/providers/notion-provider.ts
@@ -1,0 +1,509 @@
+/**
+ * Notion Knowledge Provider
+ *
+ * Implements KnowledgeSourceProvider for Notion, connecting to the Notion API
+ * to retrieve pages and their content as KnowledgeDocuments.
+ */
+
+import type { KnowledgeDocument, KnowledgeSourceProvider, ListOptions } from "../types";
+
+// Notion API version
+const NOTION_API_VERSION = "2022-06-28";
+const NOTION_API_BASE = "https://api.notion.com/v1";
+
+// Rate limit: Notion allows 3 requests/second
+const REQUESTS_PER_SECOND = 3;
+const MIN_REQUEST_INTERVAL_MS = Math.ceil(1000 / REQUESTS_PER_SECOND);
+
+// ---------------------------------------------------------------------------
+// Notion API response shapes
+// ---------------------------------------------------------------------------
+
+interface NotionRichText {
+  type: string;
+  plain_text: string;
+  href?: string | null;
+  annotations?: {
+    bold?: boolean;
+    italic?: boolean;
+    strikethrough?: boolean;
+    code?: boolean;
+    underline?: boolean;
+  };
+  text?: { content: string; link?: { url: string } | null };
+}
+
+interface NotionPageTitleProperty {
+  type: "title";
+  title: NotionRichText[];
+}
+
+interface NotionPage {
+  id: string;
+  object: "page";
+  url: string;
+  last_edited_time: string;
+  created_time: string;
+  parent?: {
+    type: string;
+    page_id?: string;
+    database_id?: string;
+    block_id?: string;
+  };
+  properties?: Record<string, { type: string; title?: NotionRichText[] }>;
+}
+
+interface NotionBlock {
+  id: string;
+  type: string;
+  has_children?: boolean;
+  // Typed property access for known block types
+  paragraph?: { rich_text: NotionRichText[]; color?: string };
+  heading_1?: { rich_text: NotionRichText[]; color?: string };
+  heading_2?: { rich_text: NotionRichText[]; color?: string };
+  heading_3?: { rich_text: NotionRichText[]; color?: string };
+  bulleted_list_item?: { rich_text: NotionRichText[] };
+  numbered_list_item?: { rich_text: NotionRichText[] };
+  code?: { rich_text: NotionRichText[]; language?: string };
+  quote?: { rich_text: NotionRichText[] };
+  callout?: { rich_text: NotionRichText[]; icon?: { type: string; emoji?: string } };
+  divider?: Record<string, never>;
+  toggle?: { rich_text: NotionRichText[] };
+  table?: { table_width: number; has_column_header: boolean; has_row_header: boolean };
+  table_row?: { cells: NotionRichText[][] };
+  child_page?: { title: string };
+  [key: string]: unknown;
+}
+
+interface NotionBlocksResponse {
+  results: NotionBlock[];
+  has_more: boolean;
+  next_cursor?: string | null;
+}
+
+interface NotionSearchResponse {
+  results: NotionPage[];
+  has_more: boolean;
+  next_cursor?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch function type for DI
+// ---------------------------------------------------------------------------
+
+export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+// ---------------------------------------------------------------------------
+// Simple token-bucket rate limiter
+// ---------------------------------------------------------------------------
+
+class RateLimiter {
+  private lastRequestTime = 0;
+
+  async throttle(): Promise<void> {
+    const now = Date.now();
+    const elapsed = now - this.lastRequestTime;
+    if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+      const delay = MIN_REQUEST_INTERVAL_MS - elapsed;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+    this.lastRequestTime = Date.now();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Block rendering helpers
+// ---------------------------------------------------------------------------
+
+function renderInlineFormatting(richText: NotionRichText[]): string {
+  return richText
+    .map((rt) => {
+      let text = rt.plain_text;
+      const ann = rt.annotations;
+      if (!ann) {
+        // Check for link in text property
+        if (rt.href) {
+          text = `[${text}](${rt.href})`;
+        }
+        return text;
+      }
+      if (ann.code) text = `\`${text}\``;
+      if (ann.bold) text = `**${text}**`;
+      if (ann.italic) text = `*${text}*`;
+      if (ann.strikethrough) text = `~~${text}~~`;
+      if (rt.href) text = `[${text}](${rt.href})`;
+      return text;
+    })
+    .join("");
+}
+
+function renderBlock(block: NotionBlock, numberedListCounters: Map<string, number>): string {
+  const type = block.type;
+
+  switch (type) {
+    case "paragraph": {
+      const rt = block.paragraph?.rich_text ?? [];
+      return renderInlineFormatting(rt);
+    }
+    case "heading_1": {
+      const rt = block.heading_1?.rich_text ?? [];
+      return `# ${renderInlineFormatting(rt)}`;
+    }
+    case "heading_2": {
+      const rt = block.heading_2?.rich_text ?? [];
+      return `## ${renderInlineFormatting(rt)}`;
+    }
+    case "heading_3": {
+      const rt = block.heading_3?.rich_text ?? [];
+      return `### ${renderInlineFormatting(rt)}`;
+    }
+    case "bulleted_list_item": {
+      const rt = block.bulleted_list_item?.rich_text ?? [];
+      return `- ${renderInlineFormatting(rt)}`;
+    }
+    case "numbered_list_item": {
+      const parentKey = "root";
+      const count = (numberedListCounters.get(parentKey) ?? 0) + 1;
+      numberedListCounters.set(parentKey, count);
+      const rt = block.numbered_list_item?.rich_text ?? [];
+      return `${count}. ${renderInlineFormatting(rt)}`;
+    }
+    case "code": {
+      const rt = block.code?.rich_text ?? [];
+      const lang = block.code?.language ?? "";
+      const codeText = rt.map((r) => r.plain_text).join("");
+      return `\`\`\`${lang}\n${codeText}\n\`\`\``;
+    }
+    case "quote": {
+      const rt = block.quote?.rich_text ?? [];
+      return `> ${renderInlineFormatting(rt)}`;
+    }
+    case "callout": {
+      const rt = block.callout?.rich_text ?? [];
+      const icon = block.callout?.icon;
+      const iconText = icon?.type === "emoji" && icon.emoji ? `${icon.emoji} ` : "";
+      return `> ${iconText}${renderInlineFormatting(rt)}`;
+    }
+    case "divider":
+      return "---";
+    case "toggle": {
+      const rt = block.toggle?.rich_text ?? [];
+      return `### ${renderInlineFormatting(rt)}`;
+    }
+    case "table_row": {
+      const cells = block.table_row?.cells ?? [];
+      const rendered = cells.map((cell) => renderInlineFormatting(cell));
+      return `| ${rendered.join(" | ")} |`;
+    }
+    case "child_page":
+      // Child pages are traversed separately; emit nothing in content
+      return "";
+    case "table":
+      // Table headers are rendered via table_row children; emit nothing here
+      return "";
+    default:
+      return `[Unsupported: ${type}]`;
+  }
+}
+
+function blocksToMarkdown(blocks: NotionBlock[]): string {
+  const lines: string[] = [];
+  const numberedListCounters = new Map<string, number>();
+  let lastType: string | null = null;
+  let tableHeaderEmitted = false;
+
+  for (const block of blocks) {
+    // Reset numbered list counter when switching away from numbered list items
+    if (block.type !== "numbered_list_item" && lastType === "numbered_list_item") {
+      numberedListCounters.clear();
+    }
+
+    // Handle table separator after header row
+    if (block.type === "table_row" && lastType === "table") {
+      tableHeaderEmitted = false;
+    }
+
+    const rendered = renderBlock(block, numberedListCounters);
+
+    if (block.type === "table_row") {
+      lines.push(rendered);
+      if (!tableHeaderEmitted) {
+        const cells = block.table_row?.cells ?? [];
+        const sep = cells.map(() => "---").join(" | ");
+        lines.push(`| ${sep} |`);
+        tableHeaderEmitted = true;
+      }
+    } else if (rendered) {
+      lines.push(rendered);
+    }
+
+    lastType = block.type;
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract page title from a Notion page object
+// ---------------------------------------------------------------------------
+
+function extractPageTitle(page: NotionPage): string {
+  if (!page.properties) return page.id;
+
+  // Check the "title" property directly
+  const titleProp = page.properties["title"] as NotionPageTitleProperty | undefined;
+  if (titleProp?.title?.length) {
+    return titleProp.title.map((rt) => rt.plain_text).join("");
+  }
+
+  // Some pages store title in "Name" property
+  const nameProp = page.properties["Name"] as NotionPageTitleProperty | undefined;
+  if (nameProp?.title?.length) {
+    return nameProp.title.map((rt) => rt.plain_text).join("");
+  }
+
+  // Fall back: look for any title-type property
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === "title" && prop.title?.length) {
+      return prop.title.map((rt) => rt.plain_text).join("");
+    }
+  }
+
+  return page.id;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: check if a title path matches any exclude pattern
+// ---------------------------------------------------------------------------
+
+function matchesExcludePattern(titlePath: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    // Support simple glob-like wildcards (* matches any characters)
+    const regexStr = pattern
+      .split("*")
+      .map((segment) => segment.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+      .join(".*");
+    const regex = new RegExp(`^${regexStr}$`, "i");
+    return regex.test(titlePath);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// NotionKnowledgeProvider
+// ---------------------------------------------------------------------------
+
+export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
+  readonly sourceType = "notion";
+  readonly sourceName: string;
+
+  private readonly rootPageId: string;
+  private readonly token: string;
+  private readonly excludePatterns: string[];
+  private readonly fetchFn: FetchFn;
+  private readonly rateLimiter: RateLimiter;
+
+  constructor(
+    rootPageId: string,
+    token: string,
+    sourceName: string,
+    options?: {
+      excludePatterns?: string[];
+      fetch?: FetchFn;
+    }
+  ) {
+    this.rootPageId = rootPageId;
+    this.token = token;
+    this.sourceName = sourceName;
+    this.excludePatterns = options?.excludePatterns ?? [];
+    this.fetchFn = options?.fetch ?? globalThis.fetch.bind(globalThis);
+    this.rateLimiter = new RateLimiter();
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  async *listDocuments(options?: ListOptions): AsyncIterable<KnowledgeDocument> {
+    const maxDepth = options?.maxDepth;
+    yield* this.traversePage(this.rootPageId, undefined, 0, maxDepth);
+  }
+
+  async fetchDocument(id: string): Promise<KnowledgeDocument> {
+    const page = await this.getPage(id);
+    const blocks = await this.getAllBlocks(id);
+    const content = blocksToMarkdown(blocks);
+    const title = extractPageTitle(page);
+
+    const parentId =
+      page.parent?.type === "page_id"
+        ? page.parent.page_id
+        : page.parent?.type === "block_id"
+          ? page.parent.block_id
+          : undefined;
+
+    return {
+      id: page.id,
+      title,
+      content,
+      url: page.url,
+      parentId,
+      lastModified: new Date(page.last_edited_time),
+      metadata: {
+        createdTime: page.created_time,
+        sourceType: "notion",
+        sourceName: this.sourceName,
+      },
+    };
+  }
+
+  async *getChangedSince(since: Date, _options?: ListOptions): AsyncIterable<KnowledgeDocument> {
+    let cursor: string | null = null;
+
+    while (true) {
+      await this.rateLimiter.throttle();
+      const body: Record<string, unknown> = {
+        filter: { property: "object", value: "page" },
+        sort: { timestamp: "last_edited_time", direction: "descending" },
+      };
+      if (cursor) body["start_cursor"] = cursor;
+
+      const resp = await this.apiPost<NotionSearchResponse>("/search", body);
+
+      for (const page of resp.results) {
+        const lastEdited = new Date(page.last_edited_time);
+        if (lastEdited <= since) {
+          // Results are sorted descending — once we see an older one, stop
+          return;
+        }
+        yield await this.fetchDocument(page.id);
+      }
+
+      if (!resp.has_more || !resp.next_cursor) break;
+      cursor = resp.next_cursor;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal traversal
+  // -------------------------------------------------------------------------
+
+  private async *traversePage(
+    pageId: string,
+    parentId: string | undefined,
+    depth: number,
+    maxDepth: number | undefined
+  ): AsyncIterable<KnowledgeDocument> {
+    // Fetch this page's metadata
+    const page = await this.getPage(pageId);
+    const title = extractPageTitle(page);
+
+    // Check exclude patterns
+    if (this.excludePatterns.length > 0 && matchesExcludePattern(title, this.excludePatterns)) {
+      return;
+    }
+
+    // Fetch all blocks
+    const blocks = await this.getAllBlocks(pageId);
+
+    // Collect child pages for recursion
+    const childPages = blocks.filter((b) => b.type === "child_page");
+
+    // Filter out child_page blocks from content rendering
+    const contentBlocks = blocks.filter((b) => b.type !== "child_page");
+    const content = blocksToMarkdown(contentBlocks);
+
+    yield {
+      id: page.id,
+      title,
+      content,
+      url: page.url,
+      parentId,
+      lastModified: new Date(page.last_edited_time),
+      metadata: {
+        createdTime: page.created_time,
+        sourceType: "notion",
+        sourceName: this.sourceName,
+      },
+    };
+
+    // Recurse into child pages if depth allows
+    if (maxDepth === undefined || depth < maxDepth) {
+      for (const childBlock of childPages) {
+        yield* this.traversePage(childBlock.id, pageId, depth + 1, maxDepth);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // API helpers
+  // -------------------------------------------------------------------------
+
+  private async getPage(pageId: string): Promise<NotionPage> {
+    await this.rateLimiter.throttle();
+    return this.apiGet<NotionPage>(`/pages/${pageId}`);
+  }
+
+  private async getAllBlocks(blockId: string): Promise<NotionBlock[]> {
+    const all: NotionBlock[] = [];
+    let cursor: string | null = null;
+
+    while (true) {
+      await this.rateLimiter.throttle();
+      const url = cursor
+        ? `/blocks/${blockId}/children?start_cursor=${encodeURIComponent(cursor)}`
+        : `/blocks/${blockId}/children`;
+
+      const resp = await this.apiGet<NotionBlocksResponse>(url);
+      all.push(...resp.results);
+
+      if (!resp.has_more || !resp.next_cursor) break;
+      cursor = resp.next_cursor;
+    }
+
+    return all;
+  }
+
+  private async apiGet<T>(path: string): Promise<T> {
+    const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
+      method: "GET",
+      headers: this.buildHeaders(),
+    });
+    return this.handleResponse<T>(resp);
+  }
+
+  private async apiPost<T>(path: string, body: unknown): Promise<T> {
+    const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
+      method: "POST",
+      headers: {
+        ...this.buildHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    return this.handleResponse<T>(resp);
+  }
+
+  private buildHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "Notion-Version": NOTION_API_VERSION,
+    };
+  }
+
+  private async handleResponse<T>(resp: Response): Promise<T> {
+    if (!resp.ok) {
+      let extra = "";
+      try {
+        const json = (await resp.json()) as { message?: string; code?: string };
+        const parts: string[] = [];
+        if (json.code) parts.push(`code=${json.code}`);
+        if (json.message) parts.push(`message=${json.message}`);
+        extra = parts.length > 0 ? ` - ${parts.join(", ")}` : "";
+      } catch {
+        extra = await resp.text().catch(() => "");
+      }
+      throw new Error(`Notion API error: ${resp.status} ${resp.statusText}${extra}`);
+    }
+    return resp.json() as Promise<T>;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first `KnowledgeSourceProvider`: `NotionKnowledgeProvider` connecting directly to the Notion API.

- Recursive page tree traversal with `maxDepth` and `excludePatterns`
- Block-to-markdown rendering for 11 block types (paragraph, headings, lists, code, quote, callout, divider, table, toggle)
- Inline formatting: bold, italic, code, strikethrough, links
- Rate limiter enforcing Notion's 3 req/s limit
- Pagination support via `has_more` + `start_cursor`
- `getChangedSince` via Notion search API with date filtering
- DI-friendly: injectable fetch function for testing
- 20 tests with fake HTTP responses, all passing

## Test plan

- [ ] All 20 tests pass (`bun test src/domain/knowledge/providers/notion-provider.test.ts`)
- [ ] TypeScript compiles with 0 errors
- [ ] ESLint passes with 0 warnings

Part of the knowledge base integration (mt#763), Phase 1.

🤖 Had Claude look into it — AI-assisted implementation