### PR TITLE
feat(mt#941): add validate→execute pipeline to command registry (ADR-004 Phase 1)

### DIFF
--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -175,6 +175,11 @@ export function registerSharedCommandsWithMcp(
               guardProjectSetup(command.id);
             }
 
+            // ADR-004: validate→execute pipeline
+            if (command.validate) {
+              await command.validate(parameters, context);
+            }
+
             // Execute the shared command (no timeout - debug actual hang)
             log.debug(`[MCP] About to execute command: ${command.id}`);
             log.debug(`[MCP] Parameters being passed:`, parameters);

--- a/src/adapters/shared/bridges/cli/command-generator-core.ts
+++ b/src/adapters/shared/bridges/cli/command-generator-core.ts
@@ -169,6 +169,11 @@ export class CommandGeneratorCore {
           guardProjectSetup(commandDef.id);
         }
 
+        // ADR-004: validate→execute pipeline
+        if (commandDef.validate) {
+          await commandDef.validate(normalizedParams, context);
+        }
+
         // Execute the command with parameters and context
         const result = await commandDef.execute(normalizedParams, context);
 

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -114,6 +114,12 @@ export interface CommandDefinition<
   /** Command execution handler */
   execute: CommandExecutionHandler<T, R>;
   /**
+   * Optional precondition validation. Runs before execute().
+   * Must throw on failure (ValidationError). Must not perform mutations.
+   * If defined, the framework guarantees it runs before execute().
+   */
+  validate?: CommandExecutionHandler<T, void>;
+  /**
    * Whether this command requires the project to be initialized before execution.
    * Defaults to true. Set to false for commands like `init`, `setup`, and `mcp.register`
    * that are responsible for initialization themselves.
@@ -173,6 +179,7 @@ export interface SharedCommand<T extends CommandParameterMap = CommandParameterM
   description: string;
   parameters: T;
   execute: CommandExecutionHandler<T, R>;
+  validate?: CommandExecutionHandler<T, void>;
   requiresSetup?: boolean;
 }
 

--- a/src/adapters/shared/commands/session/management-commands.ts
+++ b/src/adapters/shared/commands/session/management-commands.ts
@@ -4,6 +4,7 @@
  * Factories for session management operations (delete, update, migrate-backend).
  */
 import { CommandCategory, type CommandDefinition } from "../../command-registry";
+import { ValidationError } from "../../../../errors/index";
 import { type LazySessionDeps, withErrorLogging } from "./types";
 import {
   sessionDeleteCommandParams,
@@ -19,6 +20,15 @@ export function createSessionDeleteCommand(getDeps: LazySessionDeps): CommandDef
     name: "delete",
     description: "Delete a session",
     parameters: sessionDeleteCommandParams,
+    validate: async (params: Record<string, unknown>) => {
+      const name = params.name as string | undefined;
+      const task = params.task as string | undefined;
+      if (!name && !task) {
+        throw new ValidationError(
+          "Session identifier required. Provide either --name (session ID) or --task (task ID)."
+        );
+      }
+    },
     execute: withErrorLogging("session.delete", async (params: Record<string, unknown>) => {
       const { SessionService } = await import("../../../../domain/session/session-service");
       const deps = await getDeps();


### PR DESCRIPTION
## Summary

- Add optional `validate` method to `CommandDefinition` interface
- Add pipeline middleware in both MCP and CLI dispatch paths that calls `validate` before `execute`
- Demonstrate with `session.delete` command (validates session identifier is provided)
- Fully backward compatible — commands without `validate` work exactly as before

## Design (ADR-004 Phase 1)

```typescript
interface CommandDefinition<T, R> {
  // ... existing fields ...
  validate?: CommandExecutionHandler<T, void>;  // throws on failure, no mutations
  execute: CommandExecutionHandler<T, R>;
}
```

The framework guarantees ordering: if `validate` exists, it runs before `execute`. Individual commands cannot bypass this. Validation failures prevent mutations from starting.

## Phase 2 (future)

- Branded `ValidatedContext<T>` type for type-level enforcement
- Read-only dependency interfaces
- ESLint rule flagging `throw ValidationError` inside `execute()` methods

## Changed files

- `src/adapters/shared/command-registry.ts` — interface extension
- `src/adapters/mcp/shared-command-integration.ts` — MCP dispatch pipeline
- `src/adapters/shared/bridges/cli/command-generator-core.ts` — CLI dispatch pipeline
- `src/adapters/shared/commands/session/management-commands.ts` — demo migration

## Test plan

- [x] Format check passes
- [x] Backward compatible (no existing command signatures changed)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)