### PR TITLE
fix(mt#927): return pre-built message before lossy task formatter in formatResult

### DIFF
--- a/src/adapters/shared/commands/tasks/base-task-command.ts
+++ b/src/adapters/shared/commands/tasks/base-task-command.ts
@@ -145,6 +145,14 @@ export abstract class BaseTaskCommand<TParams = BaseTaskParams, TResult = unknow
       // Handle individual task details
       if (typeof result === "object" && result !== null && "task" in result) {
         const taskResult = result as Record<string, unknown>;
+
+        // Prefer the pre-built message — commands build it with full context
+        // (spec content, dep warnings, edit details, etc.) that the generic
+        // formatter below would lose.
+        if (taskResult.message && typeof taskResult.message === "string") {
+          return taskResult.message;
+        }
+
         const task = taskResult.task;
         if (task && typeof task === "object" && !Array.isArray(task)) {
           const { formatTaskIdForDisplay } = require("../../../../domain/tasks/task-id-utils");
@@ -154,8 +162,6 @@ export abstract class BaseTaskCommand<TParams = BaseTaskParams, TResult = unknow
           let output = `${displayId}: ${taskObj.title}\n`;
           output += `Status: ${taskObj.status}\n`;
 
-          // Note: Task objects don't contain spec content directly
-          // Spec content needs to be fetched separately via getTaskSpecContent
           if (taskObj.spec) {
             output += `Spec: ${taskObj.spec}\n`;
           }


### PR DESCRIPTION
## Summary

- `formatResult` in `base-task-command.ts` checked `"task" in result` before `"message" in result`, causing the lossy formatter (title + status only) to shadow the pre-built message that contains spec content, dep warnings, subtask info, etc.
- Added an early return at the top of the `"task"` branch: if `taskResult.message` is a non-empty string, return it directly.
- The generic task formatter is now a fallback for results that genuinely have no message.
- Removed the stale comment claiming spec content "needs to be fetched separately" — it is already in the message.

## Test plan

- [ ] Run `bun test --preload ./tests/setup.ts --timeout=15000 src/adapters/shared/commands/tasks/` and confirm all tests pass
- [ ] Verify that `tasks get`, `tasks edit`, and similar commands display full output (spec content, dep warnings) rather than just title + status

🤖 Generated with [Claude Code](https://claude.com/claude-code)