### PR TITLE
fix(mt#942): improve error message for missing persistence and add MCP health check

### DIFF
--- a/src/commands/mcp/start-command.ts
+++ b/src/commands/mcp/start-command.ts
@@ -47,6 +47,14 @@ async function registerAllTools(
     log.debug("Container initialized for MCP server");
   }
 
+  // Health check: verify critical dependencies are available after init
+  if (container && !container.has("sessionProvider")) {
+    log.error(
+      "MCP startup health check failed: sessionProvider not available after container init. " +
+        "Session tools will fail. Check database connectivity."
+    );
+  }
+
   // Register debug tools first to ensure they're available for debugging
   registerDebugTools(commandMapper, container);
 

--- a/src/domain/session/session-db-adapter.ts
+++ b/src/domain/session/session-db-adapter.ts
@@ -322,8 +322,9 @@ export async function createSessionProvider(
 ): Promise<SessionProviderInterface> {
   if (!deps) {
     throw new Error(
-      "createSessionProvider requires a persistence dependency. " +
-        "Pass a PersistenceProvider or CreateSessionProviderDeps object."
+      "Session provider unavailable: no persistence dependency provided. " +
+        "This usually means the DI container was not initialized before tool " +
+        "registration. If running as an MCP server, restart with /mcp."
     );
   }
 


### PR DESCRIPTION
## Summary

- Replace opaque "createSessionProvider requires a persistence dependency" with actionable guidance pointing to DI container initialization and `/mcp` restart
- Add post-init health check in MCP startup that logs when `sessionProvider` is unavailable after container init

## Context

The original error was caused by the MCP server running stale code (before mt#936 fixed container initialization). The error message gave no indication of what to do. Now it says:

> "Session provider unavailable: no persistence dependency provided. This usually means the DI container was not initialized before tool registration. If running as an MCP server, restart with /mcp."

## Test plan

- [x] Error message is clear and actionable
- [x] Health check logs at error level if sessionProvider missing post-init

🤖 Generated with [Claude Code](https://claude.com/claude-code)