### PR TITLE
refactor(mt#928): Fix CLI routing - init and setup as top-level commands

### DIFF
--- a/src/adapters/cli/customizations/init-customizations.ts
+++ b/src/adapters/cli/customizations/init-customizations.ts
@@ -1,0 +1,28 @@
+/**
+ * INIT Commands Customizations
+ *
+ * CLI customizations for INIT-related commands (init, setup).
+ *
+ * The INIT category is hidden from the CLI auto-generation because the CLI
+ * has non-shared commander commands (src/commands/init/, src/commands/setup/)
+ * that register `init` and `setup` directly as top-level commands. Hiding
+ * the category here prevents Commander.js from throwing on duplicate top-level
+ * command names.
+ */
+import type { CategoryCommandOptions } from "../../shared/bridges/cli";
+import { CommandCategory } from "../../shared/command-registry";
+
+/**
+ * Get customizations for INIT commands
+ */
+export function getInitCustomizations(): {
+  category: CommandCategory;
+  options: CategoryCommandOptions;
+} {
+  return {
+    category: CommandCategory.INIT,
+    options: {
+      hidden: true,
+    },
+  };
+}

--- a/src/adapters/cli/setup/command-setup.ts
+++ b/src/adapters/cli/setup/command-setup.ts
@@ -13,6 +13,7 @@ import {
 } from "../customizations/config-customizations";
 import { getToolsCustomizations } from "../customizations/tools-customizations";
 import { getMcpCustomizations } from "../customizations/mcp-customizations";
+import { getInitCustomizations } from "../customizations/init-customizations";
 
 /**
  * Helper function to setup common CLI command customizations
@@ -45,6 +46,9 @@ export function setupCommonCommandCustomizations(program?: Command): void {
 
   const mcpConfig = getMcpCustomizations();
   cliFactory.customizeCategory(mcpConfig.category, mcpConfig.options);
+
+  const initConfig = getInitCustomizations();
+  cliFactory.customizeCategory(initConfig.category, initConfig.options);
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,9 +57,9 @@ export async function createCli(container: AppContainerInterface): Promise<Comma
   // Register all commands via CLI command factory (which applies customizations)
   cliFactory.registerAllCommands(cli);
 
-  // Non-shared commands (context, mcp, github, lint) pull in expensive dependencies
-  // (~700ms total: AI tokenizer, MCP SDK, etc.). Only load when actually invoked
-  // or when full help is requested.
+  // Non-shared commands (context, mcp, github, lint, init, setup) pull in expensive
+  // dependencies (~700ms total: AI tokenizer, MCP SDK, etc.). Only load when actually
+  // invoked or when full help is requested.
   const requestedCommand = process.argv[2];
   const needsAll =
     !requestedCommand ||
@@ -84,6 +84,14 @@ export async function createCli(container: AppContainerInterface): Promise<Comma
   if (needsAll || requestedCommand === "lint") {
     const { createLintCommand } = await import("./commands/lint/index");
     cli.addCommand(createLintCommand());
+  }
+  if (needsAll || requestedCommand === "init") {
+    const { createInitCommand } = await import("./commands/init/index");
+    cli.addCommand(createInitCommand());
+  }
+  if (needsAll || requestedCommand === "setup") {
+    const { createSetupCommand } = await import("./commands/setup/index");
+    cli.addCommand(createSetupCommand());
   }
 
   // Set error handler

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,0 +1,64 @@
+/**
+ * `minsky init` top-level CLI command.
+ *
+ * Delegates execution to the shared `init` command definition in the registry,
+ * keeping logic DRY while presenting `init` as a top-level CLI command rather
+ * than a subcommand nested under an INIT category wrapper.
+ */
+import { Command } from "commander";
+import { sharedCommandRegistry } from "../../adapters/shared/command-registry";
+import { getErrorMessage } from "../../errors/index";
+
+export function createInitCommand(): Command {
+  const cmd = new Command("init");
+  cmd.description("Initialize a project for Minsky");
+
+  // Mirror all options from the shared command definition (init.ts)
+  cmd.option("--repo <path>", "Repository path to initialize");
+  cmd.option("--backend <string>", "Backend type (available: github, minsky)");
+  cmd.option("--overwrite", "Overwrite existing resources", false);
+  cmd.option("--workspace-path <path>", "Workspace path");
+  cmd.option("--github-owner <string>", "GitHub repository owner");
+  cmd.option("--github-repo <string>", "GitHub repository name");
+  cmd.option("--rule-format <string>", "Rule format (cursor or generic)");
+  cmd.option("--mcp <string>", "Enable/disable MCP configuration");
+  cmd.option("--mcp-transport <string>", "MCP transport type (stdio, sse, httpStream)");
+  cmd.option("--mcp-port <string>", "Port for MCP network transports");
+  cmd.option("--mcp-host <string>", "Host for MCP network transports");
+
+  cmd.action(async (options) => {
+    try {
+      const commandDef = sharedCommandRegistry.getCommand("init");
+      if (!commandDef) {
+        console.error("Shared command 'init' not found in registry");
+        process.exit(1);
+      }
+
+      const result = await commandDef.execute(
+        {
+          repo: options.repo,
+          backend: options.backend,
+          overwrite: options.overwrite ?? false,
+          workspacePath: options.workspacePath,
+          githubOwner: options.githubOwner,
+          githubRepo: options.githubRepo,
+          ruleFormat: options.ruleFormat,
+          mcp: options.mcp,
+          mcpTransport: options.mcpTransport,
+          mcpPort: options.mcpPort,
+          mcpHost: options.mcpHost,
+        },
+        { interface: "cli" }
+      );
+
+      const typed = result as { success: boolean; message?: string };
+      if (typed.message) console.log(typed.message);
+      if (!typed.success) process.exit(1);
+    } catch (error: unknown) {
+      console.error(`Error: ${getErrorMessage(error)}`);
+      process.exit(1);
+    }
+  });
+
+  return cmd;
+}

--- a/src/commands/setup/index.ts
+++ b/src/commands/setup/index.ts
@@ -1,0 +1,50 @@
+/**
+ * `minsky setup` top-level CLI command.
+ *
+ * Delegates execution to the shared `setup` command definition in the registry,
+ * keeping logic DRY while presenting `setup` as a top-level CLI command rather
+ * than a subcommand nested under an INIT category wrapper.
+ */
+import { Command } from "commander";
+import { sharedCommandRegistry } from "../../adapters/shared/command-registry";
+import { getErrorMessage } from "../../errors/index";
+
+export function createSetupCommand(): Command {
+  const cmd = new Command("setup");
+  cmd.description("Set up developer-local configuration for Minsky");
+
+  // Mirror all options from the shared command definition (setup.ts)
+  cmd.option("--client <client>", "MCP client to register with (e.g. cursor)");
+  cmd.option("--overwrite", "Overwrite existing config", false);
+  cmd.option("--repo <path>", "Repository path");
+  cmd.option("--workspace-path <path>", "Workspace path");
+
+  cmd.action(async (options) => {
+    try {
+      const commandDef = sharedCommandRegistry.getCommand("setup");
+      if (!commandDef) {
+        console.error("Shared command 'setup' not found in registry");
+        process.exit(1);
+      }
+
+      const result = await commandDef.execute(
+        {
+          client: options.client,
+          overwrite: options.overwrite ?? false,
+          repo: options.repo,
+          workspacePath: options.workspacePath,
+        },
+        { interface: "cli" }
+      );
+
+      const typed = result as { success: boolean; message?: string };
+      if (typed.message) console.log(typed.message);
+      if (!typed.success) process.exit(1);
+    } catch (error: unknown) {
+      console.error(`Error: ${getErrorMessage(error)}`);
+      process.exit(1);
+    }
+  });
+
+  return cmd;
+}

--- a/src/domain/configuration/schemas/knowledge-bases.ts
+++ b/src/domain/configuration/schemas/knowledge-bases.ts
@@ -5,7 +5,9 @@ import { z } from "zod";
  */
 const knowledgeSourceAuthSchema = z.object({
   /** Environment variable containing the API token */
-  tokenEnvVar: z.string(),
+  tokenEnvVar: z.string().optional(),
+  /** Direct token value (alternative to tokenEnvVar) */
+  token: z.string().optional(),
   /** Optional environment variable for email (used by some providers like Confluence) */
   emailEnvVar: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- Hides INIT category from CLI auto-generation (`hidden: true`) so it no longer creates a wrapper command
- Creates non-shared commander wrappers (`src/commands/init/index.ts`, `src/commands/setup/index.ts`) that delegate to shared command registry
- Wires into `cli.ts` with lazy loading
- `minsky init` and `minsky setup` now work directly as top-level commands (not `minsky init init` / `minsky init setup`)
- Fixes pre-existing knowledgeBases schema: accepts both `token` (direct) and `tokenEnvVar` (env var reference)

## Test plan

- [x] `minsky init --help` shows init options directly
- [x] `minsky setup --help` shows setup options directly
- [x] All tests pass (including previously-failing session-auto-task-creation tests)
- [x] MCP adapter still exposes init and setup tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)