### PR TITLE
feat(mt#916): add ESLint rules and architectural test for DI enforcement

### DIFF
--- a/eslint-rules/no-domain-singleton.js
+++ b/eslint-rules/no-domain-singleton.js
@@ -1,0 +1,65 @@
+/**
+ * ESLint Rule: no-domain-singleton
+ *
+ * Prevents exporting singleton instances from domain code.
+ * Domain classes should use @injectable() and be registered with the DI container.
+ *
+ * Catches patterns like:
+ *   export const myService = new MyService(...)
+ *
+ * @see mt#916 — DI enforcement: prevent domain singleton exports
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Prevent exporting singleton instances in domain code. Use @injectable() and the DI container instead.",
+    },
+    messages: {
+      noDomainSingleton:
+        "Do not export singleton instances (`export const {{name}} = new ...`) in domain code. Use @injectable() and the DI container instead.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedNames: {
+            type: "array",
+            items: { type: "string" },
+            description: "Variable names that are exempt from this rule.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    // Only apply to domain layer files
+    if (!filename.includes("/src/domain/")) return {};
+
+    const options = context.options[0] || {};
+    const allowedNames = new Set(options.allowedNames || []);
+
+    return {
+      ExportNamedDeclaration(node) {
+        if (!node.declaration || node.declaration.type !== "VariableDeclaration") return;
+
+        for (const declarator of node.declaration.declarations) {
+          if (!declarator.init || declarator.init.type !== "NewExpression") continue;
+          if (declarator.id.type !== "Identifier") continue;
+
+          const name = declarator.id.name;
+          if (allowedNames.has(name)) continue;
+
+          context.report({
+            node: declarator,
+            messageId: "noDomainSingleton",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/require-injectable.js
+++ b/eslint-rules/require-injectable.js
@@ -1,0 +1,92 @@
+/**
+ * ESLint Rule: require-injectable
+ *
+ * Requires domain classes with names ending in Service, Storage, or Adapter
+ * to have the @injectable() decorator for DI container registration.
+ *
+ * Catches patterns like:
+ *   export class MyService { ... }  // missing @injectable()
+ *
+ * @see mt#916 — DI enforcement: require @injectable() on domain service classes
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require @injectable() decorator on domain Service/Storage/Adapter classes for DI container registration.",
+    },
+    messages: {
+      requireInjectable:
+        "Domain class '{{name}}' must have @injectable() decorator for DI container registration.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedClasses: {
+            type: "array",
+            items: { type: "string" },
+            description: "Class names that are exempt from this rule.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    // Only apply to domain layer files
+    if (!filename.includes("/src/domain/")) return {};
+
+    const options = context.options[0] || {};
+    const allowedClasses = new Set(options.allowedClasses || []);
+
+    const CLASS_NAME_PATTERN = /(Service|Storage|Adapter)$/;
+
+    return {
+      ExportNamedDeclaration(node) {
+        if (!node.declaration || node.declaration.type !== "ClassDeclaration") return;
+
+        const classDecl = node.declaration;
+        if (!classDecl.id) return;
+
+        const name = classDecl.id.name;
+        if (!CLASS_NAME_PATTERN.test(name)) return;
+        if (allowedClasses.has(name)) return;
+
+        // Check if the class has an @injectable() decorator
+        const decorators = classDecl.decorators || [];
+        const hasInjectable = decorators.some((decorator) => {
+          // @injectable() — CallExpression where callee is Identifier named "injectable"
+          if (
+            decorator.expression &&
+            decorator.expression.type === "CallExpression" &&
+            decorator.expression.callee &&
+            decorator.expression.callee.type === "Identifier" &&
+            decorator.expression.callee.name === "injectable"
+          ) {
+            return true;
+          }
+          // @injectable — bare identifier (no call)
+          if (
+            decorator.expression &&
+            decorator.expression.type === "Identifier" &&
+            decorator.expression.name === "injectable"
+          ) {
+            return true;
+          }
+          return false;
+        });
+
+        if (!hasInjectable) {
+          context.report({
+            node: classDecl,
+            messageId: "requireInjectable",
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,8 @@ import noSingletonReachIn from "./eslint-rules/no-singleton-reach-in.js";
 import noFromParamsInAdapters from "./eslint-rules/no-from-params-in-adapters.js";
 import noIgnoredCommandContext from "./eslint-rules/no-ignored-command-context.js";
 import noValidationErrorInExecute from "./eslint-rules/no-validation-error-in-execute.js";
+import noDomainSingleton from "./eslint-rules/no-domain-singleton.js";
+import requireInjectable from "./eslint-rules/require-injectable.js";
 
 export default [
   js.configs.recommended,
@@ -114,6 +116,8 @@ export default [
           "no-from-params-in-adapters": noFromParamsInAdapters,
           "no-ignored-command-context": noIgnoredCommandContext,
           "no-validation-error-in-execute": noValidationErrorInExecute,
+          "no-domain-singleton": noDomainSingleton,
+          "require-injectable": requireInjectable,
         },
       },
     },
@@ -176,6 +180,37 @@ export default [
       "custom/no-from-params-in-adapters": "error", // Prevent ad-hoc provider creation in adapter layer (mt#788)
       "custom/no-ignored-command-context": "error", // Flags commands with DI-requiring params (session) that ignore context (mt#929)
       "custom/no-validation-error-in-execute": "warn", // ADR-004: ValidationError belongs in validate(), not execute()
+      "custom/no-domain-singleton": [
+        "error",
+        {
+          allowedNames: [
+            "ruleOperationRegistry",
+            "gitOperationRegistry",
+            "modularGitCommandsManager",
+            "defaultLoader",
+            "legacyConfig",
+            "log",
+            "EXEMPT_COMMANDS",
+            "testConfigManager",
+          ],
+        },
+      ], // Prevent singleton exports in domain code — use @injectable() and the DI container (mt#916)
+      "custom/require-injectable": [
+        "error",
+        {
+          allowedClasses: [
+            "FakeGitService",
+            "FakeTaskService",
+            "MemoryVectorStorage",
+            "SqliteStorage",
+            "SessionMigrationService",
+            "StorageError",
+            "StorageErrorClassifier",
+            "StorageErrorRecovery",
+            "StorageErrorMonitor",
+          ],
+        },
+      ], // Require @injectable() on domain Service/Storage/Adapter classes (mt#916)
 
       // === SINGLETON ARCHITECTURE ===
       "custom/no-singleton-reach-in": [

--- a/src/domain/knowledge/knowledge-service.ts
+++ b/src/domain/knowledge/knowledge-service.ts
@@ -5,6 +5,7 @@
  * knowledge source provider for each configured source.
  */
 
+import { injectable } from "tsyringe";
 import type { EmbeddingService } from "../ai/embeddings/types";
 import type { VectorStorage } from "../storage/vector/types";
 import type { KnowledgeSourceConfig, KnowledgeSourceProvider, SyncReport } from "./types";
@@ -21,6 +22,7 @@ export interface KnowledgeServiceDeps {
   config: { knowledgeBases: KnowledgeSourceConfig[] };
 }
 
+@injectable()
 export class KnowledgeService {
   constructor(private deps: KnowledgeServiceDeps) {}
 

--- a/src/domain/provenance/provenance-service.ts
+++ b/src/domain/provenance/provenance-service.ts
@@ -12,6 +12,7 @@
  * @see mt#923 — Phase 1: provenance chain data model
  */
 
+import { injectable } from "tsyringe";
 import { eq, and } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
@@ -71,6 +72,7 @@ export function computePreliminaryTier(signals: TierSignals): AuthorshipTier {
   return AuthorshipTier.CO_AUTHORED;
 }
 
+@injectable()
 export class ProvenanceService {
   constructor(private readonly db: PostgresJsDatabase) {}
 

--- a/tests/architecture/di-enforcement.test.ts
+++ b/tests/architecture/di-enforcement.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect } from "bun:test";
+import { execSync } from "child_process";
+import path from "path";
+
+const ROOT = path.resolve(import.meta.dir, "../..");
+
+function execStr(cmd: string, opts?: Parameters<typeof execSync>[1]): string {
+  return execSync(cmd, { encoding: "utf-8", ...opts }) as unknown as string;
+}
+
+function grepCount(pattern: string, dir: string, opts?: string): number {
+  try {
+    const result = execStr(
+      `grep -r ${opts || ""} "${pattern}" "${dir}" --include="*.ts" | grep -v "node_modules" | grep -v ".test.ts" | grep -v "/tests/" | grep -v "// " | wc -l`
+    );
+    return parseInt(result.trim(), 10);
+  } catch {
+    return 0; // grep returns exit code 1 when no matches
+  }
+}
+
+describe("DI enforcement", () => {
+  describe("banned anti-patterns in production code", () => {
+    const bannedPatterns = [
+      "defaultInstance",
+      "getAppContainer",
+      "setAppContainer",
+      "resolveProvider",
+      "createSessionDeps",
+      "getSharedSessionProvider",
+      "session-provider-cache",
+    ];
+
+    for (const pattern of bannedPatterns) {
+      test(`no '${pattern}' references outside comments`, () => {
+        // Use grep -v to exclude comment lines
+        const srcDir = path.join(ROOT, "src");
+        const count = grepCount(pattern, srcDir, "-l");
+        // Allow in comments/types.ts descriptions but not actual usage
+        if (count > 0) {
+          const files = execStr(
+            `grep -rl "${pattern}" "${srcDir}" --include="*.ts" | grep -v node_modules | grep -v ".test.ts"`
+          )
+            .trim()
+            .split("\n");
+
+          // Check each file — only comments/strings are acceptable
+          for (const file of files) {
+            try {
+              const lines = execStr(
+                `grep -n "${pattern}" "${file}" | grep -v "^[0-9]*:[[:space:]]*//" | grep -v "^[0-9]*:[[:space:]]*\\*" | grep -v "^[0-9]*:[[:space:]]*/\\*" | grep -v "\\*/" | grep -v "^[0-9]*:[[:space:]]*\\*"`,
+                { stdio: ["pipe", "pipe", "pipe"] }
+              ).trim();
+              // Filter out lines that are clearly doc comments (contain /** or * at any indent)
+              const nonCommentLines = lines
+                .split("\n")
+                .filter((l) => l.length > 0)
+                .filter((l) => {
+                  const content = l.replace(/^\d+:\s*/, "");
+                  return (
+                    !content.startsWith("//") &&
+                    !content.startsWith("*") &&
+                    !content.startsWith("/*") &&
+                    !content.startsWith("/**")
+                  );
+                });
+              expect(nonCommentLines).toEqual([]); // No non-comment usage
+            } catch {
+              // grep returns exit code 1 when all lines are filtered out — that's a pass
+            }
+          }
+        }
+      });
+    }
+  });
+
+  describe("domain singleton prevention", () => {
+    const allowedSingletons = new Set([
+      "ruleOperationRegistry",
+      "gitOperationRegistry",
+      "modularGitCommandsManager",
+      "defaultLoader",
+      "legacyConfig",
+      "log",
+      "EXEMPT_COMMANDS",
+      "testConfigManager",
+    ]);
+
+    test("no export const x = new X() outside allowlist", () => {
+      const srcDomain = path.join(ROOT, "src/domain");
+      const result = execStr(
+        `grep -rn "export const .* = new " "${srcDomain}" --include="*.ts" | grep -v node_modules | grep -v ".test.ts"`,
+        { stdio: ["pipe", "pipe", "pipe"] }
+      ).trim();
+
+      if (!result) return; // No matches = pass
+
+      const lines = result.split("\n");
+      for (const line of lines) {
+        const match = line.match(/export const (\w+)/);
+        if (match && match[1]) {
+          expect(allowedSingletons.has(match[1])).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("@injectable() decorator completeness", () => {
+    test("all *Service/*Storage/*Adapter classes in domain have @injectable()", () => {
+      const allowedMissing = new Set([
+        "FakeGitService",
+        "FakeTaskService",
+        "MemoryVectorStorage",
+        "SqliteStorage",
+        "SessionMigrationService",
+        // Error-handling utility classes (not DI services despite "Storage" in name)
+        "StorageError",
+        "StorageErrorClassifier",
+        "StorageErrorRecovery",
+        "StorageErrorMonitor",
+      ]);
+
+      const srcDomain = path.join(ROOT, "src/domain");
+      // Find all export class declarations matching the pattern
+      const classLines = execStr(
+        `grep -rn "export class \\w*\\(Service\\|Storage\\|Adapter\\)" "${srcDomain}" --include="*.ts" | grep -v node_modules | grep -v ".test.ts"`,
+        { stdio: ["pipe", "pipe", "pipe"] }
+      ).trim();
+
+      if (!classLines) return;
+
+      const missing: string[] = [];
+      for (const line of classLines.split("\n")) {
+        const classMatch = line.match(/export class (\w+)/);
+        if (!classMatch || !classMatch[1]) continue;
+        const className = classMatch[1];
+        if (allowedMissing.has(className)) continue;
+
+        // Check if @injectable() is on the preceding line
+        const parts = line.split(":");
+        const filePath = parts[0] ?? "";
+        const lineNum = parts[1] ?? "1";
+        const lineNumber = parseInt(lineNum, 10);
+        const prevLine = execStr(`sed -n '${lineNumber - 1}p' "${filePath}"`).trim();
+
+        if (!prevLine.includes("@injectable()")) {
+          missing.push(`${className} in ${filePath}:${lineNumber}`);
+        }
+      }
+
+      expect(missing).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `no-domain-singleton` ESLint rule: errors on `export const x = new X()` in `src/domain/` (with allowlist for registries/config)
- Add `require-injectable` ESLint rule: errors on `Service`/`Storage`/`Adapter` classes in `src/domain/` missing `@injectable()` decorator
- Add architectural test (`tests/architecture/di-enforcement.test.ts`) that greps for banned anti-patterns (`defaultInstance`, `getAppContainer`, `resolveProvider`, etc.) and verifies decorator completeness
- Fix `KnowledgeService` and `ProvenanceService` which were missing `@injectable()`

## Test plan

- [ ] `bun run lint` passes with zero errors (new rules active)
- [ ] `bun test tests/architecture/di-enforcement.test.ts` — all 9 tests pass
- [ ] Adding `export const bad = new Foo()` in `src/domain/` triggers `no-domain-singleton`
- [ ] Adding `export class BadService {}` without `@injectable()` in `src/domain/` triggers `require-injectable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)