### PR TITLE
feat(mt#923): Add provenance chain data model for authorship tier system

### DIFF
--- a/drizzle.pg.config.ts
+++ b/drizzle.pg.config.ts
@@ -49,6 +49,7 @@ export default {
     "./src/domain/storage/schemas/task-embeddings.ts",
     "./src/domain/storage/schemas/rule-embeddings.ts",
     "./src/domain/storage/schemas/task-relationships.ts",
+    "./src/domain/storage/schemas/provenance-schema.ts",
   ],
   out: "./src/domain/storage/migrations/pg",
   dialect: "postgresql",

--- a/src/domain/provenance/index.ts
+++ b/src/domain/provenance/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Authorship Provenance — public API
+ *
+ * @see mt#846 — Design: authorship semantics
+ * @see mt#923 — Phase 1: provenance chain data model
+ */
+
+export { ProvenanceService, computePreliminaryTier } from "./provenance-service";
+export {
+  AuthorshipTier,
+  type ArtifactType,
+  type CreateProvenanceInput,
+  type InitiationMode,
+  type Participant,
+  type ParticipantRole,
+  type ProvenanceRecord,
+  type SpecAuthorship,
+  type TaskOrigin,
+  type TierSignals,
+} from "./types";

--- a/src/domain/provenance/provenance-service.ts
+++ b/src/domain/provenance/provenance-service.ts
@@ -1,0 +1,152 @@
+/**
+ * Provenance Service
+ *
+ * CRUD operations for authorship provenance records. Tracks the causal chain
+ * from task → session → artifact and computes preliminary authorship tiers
+ * from static signals.
+ *
+ * The preliminary tier is a heuristic from observable signals (task origin,
+ * spec authorship, initiation mode). The final tier (Phase 4) will use
+ * AI-based transcript analysis.
+ *
+ * @see mt#923 — Phase 1: provenance chain data model
+ */
+
+import { eq, and } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+import { provenanceTable } from "../storage/schemas/provenance-schema";
+import {
+  AuthorshipTier,
+  type ArtifactType,
+  type CreateProvenanceInput,
+  type ProvenanceRecord,
+  type TierSignals,
+  type Participant,
+} from "./types";
+
+/** Maps a DB row to a typed ProvenanceRecord. */
+function toProvenanceRecord(row: typeof provenanceTable.$inferSelect): ProvenanceRecord {
+  return {
+    id: row.id,
+    artifactId: row.artifactId,
+    artifactType: row.artifactType as ArtifactType,
+    taskId: row.taskId,
+    sessionId: row.sessionId,
+    transcriptId: row.transcriptId,
+    taskOrigin: row.taskOrigin as ProvenanceRecord["taskOrigin"],
+    specAuthorship: row.specAuthorship as ProvenanceRecord["specAuthorship"],
+    initiationMode: row.initiationMode as ProvenanceRecord["initiationMode"],
+    humanMessages: row.humanMessages ?? 0,
+    totalMessages: row.totalMessages ?? 0,
+    corrections: row.corrections ?? 0,
+    participants: (row.participants ?? []) as Participant[],
+    substantiveHumanInput: row.substantiveHumanInput,
+    trajectoryChanges: row.trajectoryChanges,
+    authorshipTier: row.authorshipTier as AuthorshipTier | null,
+    tierRationale: row.tierRationale,
+    policyVersion: row.policyVersion ?? "1.0.0",
+    judgingModel: row.judgingModel,
+    computedAt: row.computedAt ?? new Date(),
+    createdAt: row.createdAt ?? new Date(),
+    updatedAt: row.updatedAt ?? new Date(),
+  };
+}
+
+/**
+ * Compute a preliminary authorship tier from static signals.
+ *
+ * Heuristic:
+ * - Agent-originated + autonomous → Tier 3 (agent-authored)
+ * - Human-originated + human-authored spec → Tier 1 (human-authored)
+ * - Everything else → Tier 2 (co-authored, the honest middle ground)
+ */
+export function computePreliminaryTier(signals: TierSignals): AuthorshipTier {
+  if (signals.taskOrigin === "agent" && signals.initiationMode === "autonomous") {
+    return AuthorshipTier.AGENT_AUTHORED;
+  }
+  if (signals.taskOrigin === "human" && signals.specAuthorship === "human") {
+    return AuthorshipTier.HUMAN_AUTHORED;
+  }
+  return AuthorshipTier.CO_AUTHORED;
+}
+
+export class ProvenanceService {
+  constructor(private readonly db: PostgresJsDatabase) {}
+
+  /** Create a provenance record with a preliminary tier computed from static signals. */
+  async createProvenanceRecord(input: CreateProvenanceInput): Promise<ProvenanceRecord> {
+    const tier = computePreliminaryTier({
+      taskOrigin: input.taskOrigin,
+      specAuthorship: input.specAuthorship,
+      initiationMode: input.initiationMode,
+    });
+
+    const tierRationale = `Preliminary tier from static signals: task_origin=${input.taskOrigin ?? "unknown"}, spec_authorship=${input.specAuthorship ?? "unknown"}, initiation_mode=${input.initiationMode ?? "unknown"}`;
+
+    const rows = await this.db
+      .insert(provenanceTable)
+      .values({
+        artifactId: input.artifactId,
+        artifactType: input.artifactType,
+        taskId: input.taskId ?? null,
+        sessionId: input.sessionId ?? null,
+        taskOrigin: input.taskOrigin ?? null,
+        specAuthorship: input.specAuthorship ?? null,
+        initiationMode: input.initiationMode ?? null,
+        humanMessages: input.humanMessages ?? 0,
+        totalMessages: input.totalMessages ?? 0,
+        corrections: input.corrections ?? 0,
+        participants: (input.participants ?? []) as Participant[],
+        authorshipTier: tier,
+        tierRationale,
+      })
+      .returning();
+
+    const row = rows[0];
+    if (!row) {
+      throw new Error("Failed to insert provenance record — no row returned");
+    }
+    return toProvenanceRecord(row);
+  }
+
+  /** Look up provenance for a specific artifact. */
+  async getProvenanceForArtifact(
+    artifactId: string,
+    artifactType: ArtifactType
+  ): Promise<ProvenanceRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(provenanceTable)
+      .where(
+        and(
+          eq(provenanceTable.artifactId, artifactId),
+          eq(provenanceTable.artifactType, artifactType)
+        )
+      )
+      .limit(1);
+
+    const row = rows[0];
+    return row ? toProvenanceRecord(row) : null;
+  }
+
+  /** Get all provenance records for a session. */
+  async getProvenanceForSession(sessionId: string): Promise<ProvenanceRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(provenanceTable)
+      .where(eq(provenanceTable.sessionId, sessionId));
+
+    return rows.map(toProvenanceRecord);
+  }
+
+  /** Get all provenance records linked to a task. */
+  async getProvenanceForTask(taskId: string): Promise<ProvenanceRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(provenanceTable)
+      .where(eq(provenanceTable.taskId, taskId));
+
+    return rows.map(toProvenanceRecord);
+  }
+}

--- a/src/domain/provenance/types.ts
+++ b/src/domain/provenance/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Authorship Provenance Types
+ *
+ * Domain types for the three-tier authorship model. Provenance records track
+ * the causal chain from task → session → artifact, with observable signals
+ * that feed into tier computation.
+ *
+ * @see mt#846 — Design: authorship semantics for bot-identity operations
+ * @see mt#923 — Phase 1: provenance chain data model
+ */
+
+/** Authorship tier — determines git author, trailers, and PR labels. */
+export enum AuthorshipTier {
+  /** Human provided substantial direction and design. */
+  HUMAN_AUTHORED = 1,
+  /** Mixed contribution — both human and agent shaped the outcome. */
+  CO_AUTHORED = 2,
+  /** Agent-initiated with minimal human involvement. */
+  AGENT_AUTHORED = 3,
+}
+
+/** Role a participant played in producing the artifact. */
+export type ParticipantRole = "director" | "implementer" | "reviewer" | "approver";
+
+/** How the work was initiated. */
+export type InitiationMode = "dispatched" | "autonomous" | "interactive";
+
+/** Who created the originating task. */
+export type TaskOrigin = "human" | "agent" | "automated";
+
+/** Who authored the task spec. */
+export type SpecAuthorship = "human" | "agent" | "mixed";
+
+/** Type of artifact tracked by provenance. */
+export type ArtifactType = "commit" | "pr" | "review" | "issue_comment";
+
+/** A participant in the artifact's creation. */
+export interface Participant {
+  identity: string;
+  role: ParticipantRole;
+}
+
+/** Full provenance record as stored in the database. */
+export interface ProvenanceRecord {
+  id: string;
+  artifactId: string;
+  artifactType: ArtifactType;
+  taskId: string | null;
+  sessionId: string | null;
+  transcriptId: string | null;
+  taskOrigin: TaskOrigin | null;
+  specAuthorship: SpecAuthorship | null;
+  initiationMode: InitiationMode | null;
+  humanMessages: number;
+  totalMessages: number;
+  corrections: number;
+  participants: Participant[];
+  substantiveHumanInput: string | null;
+  trajectoryChanges: unknown | null;
+  authorshipTier: AuthorshipTier | null;
+  tierRationale: string | null;
+  policyVersion: string;
+  judgingModel: string | null;
+  computedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Input for creating a provenance record — computed fields omitted. */
+export interface CreateProvenanceInput {
+  artifactId: string;
+  artifactType: ArtifactType;
+  taskId?: string;
+  sessionId?: string;
+  taskOrigin?: TaskOrigin;
+  specAuthorship?: SpecAuthorship;
+  initiationMode?: InitiationMode;
+  humanMessages?: number;
+  totalMessages?: number;
+  corrections?: number;
+  participants?: Participant[];
+}
+
+/** Signals used for preliminary tier computation. */
+export interface TierSignals {
+  taskOrigin?: TaskOrigin;
+  specAuthorship?: SpecAuthorship;
+  initiationMode?: InitiationMode;
+}

--- a/src/domain/storage/migrations/pg/0021_provenance_chain.sql
+++ b/src/domain/storage/migrations/pg/0021_provenance_chain.sql
@@ -1,0 +1,33 @@
+-- Create provenance table for authorship provenance chain records
+-- Every Minsky-managed artifact (commit, PR, review) gets an associated provenance
+-- record linking it to its task, session, and authorship signals.
+CREATE TABLE IF NOT EXISTS "provenance" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"artifact_id" text NOT NULL,
+	"artifact_type" text NOT NULL,
+	"task_id" text,
+	"session_id" text,
+	"transcript_id" text,
+	"task_origin" text,
+	"spec_authorship" text,
+	"initiation_mode" text,
+	"human_messages" integer DEFAULT 0,
+	"total_messages" integer DEFAULT 0,
+	"corrections" integer DEFAULT 0,
+	"participants" jsonb DEFAULT '[]'::jsonb,
+	"substantive_human_input" text,
+	"trajectory_changes" jsonb,
+	"authorship_tier" integer,
+	"tier_rationale" text,
+	"policy_version" text DEFAULT '1.0.0',
+	"judging_model" text,
+	"computed_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provenance_artifact" ON "provenance" ("artifact_id","artifact_type");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provenance_session" ON "provenance" ("session_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provenance_task" ON "provenance" ("task_id");

--- a/src/domain/storage/migrations/pg/meta/_journal.json
+++ b/src/domain/storage/migrations/pg/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1745020800000,
       "tag": "0020_knowledge_embeddings",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1745107200000,
+      "tag": "0021_provenance_chain",
+      "breakpoints": true
     }
   ]
 }

--- a/src/domain/storage/schemas/provenance-schema.ts
+++ b/src/domain/storage/schemas/provenance-schema.ts
@@ -1,0 +1,62 @@
+import { pgTable, text, uuid, integer, timestamp, index, jsonb } from "drizzle-orm/pg-core";
+
+/**
+ * Provenance table — authorship provenance chain records for Minsky-managed artifacts.
+ *
+ * Every commit, PR, or review created by Minsky gets an associated provenance record
+ * linking it to its task, session, and authorship signals. The preliminary authorship
+ * tier is computed from static signals at creation time; AI-judged fields are populated
+ * later (Phase 4).
+ *
+ * Conventions followed:
+ * - UUID PK (same as task_relationships)
+ * - No FK constraints — task_id/session_id are plain text refs per project convention
+ * - jsonb for structured metadata (participants, trajectory_changes)
+ * - withTimezone on all timestamps
+ */
+export const provenanceTable = pgTable(
+  "provenance",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+
+    // Artifact identity
+    artifactId: text("artifact_id").notNull(), // commit SHA, PR number, review ID
+    artifactType: text("artifact_type").notNull(), // 'commit' | 'pr' | 'review' | 'issue_comment'
+
+    // Causal chain (plain text refs, no FKs per convention)
+    taskId: text("task_id"), // originating task (nullable for taskless sessions)
+    sessionId: text("session_id"), // Minsky session ID
+    transcriptId: text("transcript_id"), // future: reference to stored transcript
+
+    // Static signals
+    taskOrigin: text("task_origin"), // 'human' | 'agent' | 'automated'
+    specAuthorship: text("spec_authorship"), // 'human' | 'agent' | 'mixed'
+    initiationMode: text("initiation_mode"), // 'dispatched' | 'autonomous' | 'interactive'
+    humanMessages: integer("human_messages").default(0),
+    totalMessages: integer("total_messages").default(0),
+    corrections: integer("corrections").default(0),
+
+    // Participants: [{identity: string, role: ParticipantRole}]
+    participants: jsonb("participants").default([]),
+
+    // AI-judged fields (populated in Phase 4, nullable for now)
+    substantiveHumanInput: text("substantive_human_input"),
+    trajectoryChanges: jsonb("trajectory_changes"),
+
+    // Tier
+    authorshipTier: integer("authorship_tier"), // 1 | 2 | 3
+    tierRationale: text("tier_rationale"),
+
+    // Audit
+    policyVersion: text("policy_version").default("1.0.0"),
+    judgingModel: text("judging_model"),
+    computedAt: timestamp("computed_at", { withTimezone: true }).defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    byArtifact: index("idx_provenance_artifact").on(table.artifactId, table.artifactType),
+    bySession: index("idx_provenance_session").on(table.sessionId),
+    byTask: index("idx_provenance_task").on(table.taskId),
+  })
+);


### PR DESCRIPTION
## Summary

Phase 1 of the authorship tier system (mt#922). Introduces the foundational data model for tracking authorship provenance chains.

- **Drizzle schema** (`provenance-schema.ts`): `provenance` table with UUID PK, artifact identity, causal chain refs (task/session), static signals (task origin, spec authorship, initiation mode), AI-judged fields (nullable for Phase 4), authorship tier, and audit metadata
- **Migration 0021**: Creates the table with indexes on artifact, session, and task
- **Domain types** (`src/domain/provenance/types.ts`): `AuthorshipTier` enum, `ProvenanceRecord`, `CreateProvenanceInput`, `TierSignals`, participant/role types
- **ProvenanceService**: CRUD operations + preliminary tier computation from static signals
- **Tier heuristic**: agent+autonomous → Tier 3, human+human-spec → Tier 1, else → Tier 2

## Test plan

- [ ] Migration applies cleanly to Postgres (`minsky persistence migrate`)
- [ ] ProvenanceService CRUD operations work against real DB
- [ ] `computePreliminaryTier` returns correct tier for each signal combination
- [ ] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)