### PR TITLE
feat(mt#912): Add @minsky/definitions module

### DIFF
--- a/src/domain/definitions/definitions.test.ts
+++ b/src/domain/definitions/definitions.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import { dirname } from "path";
+
+import { defineAgent, defineRule, defineSkill, loadMarkdown } from "./index";
+
+describe("defineSkill", () => {
+  test("accepts a valid skill definition", () => {
+    const skill = defineSkill({
+      name: "implement-task",
+      description: "Full implementation lifecycle for a Minsky task",
+      tags: ["workflow"],
+      content: "# Implement Task\n\nStep-by-step guide...",
+    });
+    expect(skill.name).toBe("implement-task");
+    expect(skill.description).toBe("Full implementation lifecycle for a Minsky task");
+  });
+
+  test("rejects uppercase names", () => {
+    expect(() =>
+      defineSkill({
+        name: "Implement-Task",
+        description: "test",
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects names starting with hyphen", () => {
+    expect(() =>
+      defineSkill({
+        name: "-bad-name",
+        description: "test",
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects names with consecutive hyphens", () => {
+    expect(() =>
+      defineSkill({
+        name: "bad--name",
+        description: "test",
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects empty description", () => {
+    expect(() =>
+      defineSkill({
+        name: "test-skill",
+        description: "",
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects description over 1024 chars", () => {
+    expect(() =>
+      defineSkill({
+        name: "test-skill",
+        description: "x".repeat(1025),
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects empty content", () => {
+    expect(() =>
+      defineSkill({
+        name: "test-skill",
+        description: "A valid description",
+        content: "",
+      })
+    ).toThrow();
+  });
+
+  test("defaults userInvocable to true", () => {
+    const skill = defineSkill({
+      name: "test-skill",
+      description: "test",
+      content: "test content",
+    });
+    expect(skill.userInvocable).toBe(true);
+  });
+
+  test("defaults disableModelInvocation to false", () => {
+    const skill = defineSkill({
+      name: "test-skill",
+      description: "test",
+      content: "test content",
+    });
+    expect(skill.disableModelInvocation).toBe(false);
+  });
+});
+
+describe("defineRule", () => {
+  test("accepts a valid rule definition", () => {
+    const rule = defineRule({
+      description: "Zero tolerance for skipped tests",
+      tags: ["testing"],
+      alwaysApply: false,
+      content: "# No Skipped Tests\n\nEvery test must pass or be deleted.",
+    });
+    expect(rule.description).toBe("Zero tolerance for skipped tests");
+    expect(rule.alwaysApply).toBe(false);
+  });
+
+  test("accepts a rule with glob string", () => {
+    const rule = defineRule({
+      description: "test",
+      globs: "**/*.ts",
+      content: "test content",
+    });
+    expect(rule.globs).toBe("**/*.ts");
+  });
+
+  test("accepts a rule with glob array", () => {
+    const rule = defineRule({
+      description: "test",
+      globs: ["**/*.ts", "**/*.tsx"],
+      content: "test content",
+    });
+    expect(rule.globs).toEqual(["**/*.ts", "**/*.tsx"]);
+  });
+
+  test("rejects empty description", () => {
+    expect(() =>
+      defineRule({
+        description: "",
+        content: "test",
+      })
+    ).toThrow();
+  });
+
+  test("defaults alwaysApply to false", () => {
+    const rule = defineRule({
+      description: "test",
+      content: "test content",
+    });
+    expect(rule.alwaysApply).toBe(false);
+  });
+});
+
+describe("defineAgent", () => {
+  test("accepts a valid agent definition", () => {
+    const agent = defineAgent({
+      name: "implementer",
+      description: "Implementation subagent for task work in sessions",
+      model: "sonnet",
+      skills: ["implement-task", "prepare-pr"],
+      tools: ["Read", "Edit", "Write"],
+      prompt: "You are an implementation agent...",
+    });
+    expect(agent.name).toBe("implementer");
+    expect(agent.skills).toEqual(["implement-task", "prepare-pr"]);
+  });
+
+  test("rejects invalid model value", () => {
+    expect(() =>
+      defineAgent({
+        name: "test-agent",
+        description: "test",
+        model: "gpt-4" as "sonnet",
+        prompt: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects invalid permission mode", () => {
+    expect(() =>
+      defineAgent({
+        name: "test-agent",
+        description: "test",
+        permissionMode: "yolo" as "default",
+        prompt: "test",
+      })
+    ).toThrow();
+  });
+
+  test("rejects uppercase agent names", () => {
+    expect(() =>
+      defineAgent({
+        name: "MyAgent",
+        description: "test",
+        prompt: "test",
+      })
+    ).toThrow();
+  });
+
+  test("defaults model to inherit", () => {
+    const agent = defineAgent({
+      name: "test-agent",
+      description: "test",
+      prompt: "test prompt",
+    });
+    expect(agent.model).toBe("inherit");
+  });
+
+  test("defaults permissionMode to default", () => {
+    const agent = defineAgent({
+      name: "test-agent",
+      description: "test",
+      prompt: "test prompt",
+    });
+    expect(agent.permissionMode).toBe("default");
+  });
+
+  test("accepts maxTurns as positive integer", () => {
+    const agent = defineAgent({
+      name: "test-agent",
+      description: "test",
+      prompt: "test",
+      maxTurns: 50,
+    });
+    expect(agent.maxTurns).toBe(50);
+  });
+
+  test("rejects negative maxTurns", () => {
+    expect(() =>
+      defineAgent({
+        name: "test-agent",
+        description: "test",
+        prompt: "test",
+        maxTurns: -1,
+      })
+    ).toThrow();
+  });
+});
+
+describe("loadMarkdown", () => {
+  test("reads a markdown file from the specified directory", () => {
+    // Use this test file's own directory — definitions.test.ts is a real file we can locate
+    const thisDir = dirname(new URL(import.meta.url).pathname);
+    // Load the adjacent index.ts as a stand-in (any readable file works)
+    const content = loadMarkdown(thisDir, "index.ts");
+    expect(content).toContain("defineSkill");
+  });
+
+  test("throws for nonexistent file", () => {
+    expect(() => loadMarkdown("/mock/nonexistent", "missing.md")).toThrow();
+  });
+});

--- a/src/domain/definitions/factories.ts
+++ b/src/domain/definitions/factories.ts
@@ -1,0 +1,44 @@
+/**
+ * Factory functions for creating validated definitions.
+ *
+ * These provide compile-time type checking via TypeScript
+ * and runtime validation via Zod schemas.
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+import type { AgentDefinition, RuleDefinition, SkillDefinition } from "./types";
+import { agentDefinitionSchema, ruleDefinitionSchema, skillDefinitionSchema } from "./schemas";
+
+/**
+ * Define a skill with compile-time type checking and runtime validation.
+ */
+export function defineSkill(config: SkillDefinition): SkillDefinition {
+  return skillDefinitionSchema.parse(config) as SkillDefinition;
+}
+
+/**
+ * Define a rule with compile-time type checking and runtime validation.
+ */
+export function defineRule(config: RuleDefinition): RuleDefinition {
+  return ruleDefinitionSchema.parse(config) as RuleDefinition;
+}
+
+/**
+ * Define an agent with compile-time type checking and runtime validation.
+ */
+export function defineAgent(config: AgentDefinition): AgentDefinition {
+  return agentDefinitionSchema.parse(config) as AgentDefinition;
+}
+
+/**
+ * Load markdown content from a file adjacent to the definition module.
+ *
+ * @param dir - The directory containing the definition (use `import.meta.dir`)
+ * @param filename - The markdown file to load (e.g., "content.md" or "prompt.md")
+ */
+export function loadMarkdown(dir: string, filename: string): string {
+  const filePath = resolve(dir, filename);
+  return readFileSync(filePath, "utf8") as string;
+}

--- a/src/domain/definitions/index.ts
+++ b/src/domain/definitions/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @minsky/definitions — TypeScript-first authoring for behavioral artifacts.
+ *
+ * All skills, rules, and agents are authored as TypeScript modules
+ * using defineSkill, defineRule, and defineAgent, then compiled
+ * to harness-specific output formats.
+ */
+
+export type {
+  AgentDefinition,
+  AgentModel,
+  AgentPermissionMode,
+  RuleDefinition,
+  SkillDefinition,
+} from "./types";
+
+export { defineAgent, defineRule, defineSkill, loadMarkdown } from "./factories";
+
+export { agentDefinitionSchema, ruleDefinitionSchema, skillDefinitionSchema } from "./schemas";

--- a/src/domain/definitions/schemas.ts
+++ b/src/domain/definitions/schemas.ts
@@ -1,0 +1,59 @@
+/**
+ * Zod validation schemas for definition types.
+ *
+ * Used at compile time to validate TypeScript-authored definitions
+ * before producing harness-specific output.
+ */
+
+import { z } from "zod";
+
+/** Name format: lowercase letters, numbers, hyphens. No leading/trailing/consecutive hyphens. */
+const nameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+    "Must be lowercase letters, numbers, and hyphens. Cannot start/end with hyphen or have consecutive hyphens."
+  )
+  .refine((s) => !s.includes("--"), "Cannot contain consecutive hyphens");
+
+const descriptionSchema = z.string().min(1).max(1024);
+
+export const skillDefinitionSchema = z.object({
+  name: nameSchema,
+  description: descriptionSchema,
+  tags: z.array(z.string()).optional(),
+  userInvocable: z.boolean().optional().default(true),
+  disableModelInvocation: z.boolean().optional().default(false),
+  allowedTools: z.array(z.string()).optional(),
+  content: z.string().min(1),
+});
+
+export const ruleDefinitionSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().min(1),
+  alwaysApply: z.boolean().optional().default(false),
+  tags: z.array(z.string()).optional(),
+  globs: z.union([z.string(), z.array(z.string())]).optional(),
+  content: z.string().min(1),
+});
+
+const agentModelSchema = z.enum(["sonnet", "opus", "haiku", "inherit"]);
+const permissionModeSchema = z.enum(["default", "acceptEdits", "auto", "dontAsk", "plan"]);
+
+export const agentDefinitionSchema = z.object({
+  name: nameSchema,
+  description: descriptionSchema,
+  model: agentModelSchema.optional().default("inherit"),
+  skills: z.array(z.string()).optional(),
+  tools: z.array(z.string()).optional(),
+  disallowedTools: z.array(z.string()).optional(),
+  permissionMode: permissionModeSchema.optional().default("default"),
+  maxTurns: z.number().int().positive().optional(),
+  prompt: z.string().min(1),
+});
+
+export type SkillDefinitionInput = z.input<typeof skillDefinitionSchema>;
+export type RuleDefinitionInput = z.input<typeof ruleDefinitionSchema>;
+export type AgentDefinitionInput = z.input<typeof agentDefinitionSchema>;

--- a/src/domain/definitions/types.ts
+++ b/src/domain/definitions/types.ts
@@ -1,0 +1,77 @@
+/**
+ * Core type definitions for Minsky behavioral artifacts.
+ *
+ * All skills, rules, and agents are authored as TypeScript modules
+ * using these interfaces and compiled to harness-specific formats.
+ */
+
+/**
+ * A skill definition — procedural workflow invoked on-demand.
+ * Compiles to: .claude/skills/<name>/SKILL.md (Agent Skills format)
+ */
+export interface SkillDefinition {
+  /** Skill name. Lowercase letters, numbers, hyphens. Max 64 chars. Must match directory name. */
+  name: string;
+  /** What this skill does and when to use it. Max 1024 chars. */
+  description: string;
+  /** Categorization tags. */
+  tags?: string[];
+  /** Whether users can invoke via /name. Default: true. */
+  userInvocable?: boolean;
+  /** Prevent Claude from auto-invoking. Default: false. */
+  disableModelInvocation?: boolean;
+  /** Tools pre-approved when this skill is active. */
+  allowedTools?: string[];
+  /** The markdown body — the skill instructions. */
+  content: string;
+}
+
+/**
+ * A rule definition — declarative constraint (always-on or file-triggered).
+ * Compiles to: .cursor/rules/<name>.mdc, AGENTS.md sections, CLAUDE.md
+ */
+export interface RuleDefinition {
+  /** Rule display name. */
+  name?: string;
+  /** When this rule applies. Triggers rule loading. */
+  description: string;
+  /** If true, always included in context. */
+  alwaysApply?: boolean;
+  /** Categorization tags. */
+  tags?: string[];
+  /** File glob patterns that trigger this rule. */
+  globs?: string | string[];
+  /** The markdown body — the rule content. */
+  content: string;
+}
+
+/** Model options for agent definitions. */
+export type AgentModel = "sonnet" | "opus" | "haiku" | "inherit";
+
+/** Permission modes for subagents. */
+export type AgentPermissionMode = "default" | "acceptEdits" | "auto" | "dontAsk" | "plan";
+
+/**
+ * An agent definition — subagent configuration for dispatch.
+ * Compiles to: .claude/agents/<name>.md (Claude Code format)
+ */
+export interface AgentDefinition {
+  /** Agent identifier. Lowercase letters, numbers, hyphens. */
+  name: string;
+  /** What this agent does. Used for auto-delegation matching. */
+  description: string;
+  /** Model to use. Default: "inherit". */
+  model?: AgentModel;
+  /** Skills to preload into the agent's context at startup. */
+  skills?: string[];
+  /** Tools available to this agent. Omit for all tools. */
+  tools?: string[];
+  /** Tools explicitly denied to this agent. */
+  disallowedTools?: string[];
+  /** Permission mode for the agent. Default: "default". */
+  permissionMode?: AgentPermissionMode;
+  /** Maximum agentic turns before stopping. */
+  maxTurns?: number;
+  /** The system prompt — markdown body defining agent behavior. */
+  prompt: string;
+}


### PR DESCRIPTION
## Summary

Adds the `@minsky/definitions` module — the foundation for TypeScript-first authoring of behavioral artifacts.

- `defineSkill()`, `defineRule()`, `defineAgent()` factory functions with compile-time type checking and runtime Zod validation
- `SkillDefinition`, `RuleDefinition`, `AgentDefinition` interfaces
- `loadMarkdown()` helper for loading adjacent markdown content files
- Zod schemas with proper constraints (name format, description length, enum validation)
- 24 unit tests covering valid/invalid inputs, defaults, and edge cases

## Test plan

- [ ] `bun test src/domain/definitions/definitions.test.ts` — 24 tests pass
- [ ] Invalid names (uppercase, leading hyphen, consecutive hyphens) are rejected
- [ ] Invalid models and permission modes are rejected
- [ ] Defaults are applied correctly (userInvocable=true, model=inherit, etc.)

## Context

First subtask of mt#800 (TypeScript-first authoring). ADR: https://www.notion.so/348937f03cb4811eb4bedb7057217dd3