### PR TITLE
fix(mt#947): remove CI & Branch Protection section from CLAUDE.md — defer to orchestrate skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Minsky exposes 80+ MCP tools. Use them for all task and session operations inste
 ### CI & Branch Protection
 
 - **Main branch is protected** — all PRs must pass CI checks (`build` + `Prevent Placeholder Tests`) before merging.
-- **Never merge with failing or pending checks** — always wait for `get_check_runs` to show all checks as `status: "completed"` with `conclusion: "success"` before merging.
+- **Never merge with failing or pending checks** — use the `orchestrate` skill's merge step (step 6) to wait for CI and merge.
 - **The build must always be green** — if CI fails, investigate and fix before merging. Never bypass with the GitHub API.
 - **Tests must be hermetic** — no environment-dependent tests that pass locally but fail in CI. If a test needs local config/db/git, it's an integration test and must handle missing deps gracefully (not with `test.skipIf(isCI)`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,13 +196,6 @@ Minsky exposes 80+ MCP tools. Use them for all task and session operations inste
 - **Format**: `bun run format:check` / `bun run format:all`
 - **All checks**: `bun run validate-all`
 
-### CI & Branch Protection
-
-- **Main branch is protected** — all PRs must pass CI checks (`build` + `Prevent Placeholder Tests`) before merging.
-- **Never merge with failing or pending checks** — use the `orchestrate` skill's merge step (step 6) to wait for CI and merge.
-- **The build must always be green** — if CI fails, investigate and fix before merging. Never bypass with the GitHub API.
-- **Tests must be hermetic** — no environment-dependent tests that pass locally but fail in CI. If a test needs local config/db/git, it's an integration test and must handle missing deps gracefully (not with `test.skipIf(isCI)`).
-
 ## Hook Files
 
 - **All `.claude/hooks/*.ts` files must have execute permission** (`chmod +x`). The `Write` tool creates files with `644` by default — always run `chmod +x` after creating a hook file.


### PR DESCRIPTION
## Summary

Remove the CI & Branch Protection section from CLAUDE.md. This content is redundant:
- **CI waiting + merge flow** → covered by `orchestrate` skill step 6 (`session_pr_checks` with `wait: true`)
- **Test hermiticity** → covered by memory (`feedback_test_hermiticity.md`, `feedback_fakes_not_real_resources.md`)

CLAUDE.md was also actively wrong — it referenced `get_check_runs` as the CI tool instead of `session_pr_checks`.

### Documentation impact

- CLAUDE.md: 7 lines removed (CI & Branch Protection section)
- No other docs reference this section
- Skills and memory already cover the content

## Spec verification

**Task:** mt#947

| Criterion | Status | Evidence |
|---|---|---|
| No get_check_runs reference in CLAUDE.md | Met | Section removed entirely |
| CI guidance deferred to orchestrate skill | Met | Skill step 6 is authoritative |

🤖 Generated with [Claude Code](https://claude.com/claude-code)