### PR TITLE
fix(mt#944): pass deps through to updateSessionFromParams in PR create

### DIFF
--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -42,47 +42,6 @@ export interface SessionUpdateParams {
 }
 
 /**
- * Pure session update domain function
- */
-export async function pureSessionUpdate(params: SessionUpdateParams): Promise<{
-  success: boolean;
-  message: string;
-}> {
-  if (!params.session) {
-    throw new MinskyError("Session parameter is required", "VALIDATION_ERROR");
-  }
-
-  log.debug("Pure session update command", { session: params.session });
-
-  const { updateSessionFromParams } = await import("../session.js");
-
-  try {
-    await updateSessionFromParams({
-      name: params.session,
-      branch: params.branch,
-      force: params.force ?? false,
-      dryRun: params.dryRun ?? false,
-      noStash: params.noStash ?? false,
-      noPush: params.noPush ?? false,
-      skipConflictCheck: params.skipConflictCheck ?? false,
-      skipIfAlreadyMerged: params.skipIfAlreadyMerged ?? false,
-      autoResolveDeleteConflicts: params.autoResolveDeleteConflicts ?? false,
-    });
-
-    return {
-      success: true,
-      message: "Session updated successfully",
-    };
-  } catch (error) {
-    log.debug("Pure session update failed", {
-      error: error instanceof Error ? error.message : String(error),
-      session: params.session,
-    });
-    throw error;
-  }
-}
-
-/**
  * Pure domain interface for session approval
  */
 export interface SessionApproveParams {

--- a/src/domain/session/session-pr-operations.ts
+++ b/src/domain/session/session-pr-operations.ts
@@ -237,19 +237,23 @@ Please provide a title for your pull request:
   log.cli("🔍 Checking for conflicts before PR creation...");
 
   try {
-    // Use enhanced update with conflict detection options
-    await updateSessionFromParams({
-      name: sessionId,
-      repo: params.repo,
-      json: false,
-      force: false,
-      noStash: false,
-      noPush: false,
-      dryRun: false,
-      skipConflictCheck: params.skipConflictCheck,
-      autoResolveDeleteConflicts: params.autoResolveDeleteConflicts,
-      skipIfAlreadyMerged: true, // Automatically skip if changes already merged
-    });
+    // Use enhanced update with conflict detection options — pass deps through
+    // so updateSessionFromParams doesn't try to create its own sessionProvider.
+    await updateSessionFromParams(
+      {
+        name: sessionId,
+        repo: params.repo,
+        json: false,
+        force: false,
+        noStash: false,
+        noPush: false,
+        dryRun: false,
+        skipConflictCheck: params.skipConflictCheck,
+        autoResolveDeleteConflicts: params.autoResolveDeleteConflicts,
+        skipIfAlreadyMerged: true, // Automatically skip if changes already merged
+      },
+      { sessionDB: deps.sessionDB, gitService: deps.gitService }
+    );
     log.cli("✅ Session updated successfully");
   } catch (error) {
     const errorMessage = getErrorMessage(error);


### PR DESCRIPTION
## Summary

- `sessionPrImpl` called `updateSessionFromParams()` without forwarding its available `sessionDB` and `gitService` deps
- The callee then tried to create its own sessionProvider without persistence, causing "Cannot create sessionProvider" on `session_pr_create`
- Also deleted `pureSessionUpdate` — dead code (never imported) with the same bug pattern baked in

Third and final instance of the "deps available but not threaded through" class of errors (mt#936, mt#939, mt#944).

## Test plan

- [ ] `session_pr_create` works via MCP after restart
- [ ] All unit tests pass (verified in pre-commit + pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)