### PR TITLE
refactor(mt#921): use IntelligentRetryService in Notion provider, direct token auth

### DIFF
--- a/src/adapters/mcp/knowledge-resources.ts
+++ b/src/adapters/mcp/knowledge-resources.ts
@@ -126,11 +126,14 @@ export function registerKnowledgeResources(
           );
         }
 
-        const token = process.env[sourceConfig.auth.tokenEnvVar];
+        const token =
+          sourceConfig.auth.token ??
+          (sourceConfig.auth.tokenEnvVar ? process.env[sourceConfig.auth.tokenEnvVar] : undefined);
         if (!token) {
-          throw new Error(
-            `API token not found. Set the "${sourceConfig.auth.tokenEnvVar}" environment variable.`
-          );
+          const hint = sourceConfig.auth.tokenEnvVar
+            ? `Set the "${sourceConfig.auth.tokenEnvVar}" environment variable or provide a direct "token" value.`
+            : `Provide a direct "token" value in the auth configuration.`;
+          throw new Error(`API token not found. ${hint}`);
         }
 
         let provider;

--- a/src/adapters/shared/commands/knowledge/index.ts
+++ b/src/adapters/shared/commands/knowledge/index.ts
@@ -260,11 +260,14 @@ export function registerKnowledgeCommands(
       // We expose provider creation by building an ad-hoc single-source KnowledgeService,
       // then rely on the provider's fetchDocument via the service's internal mechanism.
       // Since KnowledgeService.createProvider is private, we replicate the minimal logic here.
-      const token = process.env[sourceConfig.auth.tokenEnvVar];
+      const token =
+        sourceConfig.auth.token ??
+        (sourceConfig.auth.tokenEnvVar ? process.env[sourceConfig.auth.tokenEnvVar] : undefined);
       if (!token) {
-        throw new Error(
-          `API token not found. Set the "${sourceConfig.auth.tokenEnvVar}" environment variable.`
-        );
+        const hint = sourceConfig.auth.tokenEnvVar
+          ? `Set the "${sourceConfig.auth.tokenEnvVar}" environment variable or provide a direct "token" value.`
+          : `Provide a direct "token" value in the auth configuration.`;
+        throw new Error(`API token not found. ${hint}`);
       }
 
       let provider;

--- a/src/adapters/shared/commands/knowledge/knowledge-commands.test.ts
+++ b/src/adapters/shared/commands/knowledge/knowledge-commands.test.ts
@@ -267,7 +267,7 @@ describe("Knowledge Commands", () => {
       const cmd = registry.getCommand(FETCH_CMD);
       await expect(
         cmd!.execute({ source: "test-source", documentId: "doc-1" }, {})
-      ).rejects.toThrow(`API token not found. Set the "${tokenVar}" environment variable.`);
+      ).rejects.toThrow("API token not found.");
     });
   });
 

--- a/src/domain/ai/embedding-service-openai.test.ts
+++ b/src/domain/ai/embedding-service-openai.test.ts
@@ -274,6 +274,11 @@ describe("isRetryableAIError", () => {
     expect(isRetryableAIError(err)).toBe(false);
   });
 
+  it("returns true for 502 Bad Gateway", () => {
+    const err = new Error("502 Bad Gateway");
+    expect(isRetryableAIError(err)).toBe(true);
+  });
+
   it("returns true for 503 Service Unavailable", () => {
     const err = new Error("503 Service Unavailable");
     expect(isRetryableAIError(err)).toBe(true);

--- a/src/domain/ai/embedding-service-openai.ts
+++ b/src/domain/ai/embedding-service-openai.ts
@@ -12,7 +12,7 @@ export function isRetryableAIError(error: unknown): boolean {
   const msg = String((error as Error)?.message || "");
   if (/insufficient_quota/i.test(msg)) return false;
   if (error instanceof RateLimitError) return true;
-  return /429|rate.limit|503|Service Unavailable|ECONNRESET|ETIMEDOUT/i.test(msg);
+  return /429|rate.limit|502|Bad Gateway|503|Service Unavailable|ECONNRESET|ETIMEDOUT/i.test(msg);
 }
 
 interface OpenAIEmbeddingResponse {

--- a/src/domain/configuration/schemas/knowledge-bases.ts
+++ b/src/domain/configuration/schemas/knowledge-bases.ts
@@ -1,14 +1,21 @@
 import { z } from "zod";
 
 /**
- * Authentication configuration for a knowledge source
+ * Authentication configuration for a knowledge source.
+ * At least one of `token` or `tokenEnvVar` must be provided.
  */
-const knowledgeSourceAuthSchema = z.object({
-  /** Environment variable containing the API token */
-  tokenEnvVar: z.string(),
-  /** Optional environment variable for email (used by some providers like Confluence) */
-  emailEnvVar: z.string().optional(),
-});
+const knowledgeSourceAuthSchema = z
+  .object({
+    /** Direct API token value (takes precedence over tokenEnvVar) */
+    token: z.string().optional(),
+    /** Environment variable containing the API token */
+    tokenEnvVar: z.string().optional(),
+    /** Optional environment variable for email (used by some providers like Confluence) */
+    emailEnvVar: z.string().optional(),
+  })
+  .refine((data) => data.token !== undefined || data.tokenEnvVar !== undefined, {
+    message: "At least one of 'token' or 'tokenEnvVar' must be provided",
+  });
 
 /**
  * Sync schedule and behavior configuration

--- a/src/domain/knowledge/knowledge-service.ts
+++ b/src/domain/knowledge/knowledge-service.ts
@@ -79,11 +79,14 @@ export class KnowledgeService {
   private async createNotionProvider(
     config: KnowledgeSourceConfig
   ): Promise<KnowledgeSourceProvider> {
-    const token = process.env[config.auth.tokenEnvVar];
+    const token =
+      config.auth.token ??
+      (config.auth.tokenEnvVar ? process.env[config.auth.tokenEnvVar] : undefined);
     if (!token) {
-      throw new Error(
-        `Notion API token not found. Set the "${config.auth.tokenEnvVar}" environment variable.`
-      );
+      const hint = config.auth.tokenEnvVar
+        ? `Set the "${config.auth.tokenEnvVar}" environment variable or provide a direct "token" value.`
+        : `Provide a direct "token" value in the auth configuration.`;
+      throw new Error(`Notion API token not found. ${hint}`);
     }
 
     const notionConfig = config as NotionSourceConfig;

--- a/src/domain/knowledge/providers/notion-provider.test.ts
+++ b/src/domain/knowledge/providers/notion-provider.test.ts
@@ -643,24 +643,37 @@ describe("NotionKnowledgeProvider.getChangedSince", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: rate limiting
+// Tests: retry behavior (via IntelligentRetryService)
 // ---------------------------------------------------------------------------
 
-describe("NotionKnowledgeProvider rate limiting", () => {
-  it("spaces out requests to avoid exceeding 3 req/sec", async () => {
-    const pageId = "rate-test-page";
-    const callTimes: number[] = [];
+describe("NotionKnowledgeProvider retry behavior", () => {
+  it("retries on 502 Bad Gateway and succeeds on second attempt", async () => {
+    const pageId = "retry-502-page";
+    let callCount = 0;
 
     const fetchFn: FetchFn = async (url: string): Promise<Response> => {
-      callTimes.push(Date.now());
-
       if (url.includes(`/pages/${pageId}`)) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: false,
+            status: 502,
+            statusText: "Bad Gateway",
+            async json() {
+              throw new Error("no body");
+            },
+            async text() {
+              return "Bad Gateway";
+            },
+            headers: new Headers(),
+          } as unknown as Response;
+        }
         return {
           ok: true,
           status: 200,
           statusText: "OK",
           async json() {
-            return makePage(pageId, "Rate Test Page");
+            return makePage(pageId, "Retry Page");
           },
           async text() {
             return "";
@@ -668,7 +681,6 @@ describe("NotionKnowledgeProvider rate limiting", () => {
           headers: new Headers(),
         } as Response;
       }
-
       return {
         ok: true,
         status: 200,
@@ -683,18 +695,73 @@ describe("NotionKnowledgeProvider rate limiting", () => {
       } as Response;
     };
 
-    const provider = new NotionKnowledgeProvider("root", "token", "test", { fetch: fetchFn });
+    const { IntelligentRetryService } = await import("../../ai/intelligent-retry-service");
+    const provider = new NotionKnowledgeProvider("root", "token", "test", {
+      fetch: fetchFn,
+      retryService: new IntelligentRetryService({ maxRetries: 3, baseDelay: 0 }),
+    });
 
-    await provider.fetchDocument(pageId);
+    const doc = await provider.fetchDocument(pageId);
+    expect(doc.title).toBe("Retry Page");
+    expect(callCount).toBe(2);
+  });
 
-    // fetchDocument makes 2 requests (page + blocks)
-    // With rate limiting at 3 req/sec (333ms interval), 2 requests should take ~333ms
-    expect(callTimes).toHaveLength(2);
-    // At minimum, the second request should be delayed
-    if (callTimes.length >= 2) {
-      const gap = (callTimes[1] ?? 0) - (callTimes[0] ?? 0);
-      // Should be at least ~300ms (rate limiter minimum interval)
-      expect(gap).toBeGreaterThanOrEqual(300);
-    }
+  it("retries on 429 Too Many Requests and succeeds on second attempt", async () => {
+    const pageId = "retry-429-page";
+    let callCount = 0;
+
+    const fetchFn: FetchFn = async (url: string): Promise<Response> => {
+      if (url.includes(`/pages/${pageId}`)) {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: false,
+            status: 429,
+            statusText: "Too Many Requests",
+            async json() {
+              return { message: "rate limited", code: "rate_limited" };
+            },
+            async text() {
+              return "Too Many Requests";
+            },
+            headers: new Headers(),
+          } as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          async json() {
+            return makePage(pageId, "Retry 429 Page");
+          },
+          async text() {
+            return "";
+          },
+          headers: new Headers(),
+        } as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        async json() {
+          return makeBlocksResponse([]);
+        },
+        async text() {
+          return "";
+        },
+        headers: new Headers(),
+      } as Response;
+    };
+
+    const { IntelligentRetryService } = await import("../../ai/intelligent-retry-service");
+    const provider = new NotionKnowledgeProvider("root", "token", "test", {
+      fetch: fetchFn,
+      retryService: new IntelligentRetryService({ maxRetries: 3, baseDelay: 0 }),
+    });
+
+    const doc = await provider.fetchDocument(pageId);
+    expect(doc.title).toBe("Retry 429 Page");
+    expect(callCount).toBe(2);
   });
 });

--- a/src/domain/knowledge/providers/notion-provider.ts
+++ b/src/domain/knowledge/providers/notion-provider.ts
@@ -6,14 +6,12 @@
  */
 
 import type { KnowledgeDocument, KnowledgeSourceProvider, ListOptions } from "../types";
+import { IntelligentRetryService } from "../../ai/intelligent-retry-service";
+import { isRetryableAIError } from "../../ai/embedding-service-openai";
 
 // Notion API version
 const NOTION_API_VERSION = "2022-06-28";
 const NOTION_API_BASE = "https://api.notion.com/v1";
-
-// Rate limit: Notion allows 3 requests/second
-const REQUESTS_PER_SECOND = 3;
-const MIN_REQUEST_INTERVAL_MS = Math.ceil(1000 / REQUESTS_PER_SECOND);
 
 // ---------------------------------------------------------------------------
 // Notion API response shapes
@@ -92,24 +90,6 @@ interface NotionSearchResponse {
 // ---------------------------------------------------------------------------
 
 export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
-
-// ---------------------------------------------------------------------------
-// Simple token-bucket rate limiter
-// ---------------------------------------------------------------------------
-
-class RateLimiter {
-  private lastRequestTime = 0;
-
-  async throttle(): Promise<void> {
-    const now = Date.now();
-    const elapsed = now - this.lastRequestTime;
-    if (elapsed < MIN_REQUEST_INTERVAL_MS) {
-      const delay = MIN_REQUEST_INTERVAL_MS - elapsed;
-      await new Promise((resolve) => setTimeout(resolve, delay));
-    }
-    this.lastRequestTime = Date.now();
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Block rendering helpers
@@ -300,7 +280,7 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
   private readonly token: string;
   private readonly excludePatterns: string[];
   private readonly fetchFn: FetchFn;
-  private readonly rateLimiter: RateLimiter;
+  private readonly retryService: IntelligentRetryService;
 
   constructor(
     rootPageId: string,
@@ -309,6 +289,7 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
     options?: {
       excludePatterns?: string[];
       fetch?: FetchFn;
+      retryService?: IntelligentRetryService;
     }
   ) {
     this.rootPageId = rootPageId;
@@ -316,7 +297,8 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
     this.sourceName = sourceName;
     this.excludePatterns = options?.excludePatterns ?? [];
     this.fetchFn = options?.fetch ?? globalThis.fetch.bind(globalThis);
-    this.rateLimiter = new RateLimiter();
+    this.retryService =
+      options?.retryService ?? new IntelligentRetryService({ maxRetries: 3, baseDelay: 350 });
   }
 
   // -------------------------------------------------------------------------
@@ -360,7 +342,6 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
     let cursor: string | null = null;
 
     while (true) {
-      await this.rateLimiter.throttle();
       const body: Record<string, unknown> = {
         filter: { property: "object", value: "page" },
         sort: { timestamp: "last_edited_time", direction: "descending" },
@@ -439,7 +420,6 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
   // -------------------------------------------------------------------------
 
   private async getPage(pageId: string): Promise<NotionPage> {
-    await this.rateLimiter.throttle();
     return this.apiGet<NotionPage>(`/pages/${pageId}`);
   }
 
@@ -448,7 +428,6 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
     let cursor: string | null = null;
 
     while (true) {
-      await this.rateLimiter.throttle();
       const url = cursor
         ? `/blocks/${blockId}/children?start_cursor=${encodeURIComponent(cursor)}`
         : `/blocks/${blockId}/children`;
@@ -464,23 +443,35 @@ export class NotionKnowledgeProvider implements KnowledgeSourceProvider {
   }
 
   private async apiGet<T>(path: string): Promise<T> {
-    const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
-      method: "GET",
-      headers: this.buildHeaders(),
-    });
-    return this.handleResponse<T>(resp);
+    return this.retryService.execute(
+      async () => {
+        const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
+          method: "GET",
+          headers: this.buildHeaders(),
+        });
+        return this.handleResponse<T>(resp);
+      },
+      isRetryableAIError,
+      "notion"
+    );
   }
 
   private async apiPost<T>(path: string, body: unknown): Promise<T> {
-    const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
-      method: "POST",
-      headers: {
-        ...this.buildHeaders(),
-        "Content-Type": "application/json",
+    return this.retryService.execute(
+      async () => {
+        const resp = await this.fetchFn(`${NOTION_API_BASE}${path}`, {
+          method: "POST",
+          headers: {
+            ...this.buildHeaders(),
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        return this.handleResponse<T>(resp);
       },
-      body: JSON.stringify(body),
-    });
-    return this.handleResponse<T>(resp);
+      isRetryableAIError,
+      "notion"
+    );
   }
 
   private buildHeaders(): Record<string, string> {

--- a/src/domain/knowledge/types.ts
+++ b/src/domain/knowledge/types.ts
@@ -76,8 +76,10 @@ export interface KnowledgeSourceConfig {
   type: "notion" | "confluence" | "google-docs";
   /** Authentication credentials for the source */
   auth: {
+    /** Direct API token value (takes precedence over tokenEnvVar) */
+    token?: string;
     /** Environment variable containing the API token */
-    tokenEnvVar: string;
+    tokenEnvVar?: string;
     /** Optional environment variable for email (used by some providers) */
     emailEnvVar?: string;
   };


### PR DESCRIPTION
## Summary

- Replace custom `RateLimiter` class in NotionKnowledgeProvider with `IntelligentRetryService` (exponential backoff, circuit breaker, jitter)
- Add 502 Bad Gateway to `isRetryableAIError` shared utility
- Support direct `token` in knowledge base config alongside `tokenEnvVar`, matching how other providers store credentials
- Zod schema refine() ensures at least one auth method is provided

## Test plan

- [ ] All 1835 tests pass
- [ ] Retry tests: 502 first call -> retry -> success; 429 first call -> retry -> success
- [ ] `isRetryableAIError(new Error("502 Bad Gateway"))` returns true
- [ ] Config validates with `auth: { token: "ntn_..." }` (direct) or `auth: { tokenEnvVar: "NOTION_TOKEN" }` (env var)

Had Claude look into it -- AI-assisted refactoring