### PR TITLE
feat(mt#950): ADR-004 Phase 2: branded ValidatedContext, read-only interfaces, ESLint rule

### DIFF
--- a/eslint-rules/__fixtures__/no-validation-error-in-execute/invalid.js
+++ b/eslint-rules/__fixtures__/no-validation-error-in-execute/invalid.js
@@ -1,0 +1,9 @@
+// Invalid: ValidationError thrown inside execute()
+const command = {
+  execute: async (params, context) => {
+    if (!params.name) {
+      throw new ValidationError("Name is required"); // should be in validate()
+    }
+    return { success: true };
+  },
+};

--- a/eslint-rules/__fixtures__/no-validation-error-in-execute/valid.js
+++ b/eslint-rules/__fixtures__/no-validation-error-in-execute/valid.js
@@ -1,0 +1,25 @@
+// Valid: execute without ValidationError (validation belongs in validate())
+const command = {
+  validate: async (params, context) => {
+    if (!params.name) {
+      throw new ValidationError("Name is required");
+    }
+  },
+  execute: async (params, context) => {
+    // No ValidationError here — all validation is in validate()
+    const result = await doWork(params.name);
+    return { success: true, result };
+  },
+};
+
+// Valid: throwing other errors in execute is fine
+const command2 = {
+  execute: async (params, context) => {
+    throw new Error("Something went wrong");
+  },
+};
+
+// Valid: ValidationError outside execute is fine
+function checkStuff() {
+  throw new ValidationError("bad input");
+}

--- a/eslint-rules/no-validation-error-in-execute.js
+++ b/eslint-rules/no-validation-error-in-execute.js
@@ -1,0 +1,52 @@
+/**
+ * ESLint Rule: no-validation-error-in-execute
+ *
+ * Disallow throwing ValidationError inside execute() methods.
+ * Validation logic should live in the validate() method per ADR-004.
+ *
+ * @see ADR-004 — Validate→Execute Command Pipeline
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow throwing ValidationError inside execute() methods (ADR-004)",
+    },
+    messages: {
+      noValidationErrorInExecute:
+        "ValidationError should not be thrown inside execute() — move validation to the validate() method (ADR-004).",
+    },
+    schema: [],
+  },
+  create(context) {
+    let insideExecute = false;
+
+    return {
+      "Property[key.name='execute'] > ArrowFunctionExpression"() {
+        insideExecute = true;
+      },
+      "Property[key.name='execute'] > ArrowFunctionExpression:exit"() {
+        insideExecute = false;
+      },
+      "Property[key.name='execute'] > FunctionExpression"() {
+        insideExecute = true;
+      },
+      "Property[key.name='execute'] > FunctionExpression:exit"() {
+        insideExecute = false;
+      },
+      ThrowStatement(node) {
+        if (!insideExecute) return;
+        // Check if throwing ValidationError
+        const arg = node.argument;
+        if (
+          arg &&
+          arg.type === "NewExpression" &&
+          arg.callee.type === "Identifier" &&
+          arg.callee.name === "ValidationError"
+        ) {
+          context.report({ node, messageId: "noValidationErrorInExecute" });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ import noUnwaitedAsyncFactory from "./eslint-rules/no-unwaited-async-factory.js"
 import noSingletonReachIn from "./eslint-rules/no-singleton-reach-in.js";
 import noFromParamsInAdapters from "./eslint-rules/no-from-params-in-adapters.js";
 import noIgnoredCommandContext from "./eslint-rules/no-ignored-command-context.js";
+import noValidationErrorInExecute from "./eslint-rules/no-validation-error-in-execute.js";
 
 export default [
   js.configs.recommended,
@@ -112,6 +113,7 @@ export default [
           "no-singleton-reach-in": noSingletonReachIn,
           "no-from-params-in-adapters": noFromParamsInAdapters,
           "no-ignored-command-context": noIgnoredCommandContext,
+          "no-validation-error-in-execute": noValidationErrorInExecute,
         },
       },
     },
@@ -173,6 +175,7 @@ export default [
       // === DI ENFORCEMENT ===
       "custom/no-from-params-in-adapters": "error", // Prevent ad-hoc provider creation in adapter layer (mt#788)
       "custom/no-ignored-command-context": "error", // Flags commands with DI-requiring params (session) that ignore context (mt#929)
+      "custom/no-validation-error-in-execute": "warn", // ADR-004: ValidationError belongs in validate(), not execute()
 
       // === SINGLETON ARCHITECTURE ===
       "custom/no-singleton-reach-in": [

--- a/src/adapters/mcp/shared-command-integration.ts
+++ b/src/adapters/mcp/shared-command-integration.ts
@@ -176,8 +176,9 @@ export function registerSharedCommandsWithMcp(
             }
 
             // ADR-004: validate→execute pipeline
+            let validatedCtx: unknown;
             if (command.validate) {
-              await command.validate(parameters, context);
+              validatedCtx = await command.validate(parameters, context);
             }
 
             // Execute the shared command (no timeout - debug actual hang)
@@ -185,7 +186,8 @@ export function registerSharedCommandsWithMcp(
             log.debug(`[MCP] Parameters being passed:`, parameters);
             log.debug(`[MCP] Context being passed:`, { context });
 
-            const result = await command.execute(parameters, context);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const result = await command.execute(parameters, context, validatedCtx as any);
 
             const duration = Date.now() - startTime;
             log.debug(`[MCP] Command completed: ${command.id}`, { duration });

--- a/src/adapters/shared/bridges/cli/command-generator-core.ts
+++ b/src/adapters/shared/bridges/cli/command-generator-core.ts
@@ -170,12 +170,14 @@ export class CommandGeneratorCore {
         }
 
         // ADR-004: validate→execute pipeline
+        let validatedCtx: unknown;
         if (commandDef.validate) {
-          await commandDef.validate(normalizedParams, context);
+          validatedCtx = await commandDef.validate(normalizedParams, context);
         }
 
         // Execute the command with parameters and context
-        const result = await commandDef.execute(normalizedParams, context);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await commandDef.execute(normalizedParams, context, validatedCtx as any);
 
         // Handle output
         this.handleCommandOutput(result, commandDef, options, context);

--- a/src/adapters/shared/command-registry.ts
+++ b/src/adapters/shared/command-registry.ts
@@ -13,6 +13,15 @@ import {
   validateCommandRegistrationOptions,
 } from "../../schemas/command-registry";
 
+/** Brand symbol for validated command context (ADR-004 Phase 2) */
+declare const ValidatedBrand: unique symbol;
+
+/**
+ * Branded type ensuring execute() only accepts context that passed validate().
+ * Cannot be constructed directly — only returned by validate().
+ */
+export type ValidatedContext<C> = C & { readonly [ValidatedBrand]: true };
+
 /**
  * Command category enum
  *
@@ -100,6 +109,7 @@ export type CommandExecutionHandler<
 export interface CommandDefinition<
   T extends CommandParameterMap = Record<string, CommandParameterDefinition>,
   R = unknown,
+  C = void,
 > {
   /** Unique command identifier */
   id: string;
@@ -112,13 +122,22 @@ export interface CommandDefinition<
   /** Command parameters definition */
   parameters: T;
   /** Command execution handler */
-  execute: CommandExecutionHandler<T, R>;
+  execute: (
+    parameters: { [K in keyof T]: z.infer<T[K]["schema"]> },
+    context: CommandExecutionContext,
+    validated?: ValidatedContext<C>
+  ) => Promise<R>;
   /**
    * Optional precondition validation. Runs before execute().
    * Must throw on failure (ValidationError). Must not perform mutations.
    * If defined, the framework guarantees it runs before execute().
+   * May return a ValidatedContext that is threaded through to execute(),
+   * or return void for simple guard-style validators.
    */
-  validate?: CommandExecutionHandler<T, void>;
+  validate?: (
+    parameters: { [K in keyof T]: z.infer<T[K]["schema"]> },
+    context: CommandExecutionContext
+  ) => Promise<ValidatedContext<C> | void>;
   /**
    * Whether this command requires the project to be initialized before execution.
    * Defaults to true. Set to false for commands like `init`, `setup`, and `mcp.register`
@@ -163,23 +182,34 @@ export type InferParams<T extends CommandParameterMap> = {
  * });
  * ```
  */
-export function defineCommand<T extends CommandParameterMap, R = unknown>(
-  def: CommandDefinition<T, R>
-): CommandDefinition<T, R> {
+export function defineCommand<T extends CommandParameterMap, R = unknown, C = void>(
+  def: CommandDefinition<T, R, C>
+): CommandDefinition<T, R, C> {
   return def;
 }
 
 /**
  * Shared command interface that preserves type information
  */
-export interface SharedCommand<T extends CommandParameterMap = CommandParameterMap, R = unknown> {
+export interface SharedCommand<
+  T extends CommandParameterMap = CommandParameterMap,
+  R = unknown,
+  C = void,
+> {
   id: string;
   category: CommandCategory;
   name: string;
   description: string;
   parameters: T;
-  execute: CommandExecutionHandler<T, R>;
-  validate?: CommandExecutionHandler<T, void>;
+  execute: (
+    parameters: { [K in keyof T]: z.infer<T[K]["schema"]> },
+    context: CommandExecutionContext,
+    validated?: ValidatedContext<C>
+  ) => Promise<R>;
+  validate?: (
+    parameters: { [K in keyof T]: z.infer<T[K]["schema"]> },
+    context: CommandExecutionContext
+  ) => Promise<ValidatedContext<C> | void>;
   requiresSetup?: boolean;
 }
 

--- a/src/domain/session/index.ts
+++ b/src/domain/session/index.ts
@@ -30,3 +30,6 @@ export {
 
 // Export canonical session directory resolution utility
 export { resolveSessionDirectory } from "./resolve-session-directory";
+
+// Export read-only interfaces for ADR-004 validate() phase
+export type { ReadonlySessionProvider } from "./readonly-interfaces";

--- a/src/domain/session/readonly-interfaces.ts
+++ b/src/domain/session/readonly-interfaces.ts
@@ -1,0 +1,7 @@
+import type { SessionProviderInterface } from "./types";
+
+/** Read-only subset of SessionProviderInterface for use in validate() phase (ADR-004) */
+export type ReadonlySessionProvider = Pick<
+  SessionProviderInterface,
+  "listSessions" | "getSession" | "getSessionByTaskId" | "getRepoPath" | "getSessionWorkdir"
+>;

--- a/src/domain/tasks/index.ts
+++ b/src/domain/tasks/index.ts
@@ -24,3 +24,6 @@ export {
   formatTaskSpecToMarkdown,
   isValidTaskStatus,
 } from "./taskFunctions";
+
+// Export read-only interfaces for ADR-004 validate() phase
+export type { ReadonlyTaskService } from "./readonly-interfaces";

--- a/src/domain/tasks/readonly-interfaces.ts
+++ b/src/domain/tasks/readonly-interfaces.ts
@@ -1,0 +1,7 @@
+import type { TaskServiceInterface } from "./taskService";
+
+/** Read-only subset of TaskServiceInterface for use in validate() phase (ADR-004) */
+export type ReadonlyTaskService = Pick<
+  TaskServiceInterface,
+  "listTasks" | "getTask" | "getTaskStatus" | "getTasks" | "getTaskSpecContent" | "getWorkspacePath"
+>;


### PR DESCRIPTION
## Summary

Implements ADR-004 Phase 2: the typed validate→execute pipeline infrastructure.

- **Branded `ValidatedContext<C>` type** in `command-registry.ts` using a unique symbol brand, ensuring execute() only receives context that passed validate()
- **Third generic `C` (default `void`)** added to `CommandDefinition`, `SharedCommand`, and `defineCommand` — fully backward compatible
- **Pipeline dispatch updated** in both MCP (`shared-command-integration.ts`) and CLI (`command-generator-core.ts`) to thread validated context from validate() into execute()
- **Read-only dependency interfaces**: `ReadonlySessionProvider` and `ReadonlyTaskService` for use in validate() phase (no mutation methods)
- **ESLint rule `no-validation-error-in-execute`** (warn) that flags `throw new ValidationError(...)` inside execute() methods, nudging validation into validate()

## Key design decisions

- `validate()` returns `ValidatedContext<C> | void` to support both simple guard-style validators (existing) and rich context-returning validators (new)
- The `validated` parameter on `execute()` is optional, so all existing commands continue to work unchanged
- ESLint rule is set to "warn" for gradual adoption — existing commands are not migrated in this PR

## Test plan

- [ ] Verify existing commands compile without changes (backward compat)
- [ ] Verify session.delete command's existing void-returning validate() still compiles
- [ ] Verify ESLint rule detects `throw new ValidationError()` in execute() (see fixtures)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)