### PR TITLE
feat(mt#940): add session.pr.review_context tool for single-call review data

### DIFF
--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -31,6 +31,7 @@ import {
   createSessionPrGetCommand,
   createSessionPrOpenCommand,
   createSessionPrChecksCommand,
+  createSessionPrReviewContextCommand,
 } from "./session/workflow-commands";
 import { createSessionConflictsCommand } from "./session/conflicts-command";
 import { createSessionRepairCommand } from "./session/repair-command";
@@ -89,6 +90,7 @@ export async function registerSessionCommands(
     createSessionPrApproveCommand(getDeps),
     createSessionPrMergeCommand(getDeps),
     createSessionPrChecksCommand(getDeps),
+    createSessionPrReviewContextCommand(getDeps),
 
     // Migration
     createSessionMigrateCommand(getDeps),

--- a/src/adapters/shared/commands/session/pr-review-context-command.ts
+++ b/src/adapters/shared/commands/session/pr-review-context-command.ts
@@ -1,0 +1,76 @@
+/**
+ * Session PR Review Context Command
+ *
+ * Adapter command that fetches all PR review data in a single composed call:
+ * PR metadata, CI checks, diff, and task spec.
+ */
+
+import { z } from "zod";
+import { CommandCategory, type CommandDefinition } from "../../command-registry";
+import { MinskyError, getErrorMessage } from "../../../../errors/index";
+import { type LazySessionDeps, withErrorLogging } from "./types";
+import { sessionPrReviewContext } from "../../../../domain/session/commands/pr-review-context-subcommand";
+
+// ── Parameter definitions ────────────────────────────────────────────────
+
+export const sessionPrReviewContextCommandParams = {
+  sessionId: {
+    schema: z.string(),
+    description: "Session ID (positional)",
+    required: false,
+  },
+  name: {
+    schema: z.string(),
+    description: "Session name",
+    required: false,
+  },
+  task: {
+    schema: z.string(),
+    description: "Task ID to resolve session from",
+    required: false,
+  },
+  repo: {
+    schema: z.string(),
+    description: "Repository path",
+    required: false,
+  },
+};
+
+// ── Command factory ──────────────────────────────────────────────────────
+
+export function createSessionPrReviewContextCommand(getDeps: LazySessionDeps): CommandDefinition {
+  return {
+    id: "session.pr.review_context",
+    category: CommandCategory.SESSION,
+    name: "review_context",
+    description:
+      "Get all PR review data in a single call: metadata, CI checks, diff, and task spec",
+    parameters: sessionPrReviewContextCommandParams,
+    execute: withErrorLogging(
+      "session.pr.review_context",
+      async (params: Record<string, unknown>) => {
+        try {
+          const deps = await getDeps();
+          const result = await sessionPrReviewContext(
+            {
+              sessionId: params.sessionId as string | undefined,
+              name: params.name as string | undefined,
+              task: params.task as string | undefined,
+              repo: params.repo as string | undefined,
+            },
+            {
+              sessionDB: deps.sessionProvider,
+              taskService: deps.taskService,
+            }
+          );
+
+          return { success: true, ...result };
+        } catch (error) {
+          throw new MinskyError(
+            `Failed to get session PR review context: ${getErrorMessage(error)}`
+          );
+        }
+      }
+    ),
+  };
+}

--- a/src/adapters/shared/commands/session/workflow-commands.ts
+++ b/src/adapters/shared/commands/session/workflow-commands.ts
@@ -23,6 +23,7 @@ export { createSessionPrListCommand } from "./pr-list-command";
 export { createSessionPrGetCommand } from "./pr-get-command";
 export { createSessionPrOpenCommand } from "./pr-open-command";
 export { createSessionPrChecksCommand } from "./pr-checks-command";
+export { createSessionPrReviewContextCommand } from "./pr-review-context-command";
 
 export function createSessionCommitCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {

--- a/src/domain/session/commands/pr-review-context-subcommand.ts
+++ b/src/domain/session/commands/pr-review-context-subcommand.ts
@@ -159,9 +159,7 @@ export async function sessionPrReviewContext(
     ) {
       throw error;
     }
-    throw new MinskyError(
-      `Failed to get session PR review context: ${getErrorMessage(error)}`
-    );
+    throw new MinskyError(`Failed to get session PR review context: ${getErrorMessage(error)}`);
   }
 }
 

--- a/src/domain/session/commands/pr-review-context-subcommand.ts
+++ b/src/domain/session/commands/pr-review-context-subcommand.ts
@@ -1,0 +1,185 @@
+/**
+ * Session PR Review Context Subcommand
+ *
+ * Composes all PR review data into a single call, fetching PR metadata,
+ * CI checks, diff, and task spec in parallel.
+ */
+
+import { resolveSessionContextWithFeedback } from "../session-context-resolver";
+import type { SessionProviderInterface } from "../types";
+import {
+  MinskyError,
+  ResourceNotFoundError,
+  ValidationError,
+  getErrorMessage,
+} from "../../../errors/index";
+import { log } from "../../../utils/logger";
+import { createRepositoryBackendFromSession } from "../session-pr-operations";
+
+export interface SessionPrReviewContextDependencies {
+  sessionDB: SessionProviderInterface;
+  taskService?: {
+    getTaskSpecContent(
+      taskId: string,
+      section?: string
+    ): Promise<{ task: unknown; specPath: string; content: string; section?: string }>;
+  };
+}
+
+export interface SessionPrReviewContextParams {
+  sessionId?: string;
+  name?: string;
+  task?: string;
+  repo?: string;
+}
+
+export interface PrSummary {
+  number: number;
+  title: string;
+  state: string;
+  author: string | null;
+  additions: number | null;
+  deletions: number | null;
+  filesChanged: number | null;
+  url: string | null;
+  headBranch: string | null;
+  baseBranch: string | null;
+}
+
+export interface ChecksSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  details: Array<{
+    name: string;
+    status: string;
+    conclusion: string | null;
+    url: string | null;
+  }>;
+}
+
+export interface SessionPrReviewContextResult {
+  pr: PrSummary;
+  checks: ChecksSummary;
+  diff: string;
+  taskSpec: string | null;
+  taskId: string | null;
+}
+
+/**
+ * Get all PR review data in a single composed call.
+ * Runs PR metadata, CI checks, diff, and task spec fetches in parallel.
+ */
+export async function sessionPrReviewContext(
+  params: SessionPrReviewContextParams,
+  deps: SessionPrReviewContextDependencies
+): Promise<SessionPrReviewContextResult> {
+  const { sessionDB, taskService } = deps;
+
+  try {
+    // Resolve session
+    const resolvedContext = await resolveSessionContextWithFeedback({
+      session: params.sessionId ?? params.name,
+      task: params.task,
+      repo: params.repo,
+      sessionProvider: sessionDB,
+      allowAutoDetection: true,
+    });
+
+    const sessionRecord = await sessionDB.getSession(resolvedContext.sessionId);
+    if (!sessionRecord) {
+      throw new ResourceNotFoundError(`Session '${resolvedContext.sessionId}' not found`);
+    }
+
+    // Require an existing PR
+    const prNumber = sessionRecord.pullRequest?.number;
+    if (!prNumber) {
+      throw new ResourceNotFoundError(
+        `No pull request found for session '${resolvedContext.sessionId}'. ` +
+          `Use 'minsky session pr create' to create a PR first.`
+      );
+    }
+
+    const taskId = sessionRecord.taskId ?? null;
+
+    // Create repository backend from session record
+    const backend = await createRepositoryBackendFromSession(sessionRecord, sessionDB);
+
+    log.debug(`Fetching PR review context for PR #${prNumber}`);
+
+    // Fetch PR metadata, checks, and diff in parallel; task spec is independent
+    const [prData, checksResult, diffResult, taskSpecContent] = await Promise.all([
+      backend.pr.get({ prIdentifier: prNumber }),
+      backend.ci.getChecksForPR(prNumber),
+      backend.pr.getDiff({ prIdentifier: prNumber }),
+      fetchTaskSpec(taskId, taskService),
+    ]);
+
+    // Normalise PR metadata into the flat return shape
+    const pr: PrSummary = {
+      number: typeof prData.number === "number" ? prData.number : prNumber,
+      title: prData.title ?? "",
+      state: prData.state ?? "unknown",
+      author: prData.author ?? null,
+      additions: null, // not provided by backend.pr.get()
+      deletions: null,
+      filesChanged: null,
+      url: prData.url ?? null,
+      headBranch: prData.headBranch ?? null,
+      baseBranch: prData.baseBranch ?? null,
+    };
+
+    // Normalise checks
+    const checks: ChecksSummary = {
+      total: checksResult.summary.total,
+      passed: checksResult.summary.passed,
+      failed: checksResult.summary.failed,
+      pending: checksResult.summary.pending,
+      details: checksResult.checks.map((c) => ({
+        name: c.name,
+        status: c.status,
+        conclusion: c.conclusion,
+        url: c.url,
+      })),
+    };
+
+    return {
+      pr,
+      checks,
+      diff: diffResult.diff,
+      taskSpec: taskSpecContent,
+      taskId,
+    };
+  } catch (error) {
+    if (
+      error instanceof ResourceNotFoundError ||
+      error instanceof ValidationError ||
+      error instanceof MinskyError
+    ) {
+      throw error;
+    }
+    throw new MinskyError(
+      `Failed to get session PR review context: ${getErrorMessage(error)}`
+    );
+  }
+}
+
+/**
+ * Fetch task spec content, returning null if unavailable.
+ */
+async function fetchTaskSpec(
+  taskId: string | null,
+  taskService?: SessionPrReviewContextDependencies["taskService"]
+): Promise<string | null> {
+  if (!taskId || !taskService) {
+    return null;
+  }
+  try {
+    const result = await taskService.getTaskSpecContent(taskId);
+    return result.content;
+  } catch (error) {
+    log.debug(`Could not fetch task spec for ${taskId}: ${getErrorMessage(error)}`);
+    return null;
+  }
+}

--- a/src/domain/session/commands/pr-subcommands.ts
+++ b/src/domain/session/commands/pr-subcommands.ts
@@ -11,3 +11,4 @@ export { sessionPrList } from "./pr-list-subcommand";
 export { sessionPrGet } from "./pr-get-subcommand";
 export { sessionPrOpen } from "./pr-open-subcommand";
 export { sessionPrChecks } from "./pr-checks-subcommand";
+export { sessionPrReviewContext } from "./pr-review-context-subcommand";


### PR DESCRIPTION
## Summary

- Add new `session.pr.review_context` MCP tool that fetches all PR review data in a single call
- Composes 4 operations in parallel: PR metadata, check runs, diff, and task spec
- Eliminates 3-4 separate MCP round-trips currently required by the review skill

## Implementation

- New domain function `sessionPrReviewContext()` in `src/domain/session/commands/pr-review-context-subcommand.ts`
- New adapter command factory in `src/adapters/shared/commands/session/pr-review-context-command.ts`
- Registered in session command registry alongside other PR subcommands

## Return shape

```typescript
{
  pr: { number, title, state, author, additions, deletions, filesChanged, url, headBranch, baseBranch },
  checks: { total, passed, failed, pending, details: [...] },
  diff: string,
  taskSpec: string | null,
  taskId: string | null,
}
```

## Test plan

- [x] Typecheck passes (0 errors)
- [ ] Manual verification: call tool with an existing session that has a PR
- [ ] Follow-up: update `/review-pr` skill to use this tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)