### PR TITLE
fix(mt#939): thread sessionProvider through BaseGitOperation to GitService

### DIFF
--- a/smoke-test.txt
+++ b/smoke-test.txt
@@ -1,1 +1,0 @@
-smoke test

--- a/smoke-test.txt
+++ b/smoke-test.txt
@@ -1,0 +1,1 @@
+smoke test

--- a/src/domain/git.ts
+++ b/src/domain/git.ts
@@ -3,11 +3,7 @@ import { join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { normalizeRepoName } from "./repo-utils";
 import { execAsync } from "../utils/exec";
-import {
-  createSessionProvider,
-  type SessionProviderInterface,
-  type SessionRecord,
-} from "./session";
+import { type SessionProviderInterface, type SessionRecord } from "./session";
 
 import { log } from "../utils/logger";
 import { getMinskyStateDir } from "../utils/paths";
@@ -114,7 +110,10 @@ export class GitService implements GitServiceInterface {
 
   private async getSessionDb(): Promise<SessionProviderInterface> {
     if (!this.sessionDb) {
-      this.sessionDb = await createSessionProvider({ dbPath: process.cwd() });
+      throw new Error(
+        "GitService has no sessionProvider. " +
+          "Pass sessionProvider via constructor deps or use the DI container."
+      );
     }
     return this.sessionDb;
   }

--- a/src/domain/git/operations/base-git-operation.ts
+++ b/src/domain/git/operations/base-git-operation.ts
@@ -16,7 +16,10 @@ import type { SessionProviderInterface } from "../../session/index";
  * Common dependencies for git operations
  */
 export interface GitOperationDependencies {
-  createGitService: (options?: { baseDir?: string }) => GitServiceInterface;
+  createGitService: (options?: {
+    baseDir?: string;
+    sessionProvider?: SessionProviderInterface;
+  }) => GitServiceInterface;
   sessionProvider?: SessionProviderInterface;
 }
 
@@ -60,8 +63,10 @@ export abstract class BaseGitOperation<TParams, TResult> {
       // Validate parameters if schema provided
       const validParams = this.validateParams(params);
 
-      // Create git service
-      const gitService = this.deps.createGitService();
+      // Create git service with sessionProvider so it doesn't need to create its own
+      const gitService = this.deps.createGitService({
+        sessionProvider: this.deps.sessionProvider,
+      });
 
       // Resolve session to repo path if session is provided but repo is not
       const baseParams = validParams as BaseGitOperationParams;


### PR DESCRIPTION
## Summary

- `BaseGitOperation.execute()` called `createGitService()` without passing the `sessionProvider` available in `this.deps`
- `GitService` then fell back to creating its own session provider via `createSessionProvider()` without persistence, causing the same "requires a persistence dependency" error on `session_commit` and `git_push`
- Now passes `sessionProvider` through to `createGitService()`, eliminating the fallback path
- `GitService.getSessionDb()` now throws a clear error instead of silently attempting an impossible operation

Follow-up to #605 (mt#936) — same class of error, different code path.

## Test plan

- [ ] `session_commit` works via MCP after restart
- [ ] `git_push` works via MCP after restart
- [ ] All unit tests pass (verified in pre-commit + pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)