### PR TITLE
feat(mt#847): Add submitReview to RepositoryBackend and wire MCP tool + skill update

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -109,10 +109,25 @@ Classify the impact:
 
 ### 7. Post to GitHub
 
-Use `mcp__github__pull_request_review_write` to post the review:
+**Primary path:** Use `mcp__minsky__session_review_submit` when the PR is linked to a Minsky session. Extract the task ID from the branch name (e.g., `task/mt-847` → `mt#847`) and call:
+
+```
+mcp__minsky__session_review_submit
+  task: "mt#847"   (or sessionId if known)
+  body: "<full review body>"
+  event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES"
+  comments: [{ path, line, body, side? }]   (optional, for line-level comments)
+```
+
+This posts the review under the configured bot/service-account identity.
+
+**Fallback:** If `mcp__minsky__session_review_submit` is unavailable or the PR is not linked to a Minsky session, use `mcp__github__pull_request_review_write` directly:
 
 - `method: "create"` with `event` to submit immediately
 - For line-level comments: create a pending review first, add comments with `add_comment_to_pending_review`, then `submit_pending`
+
+**Event selection (applies to both paths):**
+
 - Use `event: "APPROVE"` only if you are not the PR author and there are no blocking issues
 - Use `event: "COMMENT"` if you are the PR author or there are only non-blocking issues
 - Use `event: "REQUEST_CHANGES"` if there are blocking issues or unmet spec criteria

--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -31,6 +31,7 @@ import {
   createSessionPrGetCommand,
   createSessionPrOpenCommand,
   createSessionPrChecksCommand,
+  createSessionPrReviewSubmitCommand,
 } from "./session/workflow-commands";
 import { createSessionConflictsCommand } from "./session/conflicts-command";
 import { createSessionRepairCommand } from "./session/repair-command";
@@ -89,6 +90,7 @@ export async function registerSessionCommands(
     createSessionPrApproveCommand(getDeps),
     createSessionPrMergeCommand(getDeps),
     createSessionPrChecksCommand(getDeps),
+    createSessionPrReviewSubmitCommand(getDeps),
 
     // Migration
     createSessionMigrateCommand(getDeps),

--- a/src/adapters/shared/commands/session/pr-review-submit-command.ts
+++ b/src/adapters/shared/commands/session/pr-review-submit-command.ts
@@ -1,0 +1,57 @@
+/**
+ * Session PR Review Submit Command
+ *
+ * Adapter command that exposes session.pr.review.submit as an MCP tool
+ * (mcp__minsky__session_pr_review_submit). Posts a GitHub PR review through
+ * Minsky, using the bot / service-account identity.
+ */
+
+import { CommandCategory, type CommandDefinition } from "../../command-registry";
+import { MinskyError, getErrorMessage } from "../../../../errors/index";
+import { type LazySessionDeps, withErrorLogging } from "./types";
+import { sessionPrReviewSubmitCommandParams } from "./session-parameters";
+import { sessionPrReviewSubmit } from "../../../../domain/session/commands/pr-subcommands";
+import type { ReviewComment } from "../../../../domain/repository/github-pr-review";
+
+export function createSessionPrReviewSubmitCommand(getDeps: LazySessionDeps): CommandDefinition {
+  return {
+    id: "session.pr.review.submit",
+    category: CommandCategory.SESSION,
+    name: "review-submit",
+    description:
+      "Submit a GitHub PR review (APPROVE / COMMENT / REQUEST_CHANGES) through Minsky " +
+      "using the configured bot identity",
+    parameters: sessionPrReviewSubmitCommandParams,
+    execute: withErrorLogging(
+      "session.pr.review.submit",
+      async (params: Record<string, unknown>) => {
+        try {
+          const deps = await getDeps();
+
+          const result = await sessionPrReviewSubmit(
+            {
+              sessionId: params.sessionId as string | undefined,
+              name: params.name as string | undefined,
+              task: params.task as string | undefined,
+              repo: params.repo as string | undefined,
+              body: params.body as string,
+              event: params.event as "APPROVE" | "COMMENT" | "REQUEST_CHANGES",
+              comments: params.comments as ReviewComment[] | undefined,
+            },
+            { sessionDB: deps.sessionProvider }
+          );
+
+          return {
+            success: true,
+            reviewId: result.reviewId,
+            htmlUrl: result.htmlUrl,
+            prNumber: result.prNumber,
+            sessionId: result.sessionId,
+          };
+        } catch (error) {
+          throw new MinskyError(`Failed to submit PR review: ${getErrorMessage(error)}`);
+        }
+      }
+    ),
+  };
+}

--- a/src/adapters/shared/commands/session/session-parameters.ts
+++ b/src/adapters/shared/commands/session/session-parameters.ts
@@ -609,6 +609,44 @@ export const sessionPrChecksCommandParams = {
 };
 
 /**
+ * Session PR Review Submit command parameters
+ * Submits a GitHub PR review through Minsky using the bot identity
+ */
+export const sessionPrReviewSubmitCommandParams = {
+  sessionId: {
+    schema: z.string(),
+    description: "Session ID (positional)",
+    required: false,
+  },
+  name: commonSessionParams.name,
+  task: commonSessionParams.task,
+  repo: commonSessionParams.repo,
+  body: {
+    schema: z.string().min(1),
+    description: "Review body text (overall comment)",
+    required: true,
+  },
+  event: {
+    schema: z.enum(["APPROVE", "COMMENT", "REQUEST_CHANGES"]),
+    description: "Review event type: APPROVE, COMMENT, or REQUEST_CHANGES",
+    required: true,
+  },
+  comments: {
+    schema: z.array(
+      z.object({
+        path: z.string(),
+        line: z.number().int().positive(),
+        body: z.string().min(1),
+        side: z.enum(["LEFT", "RIGHT"]).optional(),
+      })
+    ),
+    description: "Optional inline line-level comments",
+    required: false,
+  },
+  json: commonSessionParams.json,
+};
+
+/**
  * Session repair command parameters
  * Repairs various session state issues
  */

--- a/src/adapters/shared/commands/session/workflow-commands.ts
+++ b/src/adapters/shared/commands/session/workflow-commands.ts
@@ -23,6 +23,7 @@ export { createSessionPrListCommand } from "./pr-list-command";
 export { createSessionPrGetCommand } from "./pr-get-command";
 export { createSessionPrOpenCommand } from "./pr-open-command";
 export { createSessionPrChecksCommand } from "./pr-checks-command";
+export { createSessionPrReviewSubmitCommand } from "./pr-review-submit-command";
 
 export function createSessionCommitCommand(getDeps: LazySessionDeps): CommandDefinition {
   return {

--- a/src/domain/repository/github-pr-review.ts
+++ b/src/domain/repository/github-pr-review.ts
@@ -1,0 +1,125 @@
+/**
+ * GitHub PR review submission operations.
+ *
+ * Contains: submitReview — posts a review (APPROVE, COMMENT, REQUEST_CHANGES)
+ * to a GitHub pull request using the service-account / bot token.
+ */
+
+import { MinskyError } from "../../errors/index";
+import { log } from "../../utils/logger";
+import { handleOctokitError } from "./github-error-handler";
+import {
+  type GitHubContext,
+  createOctokit,
+  resolvePRNumber,
+  findPRNumberForBranch,
+} from "./github-pr-operations";
+
+export interface ReviewComment {
+  /** Relative path of the file to comment on */
+  path: string;
+  /** Line number in the file (1-based) */
+  line: number;
+  /** Review comment body */
+  body: string;
+  /** Which side of a diff hunk to attach the comment to (default: RIGHT) */
+  side?: "LEFT" | "RIGHT";
+}
+
+export interface SubmitReviewOptions {
+  /** Review body text (overall comment) */
+  body: string;
+  /** Review event type */
+  event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+  /** Optional inline (line-level) comments */
+  comments?: ReviewComment[];
+}
+
+export interface SubmitReviewResult {
+  /** GitHub review ID */
+  reviewId: number;
+  /** Web URL of the submitted review */
+  htmlUrl: string;
+}
+
+/**
+ * Submit a review on a GitHub pull request.
+ *
+ * Uses `octokit.rest.pulls.createReview()` which accepts body, event, and an
+ * optional inline-comments array in a single REST call — no GraphQL needed.
+ *
+ * Auth goes through `gh.getToken()` which honours the TokenProvider's service
+ * account when one is configured, posting the review under the bot identity.
+ */
+export async function submitReview(
+  gh: GitHubContext,
+  prIdentifier: string | number,
+  options: SubmitReviewOptions
+): Promise<SubmitReviewResult> {
+  const prNumber = await resolvePRNumber(prIdentifier, gh, async (branch) => {
+    const token = await gh.getToken();
+    const ok = createOctokit(token);
+    return findPRNumberForBranch(branch, gh, ok);
+  });
+
+  try {
+    const token = await gh.getToken();
+    const octokit = createOctokit(token);
+
+    // Validate PR is open before submitting
+    const prResponse = await octokit.rest.pulls.get({
+      owner: gh.owner,
+      repo: gh.repo,
+      pull_number: prNumber,
+    });
+
+    if (prResponse.data.state !== "open") {
+      throw new MinskyError(
+        `Pull request #${prNumber} is not open (current state: ${prResponse.data.state})`
+      );
+    }
+
+    // Map our ReviewComment[] to the shape expected by the Octokit REST API.
+    // The API accepts { path, line, body, side } directly.
+    const apiComments = options.comments?.map((c) => ({
+      path: c.path,
+      line: c.line,
+      body: c.body,
+      side: (c.side ?? "RIGHT") as "LEFT" | "RIGHT",
+    }));
+
+    const reviewResponse = await octokit.rest.pulls.createReview({
+      owner: gh.owner,
+      repo: gh.repo,
+      pull_number: prNumber,
+      body: options.body,
+      event: options.event,
+      ...(apiComments && apiComments.length > 0 ? { comments: apiComments } : {}),
+    });
+
+    const review = reviewResponse.data;
+
+    log.info("GitHub PR review submitted successfully", {
+      prNumber,
+      reviewId: review.id,
+      event: options.event,
+      owner: gh.owner,
+      repo: gh.repo,
+    });
+
+    return {
+      reviewId: review.id,
+      htmlUrl: review.html_url,
+    };
+  } catch (error) {
+    if (error instanceof MinskyError) throw error;
+    handleOctokitError(error, {
+      operation: "submit pull request review",
+      owner: gh.owner,
+      repo: gh.repo,
+      prNumber,
+    });
+    // handleOctokitError always throws; this satisfies TypeScript
+    throw error;
+  }
+}

--- a/src/domain/repository/github.ts
+++ b/src/domain/repository/github.ts
@@ -35,6 +35,8 @@ import {
   getPullRequestApprovalStatus as getApprovalStatus,
   diagnoseMergeBlocker,
 } from "./github-pr-approval";
+import { submitReview as submitReviewImpl } from "./github-pr-review";
+import type { SubmitReviewOptions, SubmitReviewResult } from "./github-pr-review";
 import { FallbackTokenProvider, type TokenProvider } from "../auth";
 
 const HTTP_NOT_FOUND = 404;
@@ -684,5 +686,17 @@ Repository: https://github.com/${this.owner}/${this.repo}
   async getPullRequestApprovalStatus(prIdentifier: string | number): Promise<ApprovalStatus> {
     const gh = this.requireGitHubContext();
     return getApprovalStatus(gh, prIdentifier);
+  }
+
+  /**
+   * Submit a review on a GitHub pull request.
+   * Posts under the bot/service-account identity when one is configured.
+   */
+  async submitReview(
+    prIdentifier: string | number,
+    options: SubmitReviewOptions
+  ): Promise<SubmitReviewResult> {
+    const gh = this.requireGitHubContext();
+    return submitReviewImpl(gh, prIdentifier, options);
   }
 }

--- a/src/domain/repository/index.ts
+++ b/src/domain/repository/index.ts
@@ -309,6 +309,25 @@ export interface RepositoryBackend {
     diff: string;
     stats?: { filesChanged: number; insertions: number; deletions: number };
   }>;
+
+  /**
+   * Submit a review on an open pull request (optional — only GitHub-backed sessions support this).
+   *
+   * Uses the bot/service-account token so reviews are posted under the configured
+   * bot identity rather than the personal token of the session author.
+   *
+   * @param prIdentifier - PR number or branch name
+   * @param options - Review body, event type, and optional line-level comments
+   * @returns Promise with the GitHub review ID and HTML URL
+   */
+  submitReview?(
+    prIdentifier: string | number,
+    options: {
+      body: string;
+      event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+      comments?: Array<{ path: string; line: number; body: string; side?: "LEFT" | "RIGHT" }>;
+    }
+  ): Promise<{ reviewId: number; htmlUrl: string }>;
 }
 
 /**

--- a/src/domain/session/commands/pr-review-submit-subcommand.ts
+++ b/src/domain/session/commands/pr-review-submit-subcommand.ts
@@ -1,0 +1,127 @@
+/**
+ * Session PR Review Submit Subcommand
+ *
+ * Posts a GitHub PR review (APPROVE, COMMENT, REQUEST_CHANGES) through Minsky,
+ * using the configured bot / service-account identity.
+ *
+ * Read operations (fetching PR details, diff, CI status) stay on the GitHub MCP
+ * server; this subcommand covers only the write path.
+ */
+
+import { resolveSessionContextWithFeedback } from "../session-context-resolver";
+import type { SessionProviderInterface } from "../types";
+import { MinskyError, ResourceNotFoundError, ValidationError } from "../../../errors/index";
+import { log } from "../../../utils/logger";
+import { createRepositoryBackend, RepositoryBackendType } from "../../repository/index";
+import type { RepositoryBackendConfig } from "../../repository/index";
+import type { ReviewComment } from "../../repository/github-pr-review";
+
+export interface SessionPrReviewSubmitDependencies {
+  sessionDB: SessionProviderInterface;
+}
+
+export interface SessionPrReviewSubmitParams {
+  /** Session UUID or task-based alias (e.g. "mt#847") */
+  sessionId?: string;
+  /** Convenience alias — same as sessionId */
+  name?: string;
+  /** Task ID — used when no explicit sessionId is provided */
+  task?: string;
+  /** Repository path filter */
+  repo?: string;
+  /** Overall review body text */
+  body: string;
+  /** Review event type */
+  event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES";
+  /** Optional inline line-level comments */
+  comments?: ReviewComment[];
+}
+
+export interface SessionPrReviewSubmitResult {
+  /** GitHub review ID */
+  reviewId: number;
+  /** Web URL of the submitted review */
+  htmlUrl: string;
+  /** PR number the review was submitted on */
+  prNumber: number;
+  /** Session that was used to find the PR */
+  sessionId: string;
+}
+
+/**
+ * Submit a review on the pull request associated with a Minsky session.
+ *
+ * The session is resolved first (by sessionId, task, or auto-detection), then
+ * the PR number is read from the session record, and finally the review is
+ * posted via the GitHubBackend's submitReview() method.
+ */
+export async function sessionPrReviewSubmit(
+  params: SessionPrReviewSubmitParams,
+  deps: SessionPrReviewSubmitDependencies
+): Promise<SessionPrReviewSubmitResult> {
+  const { sessionDB } = deps;
+
+  // Resolve session
+  const resolvedContext = await resolveSessionContextWithFeedback({
+    session: params.sessionId ?? params.name,
+    task: params.task,
+    repo: params.repo,
+    sessionProvider: sessionDB,
+    allowAutoDetection: true,
+  });
+
+  const sessionRecord = await sessionDB.getSession(resolvedContext.sessionId);
+  if (!sessionRecord) {
+    throw new ResourceNotFoundError(`Session '${resolvedContext.sessionId}' not found`);
+  }
+
+  // Only GitHub-backed sessions are supported for review submission
+  if (sessionRecord.backendType !== "github") {
+    throw new ValidationError(
+      `session.pr.review.submit only supports GitHub-backed sessions. ` +
+        `This session uses backend: ${sessionRecord.backendType ?? "unknown"}`
+    );
+  }
+
+  // Require an existing PR
+  const prNumber = sessionRecord.pullRequest?.number;
+  if (!prNumber) {
+    throw new ResourceNotFoundError(
+      `No pull request found for session '${resolvedContext.sessionId}'. ` +
+        `Use 'minsky session pr create' to create a PR first.`
+    );
+  }
+
+  // Build repository backend (picks up TokenProvider with bot token when configured)
+  const config: RepositoryBackendConfig = {
+    type: RepositoryBackendType.GITHUB,
+    repoUrl: sessionRecord.repoUrl,
+  };
+  const backend = await createRepositoryBackend(config, sessionDB);
+
+  if (!backend.submitReview) {
+    throw new MinskyError(
+      "The repository backend for this session does not support submitReview. " +
+        "Only GitHub-backed sessions support PR review submission."
+    );
+  }
+
+  log.debug("Submitting PR review via Minsky", {
+    sessionId: resolvedContext.sessionId,
+    prNumber,
+    event: params.event,
+  });
+
+  const result = await backend.submitReview(prNumber, {
+    body: params.body,
+    event: params.event,
+    comments: params.comments,
+  });
+
+  return {
+    reviewId: result.reviewId,
+    htmlUrl: result.htmlUrl,
+    prNumber,
+    sessionId: resolvedContext.sessionId,
+  };
+}

--- a/src/domain/session/commands/pr-subcommands.ts
+++ b/src/domain/session/commands/pr-subcommands.ts
@@ -11,3 +11,4 @@ export { sessionPrList } from "./pr-list-subcommand";
 export { sessionPrGet } from "./pr-get-subcommand";
 export { sessionPrOpen } from "./pr-open-subcommand";
 export { sessionPrChecks } from "./pr-checks-subcommand";
+export { sessionPrReviewSubmit } from "./pr-review-submit-subcommand";


### PR DESCRIPTION
## Summary

Implements the write-side of the hybrid read/write split for GitHub PR reviews. Reviews can now be posted through Minsky using the bot identity (minsky-ai[bot]) via TokenProvider.

### New
- `src/domain/repository/github-pr-review.ts` — `submitReview()` function using `octokit.rest.pulls.createReview()`
- `src/domain/repository/github.ts` — `GitHubBackend.submitReview()` method
- `src/domain/repository/index.ts` — `submitReview?()` optional method on `RepositoryBackend` interface
- `src/domain/session/commands/pr-review-submit-subcommand.ts` — domain function for MCP tool
- `src/adapters/shared/commands/session/pr-review-submit-command.ts` — MCP command adapter
- `.claude/skills/review-pr/SKILL.md` — Step 7 updated: Minsky tool primary, GitHub MCP fallback

### Architecture
- **Reads** (PR metadata, diff, files, CI): unchanged, GitHub MCP server (identity-agnostic)
- **Writes** (posting reviews): Minsky `submitReview` → TokenProvider → bot identity
- Architecture decision: https://www.notion.so/348937f03cb481b286cdd2768de105c8

## Test plan
- [ ] `bun run validate-all` passes
- [ ] `mcp__minsky__session_review_submit` tool appears after MCP restart
- [ ] Review posted via tool uses bot token when `github.serviceAccount` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)