### PR TITLE
feat(mt#924): Add authorship tier labels to PRs

### DIFF
--- a/src/domain/provenance/authorship-labels.ts
+++ b/src/domain/provenance/authorship-labels.ts
@@ -100,7 +100,8 @@ export async function ensureAuthorshipLabelsExist(
         // 404 → label does not exist yet, fall through to creation
       }
 
-      const cfg = LABEL_CONFIG[labelName]!;
+      const cfg = LABEL_CONFIG[labelName];
+      if (!cfg) continue;
       await octokit.rest.issues.createLabel({
         owner,
         repo,

--- a/src/domain/provenance/authorship-labels.ts
+++ b/src/domain/provenance/authorship-labels.ts
@@ -1,0 +1,137 @@
+/**
+ * Authorship PR Labels
+ *
+ * Utilities for creating and applying authorship tier labels to GitHub PRs.
+ * Labels are idempotently created on-demand, then applied to PRs as part of
+ * the `session_pr_create` flow.
+ *
+ * @see mt#924 — Phase 2: authorship labels on PRs
+ */
+
+import { log } from "../../utils/logger";
+import { getErrorMessage } from "../../errors/index";
+import { AuthorshipTier } from "./types";
+
+// ── Label name constants ────────────────────────────────────────────────────
+
+export const LABEL_HUMAN_AUTHORED = "authorship/human-authored";
+export const LABEL_CO_AUTHORED = "authorship/co-authored";
+export const LABEL_AGENT_AUTHORED = "authorship/agent-authored";
+
+/** All three authorship label names. */
+export const AUTHORSHIP_LABELS = [
+  LABEL_HUMAN_AUTHORED,
+  LABEL_CO_AUTHORED,
+  LABEL_AGENT_AUTHORED,
+] as const;
+
+/** Maps an AuthorshipTier value to the corresponding GitHub label name. */
+export function tierToLabel(tier: AuthorshipTier): string {
+  switch (tier) {
+    case AuthorshipTier.HUMAN_AUTHORED:
+      return LABEL_HUMAN_AUTHORED;
+    case AuthorshipTier.CO_AUTHORED:
+      return LABEL_CO_AUTHORED;
+    case AuthorshipTier.AGENT_AUTHORED:
+      return LABEL_AGENT_AUTHORED;
+  }
+}
+
+// ── Octokit interface (minimal surface for label ops) ───────────────────────
+
+interface OctokitLabelClient {
+  rest: {
+    issues: {
+      getLabel(params: { owner: string; repo: string; name: string }): Promise<unknown>;
+      createLabel(params: {
+        owner: string;
+        repo: string;
+        name: string;
+        color: string;
+        description: string;
+      }): Promise<unknown>;
+      addLabels(params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        labels: string[];
+      }): Promise<unknown>;
+    };
+  };
+}
+
+/** Label configuration: name → { color, description }. */
+const LABEL_CONFIG: Record<string, { color: string; description: string }> = {
+  [LABEL_HUMAN_AUTHORED]: {
+    color: "0e8a16", // green
+    description: "Authored primarily by a human",
+  },
+  [LABEL_CO_AUTHORED]: {
+    color: "0052cc", // blue
+    description: "Co-authored by human and AI agent",
+  },
+  [LABEL_AGENT_AUTHORED]: {
+    color: "5319e7", // purple
+    description: "Authored primarily by an AI agent",
+  },
+};
+
+/**
+ * Idempotently ensure all three authorship labels exist in the repo.
+ * Creates any labels that are missing; skips existing ones.
+ */
+export async function ensureAuthorshipLabelsExist(
+  octokit: OctokitLabelClient,
+  owner: string,
+  repo: string
+): Promise<void> {
+  for (const labelName of AUTHORSHIP_LABELS) {
+    try {
+      // Check whether the label already exists
+      try {
+        await octokit.rest.issues.getLabel({ owner, repo, name: labelName });
+        log.debug(`Authorship label already exists: ${labelName}`);
+        continue;
+      } catch (error: unknown) {
+        const httpError = error as { status?: number };
+        if (httpError.status !== 404) {
+          throw error;
+        }
+        // 404 → label does not exist yet, fall through to creation
+      }
+
+      const cfg = LABEL_CONFIG[labelName]!;
+      await octokit.rest.issues.createLabel({
+        owner,
+        repo,
+        name: labelName,
+        color: cfg.color,
+        description: cfg.description,
+      });
+      log.debug(`Created authorship label: ${labelName}`);
+    } catch (error) {
+      log.warn(`Failed to ensure authorship label "${labelName}": ${getErrorMessage(error)}`);
+    }
+  }
+}
+
+/**
+ * Add the authorship tier label to a GitHub PR (issue).
+ * Assumes `ensureAuthorshipLabelsExist` has already been called.
+ */
+export async function addAuthorshipLabel(
+  octokit: OctokitLabelClient,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  tier: AuthorshipTier
+): Promise<void> {
+  const labelName = tierToLabel(tier);
+  await octokit.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: prNumber,
+    labels: [labelName],
+  });
+  log.debug(`Added authorship label "${labelName}" to PR #${prNumber}`);
+}

--- a/src/domain/provenance/index.ts
+++ b/src/domain/provenance/index.ts
@@ -18,3 +18,12 @@ export {
   type TaskOrigin,
   type TierSignals,
 } from "./types";
+export {
+  LABEL_HUMAN_AUTHORED,
+  LABEL_CO_AUTHORED,
+  LABEL_AGENT_AUTHORED,
+  AUTHORSHIP_LABELS,
+  tierToLabel,
+  ensureAuthorshipLabelsExist,
+  addAuthorshipLabel,
+} from "./authorship-labels";

--- a/src/domain/repository/github-pr-operations.ts
+++ b/src/domain/repository/github-pr-operations.ts
@@ -21,6 +21,8 @@ import {
   handleMerge405or422,
   type ErrorContext,
 } from "./github-error-handler";
+import type { AuthorshipTier } from "../provenance/types";
+import { ensureAuthorshipLabelsExist, addAuthorshipLabel } from "../provenance/authorship-labels";
 
 // ── Shared helpers ──────────────────────────────────────────────────────
 
@@ -112,7 +114,8 @@ export async function createPullRequest(
   workdir: string,
   session: string | undefined,
   draft: boolean,
-  getSessionDB: () => Promise<SessionProviderInterface>
+  getSessionDB: () => Promise<SessionProviderInterface>,
+  authorshipTier?: AuthorshipTier
 ): Promise<PRInfo> {
   try {
     // Ensure the source branch is pushed to the remote
@@ -189,6 +192,19 @@ export async function createPullRequest(
         }
       } catch (error) {
         log.debug(`Failed to update session record with PR info: ${error}`);
+      }
+    }
+
+    // Apply authorship tier label if a tier was provided
+    if (authorshipTier !== undefined) {
+      try {
+        await ensureAuthorshipLabelsExist(octokit, gh.owner, gh.repo);
+        await addAuthorshipLabel(octokit, gh.owner, gh.repo, pr.number, authorshipTier);
+      } catch (labelError) {
+        // Label failure is non-fatal — warn but don't block PR creation
+        log.warn(
+          `Failed to apply authorship label to PR #${pr.number}: ${getErrorMessage(labelError)}`
+        );
       }
     }
 

--- a/src/domain/repository/github.ts
+++ b/src/domain/repository/github.ts
@@ -613,7 +613,8 @@ Repository: https://github.com/${this.owner}/${this.repo}
           workdir,
           options.session,
           options.draft || false,
-          () => this.getSessionDB()
+          () => this.getSessionDB(),
+          options.authorshipTier
         );
       },
 

--- a/src/domain/repository/index.ts
+++ b/src/domain/repository/index.ts
@@ -215,6 +215,8 @@ export interface CreatePROptions {
   baseBranch: string;
   session?: string;
   draft?: boolean;
+  /** Optional authorship tier — when provided, the corresponding label is applied to the PR. */
+  authorshipTier?: import("../provenance/types").AuthorshipTier;
 }
 
 export interface UpdatePROptions {

--- a/src/domain/session/session-pr-operations.ts
+++ b/src/domain/session/session-pr-operations.ts
@@ -22,7 +22,8 @@ import {
 } from "../repository/index";
 import type { SessionRecord } from "./types";
 import { assertSessionMutable } from "./session-mutability";
-import type { PersistenceProvider } from "../persistence/types";
+import type { PersistenceProvider, SqlCapablePersistenceProvider } from "../persistence/types";
+import { ProvenanceService, computePreliminaryTier } from "../provenance/provenance-service";
 
 export interface SessionPrDependencies {
   sessionDB: SessionProviderInterface;
@@ -313,7 +314,14 @@ Please provide a title for your pull request:
       preparedContent.warnings.forEach((warning) => log.warn(`PR Content Warning: ${warning}`));
     }
 
-    // Use repository backend to create pull request
+    // Compute authorship tier from static signals for label application
+    const authorshipTier = computePreliminaryTier({
+      taskOrigin: "human", // default: human-dispatched sessions
+      specAuthorship: "mixed", // default: mixed authorship
+      initiationMode: "dispatched", // all current sessions are human-dispatched
+    });
+
+    // Use repository backend to create pull request (includes authorship label)
     const baseBranch = params.baseBranch || "main";
     const prInfo = await repositoryBackend.pr.create({
       title: preparedContent.title,
@@ -322,11 +330,40 @@ Please provide a title for your pull request:
       baseBranch,
       session: sessionId,
       draft: params.draft || false,
+      authorshipTier,
     });
 
     log.cli(`✅ Pull request created successfully!`);
 
     // PR state persistence is handled by repository backends
+
+    // Record provenance for the created PR (non-fatal — failures log and continue)
+    if (deps.persistenceProvider) {
+      try {
+        const provider = deps.persistenceProvider as SqlCapablePersistenceProvider;
+        if (provider.getDatabaseConnection) {
+          const db = await provider.getDatabaseConnection();
+          if (db) {
+            const provenanceService = new ProvenanceService(db);
+            await provenanceService.createProvenanceRecord({
+              artifactId: String(prInfo.number),
+              artifactType: "pr",
+              taskId: sessionRecord?.taskId ?? undefined,
+              sessionId,
+              taskOrigin: "human",
+              specAuthorship: "mixed",
+              initiationMode: "dispatched",
+              participants: [],
+            });
+            log.debug(`Recorded provenance for PR #${prInfo.number}`);
+          }
+        }
+      } catch (provenanceError) {
+        log.warn(
+          `Failed to record provenance for PR #${prInfo.number}: ${getErrorMessage(provenanceError)}`
+        );
+      }
+    }
 
     // Update task status to IN-REVIEW if associated with a task
     if (!params.noStatusUpdate) {


### PR DESCRIPTION
## Summary

Phase 2 of the authorship tier system (mt#922). Hooks the provenance system into `session_pr_create` to compute a preliminary authorship tier, create a provenance record, and add a GitHub label.

- **`authorship-labels.ts`**: Label constants (`authorship/human-authored`, `authorship/co-authored`, `authorship/agent-authored`), idempotent label creation, label assignment via Octokit
- **`github-pr-operations.ts`**: Optional `authorshipTier` parameter on `createPullRequest()`, label applied after PR creation (non-fatal try/catch)
- **`session-pr-operations.ts`**: Computes preliminary tier via `computePreliminaryTier()`, passes to PR creation, records provenance via `ProvenanceService` (non-fatal)
- **Graceful degradation**: Both provenance recording and label assignment are wrapped in try/catch — failures log warnings but don't block PR creation

## Test plan

- [ ] Creating a PR via `session_pr_create` adds an `authorship/*` label
- [ ] Labels are created idempotently (no error on second PR creation)
- [ ] Provenance record exists in DB after PR creation
- [ ] Label/provenance failure doesn't block PR creation
- [ ] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)