### PR TITLE
feat(mt#883): extend config schema for multi-forge extensibility

### DIFF
--- a/src/domain/configuration/schemas/backend.ts
+++ b/src/domain/configuration/schemas/backend.ts
@@ -57,6 +57,26 @@ export const repositoryGitHubConfigSchema = z.object({
 });
 
 /**
+ * Repository GitLab-specific configuration (config-plumbing only; runtime not yet implemented)
+ */
+export const repositoryGitLabConfigSchema = z.object({
+  projectId: z.string().optional(),
+  projectPath: z.string().optional(),
+  token: z.string().optional(),
+  baseUrl: z.string().optional(),
+});
+
+/**
+ * Repository Bitbucket-specific configuration (config-plumbing only; runtime not yet implemented)
+ */
+export const repositoryBitbucketConfigSchema = z.object({
+  workspace: z.string().optional(),
+  repoSlug: z.string().optional(),
+  token: z.string().optional(),
+  baseUrl: z.string().optional(),
+});
+
+/**
  * Repository backend configuration
  *
  * Stores the project-level repository backend type and associated settings,
@@ -66,6 +86,8 @@ export const repositoryConfigSchema = z.looseObject({
   backend: enumSchemas.repoBackendType.optional(),
   url: z.string().optional(),
   github: repositoryGitHubConfigSchema.optional(),
+  gitlab: repositoryGitLabConfigSchema.optional(),
+  bitbucket: repositoryBitbucketConfigSchema.optional(),
 });
 
 // Type exports
@@ -74,6 +96,8 @@ export type GitHubIssuesBackendConfig = z.infer<typeof githubIssuesBackendConfig
 export type BackendConfig = z.infer<typeof backendConfigSchema>;
 export type BackendFullConfig = z.infer<typeof backendFullConfigSchema>;
 export type RepositoryGitHubConfig = z.infer<typeof repositoryGitHubConfigSchema>;
+export type RepositoryGitLabConfig = z.infer<typeof repositoryGitLabConfigSchema>;
+export type RepositoryBitbucketConfig = z.infer<typeof repositoryBitbucketConfigSchema>;
 export type RepositoryConfig = z.infer<typeof repositoryConfigSchema>;
 
 /**

--- a/src/domain/configuration/schemas/base.ts
+++ b/src/domain/configuration/schemas/base.ts
@@ -96,8 +96,8 @@ export const enumSchemas = {
   }),
 
   // Repository backend types (distinct from task backendType)
-  repoBackendType: z.enum(["github", "gitlab", "local"], {
-    error: "Repository backend must be one of: github, gitlab, local",
+  repoBackendType: z.enum(["github", "gitlab", "bitbucket", "local"], {
+    error: "Repository backend must be one of: github, gitlab, bitbucket, local",
   }),
 } as const;
 

--- a/src/domain/repository/index.ts
+++ b/src/domain/repository/index.ts
@@ -48,7 +48,7 @@ export interface RepositoryBackendConfig {
   /**
    * The type of repository backend to use
    */
-  type: "github";
+  type: "github" | "gitlab" | "bitbucket";
 
   /**
    * Repository URL or path
@@ -355,9 +355,19 @@ export async function createRepositoryBackend(
       return new GitHubBackend(config, sessionDB, tokenProvider);
     }
 
+    case RepositoryBackendType.GITLAB:
+      throw new Error(
+        "GitLab backend is not yet implemented. Only GitHub is currently supported for PR/CI/review operations."
+      );
+
+    case RepositoryBackendType.BITBUCKET:
+      throw new Error(
+        "Bitbucket backend is not yet implemented. Only GitHub is currently supported for PR/CI/review operations."
+      );
+
     default:
       throw new Error(
-        `Unsupported repository backend type: ${config.type}. Only "github" is supported.`
+        `Unsupported repository backend type: ${config.type}. Only "github" is currently supported for PR/CI/review operations.`
       );
   }
 }

--- a/src/domain/repository/legacy-types.ts
+++ b/src/domain/repository/legacy-types.ts
@@ -9,10 +9,23 @@ import type { UriFormat } from "../uri-utils";
 
 /**
  * Repository backend types supported by the system.
- * Only GitHub is supported; LOCAL and REMOTE backends have been removed.
+ * GitHub is fully supported; GitLab and Bitbucket are config-plumbing only.
  */
 export enum RepositoryBackendType {
   GITHUB = "github",
+  GITLAB = "gitlab",
+  BITBUCKET = "bitbucket",
+}
+
+/**
+ * Returns true if the given backend type is a forge (hosted git platform).
+ */
+export function isForgeBackend(type: RepositoryBackendType): boolean {
+  return [
+    RepositoryBackendType.GITHUB,
+    RepositoryBackendType.GITLAB,
+    RepositoryBackendType.BITBUCKET,
+  ].includes(type);
 }
 
 /**

--- a/src/domain/session/commands/pr-get-subcommand.ts
+++ b/src/domain/session/commands/pr-get-subcommand.ts
@@ -49,7 +49,7 @@ export async function sessionPrGet(
     task?: string;
     repo?: string;
     json?: boolean;
-    backend?: "github";
+    backend?: "github" | "gitlab" | "bitbucket";
     status?: string; // optional constraint
     since?: string;
     until?: string;
@@ -72,7 +72,7 @@ export async function sessionPrGet(
     author?: string;
     filesChanged?: number;
     commits?: number;
-    backendType?: "github";
+    backendType?: "github" | "gitlab" | "bitbucket";
   };
 }> {
   const { sessionDB } = deps;

--- a/src/domain/session/repository-backend-config.test.ts
+++ b/src/domain/session/repository-backend-config.test.ts
@@ -4,16 +4,19 @@
  * Tests for:
  * - resolveRepositoryFromGitRemote (init-time detection)
  * - getRepositoryBackendFromConfig (config-based session creation)
+ * - detectRepositoryBackendTypeFromUrl (URL-based type detection)
+ * - createRepositoryBackend (factory error messages)
  *
  * All tests are hermetic — no real filesystem, git, or network access.
  * Uses dependency injection instead of mock.module().
  */
 import { describe, it, expect, beforeEach } from "bun:test";
-import { RepositoryBackendType } from "../repository/index";
+import { RepositoryBackendType, createRepositoryBackend } from "../repository/index";
 import type { RepositoryBackendDetectionDeps } from "./repository-backend-detection";
 import {
   resolveRepositoryFromGitRemote,
   getRepositoryBackendFromConfig,
+  detectRepositoryBackendTypeFromUrl,
 } from "./repository-backend-detection";
 
 // ─── Shared mutable state for mock control ───────────────────────────────────
@@ -126,5 +129,71 @@ describe("getRepositoryBackendFromConfig", () => {
       expect(result.backendType).toBe(RepositoryBackendType.GITHUB);
       expect(result.repoUrl).toContain("github.com");
     });
+  });
+});
+
+// ─── detectRepositoryBackendTypeFromUrl ─────────────────────────────────────
+
+describe("detectRepositoryBackendTypeFromUrl", () => {
+  it("returns GITHUB for github.com URLs", () => {
+    expect(detectRepositoryBackendTypeFromUrl("https://github.com/owner/repo.git")).toBe(
+      RepositoryBackendType.GITHUB
+    );
+    expect(detectRepositoryBackendTypeFromUrl("git@github.com:owner/repo.git")).toBe(
+      RepositoryBackendType.GITHUB
+    );
+  });
+
+  it("returns GITLAB for gitlab.com URLs", () => {
+    expect(detectRepositoryBackendTypeFromUrl("https://gitlab.com/someorg/somerepo.git")).toBe(
+      RepositoryBackendType.GITLAB
+    );
+    expect(detectRepositoryBackendTypeFromUrl("git@gitlab.com:someorg/somerepo.git")).toBe(
+      RepositoryBackendType.GITLAB
+    );
+  });
+
+  it("returns BITBUCKET for bitbucket.org URLs", () => {
+    expect(detectRepositoryBackendTypeFromUrl("https://bitbucket.org/someuser/somerepo.git")).toBe(
+      RepositoryBackendType.BITBUCKET
+    );
+    expect(detectRepositoryBackendTypeFromUrl("git@bitbucket.org:someuser/somerepo.git")).toBe(
+      RepositoryBackendType.BITBUCKET
+    );
+  });
+
+  it("throws for unrecognized URLs", () => {
+    expect(() => detectRepositoryBackendTypeFromUrl("https://example.com/repo.git")).toThrow(
+      /Unsupported repository forge/
+    );
+  });
+});
+
+// ─── createRepositoryBackend factory error messages ─────────────────────────
+
+// Minimal stub — only the type signature needs to satisfy SessionProviderInterface
+const stubSessionDB = {} as any;
+
+describe("createRepositoryBackend factory", () => {
+  it("throws a clear error for gitlab type", async () => {
+    await expect(
+      createRepositoryBackend(
+        { type: "gitlab", repoUrl: "https://gitlab.com/org/repo" },
+        stubSessionDB
+      )
+    ).rejects.toThrow(
+      "GitLab backend is not yet implemented. Only GitHub is currently supported for PR/CI/review operations."
+    );
+  });
+
+  it("throws a clear error for bitbucket type", async () => {
+    await expect(
+      createRepositoryBackend(
+        { type: "bitbucket", repoUrl: "https://bitbucket.org/user/repo" },
+        stubSessionDB
+      )
+    ).rejects.toThrow(
+      "Bitbucket backend is not yet implemented. Only GitHub is currently supported for PR/CI/review operations."
+    );
   });
 });

--- a/src/domain/session/repository-backend-detection.ts
+++ b/src/domain/session/repository-backend-detection.ts
@@ -23,15 +23,25 @@ const defaultDeps: RepositoryBackendDetectionDeps = {
 
 /**
  * Detect repository backend type directly from a repository URL.
- * Only GitHub is supported; non-GitHub URLs throw an error.
+ * GitHub, GitLab, and Bitbucket are recognized; other URLs throw an error.
+ * Note: GitLab and Bitbucket are config-plumbing only — runtime operations (PR/CI/review) are
+ * not yet implemented and will throw when the factory is called.
  */
 export function detectRepositoryBackendTypeFromUrl(repoUrl: string): RepositoryBackendType {
   if (repoUrl.includes("github.com")) {
     return RepositoryBackendType.GITHUB;
   }
 
+  if (repoUrl.includes("gitlab.com")) {
+    return RepositoryBackendType.GITLAB;
+  }
+
+  if (repoUrl.includes("bitbucket.org")) {
+    return RepositoryBackendType.BITBUCKET;
+  }
+
   throw new Error(
-    `Unsupported repository forge for URL: ${repoUrl}. Only GitHub repositories are supported.`
+    `Unsupported repository forge for URL: ${repoUrl}. Only GitHub, GitLab, and Bitbucket repositories are recognized.`
   );
 }
 

--- a/src/domain/session/session-db.ts
+++ b/src/domain/session/session-db.ts
@@ -74,7 +74,7 @@ export interface SessionRecord {
   repoPath?: string; // Local path to the repository
   createdAt: string;
   taskId?: string;
-  backendType?: "github"; // Repository backend type — only GitHub is supported
+  backendType?: "github" | "gitlab" | "bitbucket"; // Repository backend type
   prState?: {
     branchName: string;
     exists?: boolean;

--- a/src/domain/session/types.ts
+++ b/src/domain/session/types.ts
@@ -17,7 +17,7 @@ export interface SessionRecord {
   createdAt: string;
   /** Task ID in storage format (plain number string, e.g., "283") */
   taskId?: string;
-  backendType?: "github"; // Repository backend type — only GitHub is supported
+  backendType?: "github" | "gitlab" | "bitbucket"; // Repository backend type
   /** Git branch name created for this session */
   branch?: string;
   prState?: {
@@ -63,7 +63,7 @@ export interface Session {
   createdAt?: string;
   /** Task ID in storage format (plain number string, e.g., "283") */
   taskId?: string;
-  backendType?: "github";
+  backendType?: "github" | "gitlab" | "bitbucket";
   github?: {
     owner?: string;
     repo?: string;


### PR DESCRIPTION
## Summary

- Add optional `gitlab` and `bitbucket` config sections to `repositoryConfigSchema` with forge-specific fields (projectId, projectPath, workspace, repoSlug, token, baseUrl)
- Update `repoBackendType` enum in base.ts to include `bitbucket` alongside github/gitlab/local
- Export `RepositoryGitLabConfig` and `RepositoryBitbucketConfig` types from backend schema
- `detectRepositoryBackendTypeFromUrl` now recognizes gitlab.com and bitbucket.org URLs, returning GITLAB/BITBUCKET enum values instead of throwing
- `createRepositoryBackend` factory gives clear not-yet-implemented errors for GITLAB and BITBUCKET types
- Widen `Session.backendType` and `SessionPrGet.backend` to include all three forge types
- Add tests for gitlab.com/bitbucket.org URL detection and factory error messages

## Test plan

- [x] TypeScript compilation passes (0 errors)
- [x] `detectRepositoryBackendTypeFromUrl` returns GITLAB for gitlab.com URLs
- [x] `detectRepositoryBackendTypeFromUrl` returns BITBUCKET for bitbucket.org URLs
- [x] `createRepositoryBackend` throws helpful error for gitlab/bitbucket types
- [x] Existing GitHub and other tests pass (1833 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)