### PR TITLE
chore(mt#952): migrate ValidationError violations, escalate ESLint rule, update review-pr skill

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -19,7 +19,9 @@ The argument is a PR number (e.g., `/review-pr 328`) or a GitHub PR URL.
 
 ### 1. Gather context
 
-Fetch in parallel:
+Use `mcp__minsky__session_pr_review_context` with the task ID or session ID to fetch all review data in a single call. This returns PR metadata, CI check runs, the diff, and the task spec.
+
+If the session tool fails (e.g., no session exists for this PR), fall back to fetching in parallel:
 
 - PR metadata: `mcp__github__pull_request_read` with `method: "get"`
 - CI status: `mcp__github__pull_request_read` with `method: "get_check_runs"`
@@ -27,11 +29,11 @@ Fetch in parallel:
 
 ### 2. Identify the task
 
-Extract the task ID from the PR title or branch name (e.g., `mt#671` from `task/mt-671`). If there's an associated task, fetch its spec with `mcp__minsky__tasks_spec_get`. This is needed for step 6.
+Extract the task ID from the PR title or branch name (e.g., `mt#671` from `task/mt-671`). If the task spec was not already returned by step 1, fetch it with `mcp__minsky__tasks_spec_get`. This is needed for step 6.
 
 ### 3. Read the diff
 
-Use `mcp__github__pull_request_read` with `method: "get_diff"`. For large diffs, the result will be saved to a file — read it in sequential chunks until 100% is covered.
+If the diff was not already returned by step 1, use `mcp__github__pull_request_read` with `method: "get_diff"`. For large diffs, the result will be saved to a file — read it in sequential chunks until 100% is covered.
 
 ### 4. Analyze changes
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,8 @@ export default [
   prettierConfig, // Disables ESLint rules that conflict with Prettier
   {
     ignores: [
+      // Exclude ESLint rule test fixtures (they intentionally violate rules)
+      "eslint-rules/__fixtures__/**",
       // Exclude other development/temporary files
       "test-tmp/**",
       "test-analysis/**",
@@ -179,7 +181,7 @@ export default [
       // === DI ENFORCEMENT ===
       "custom/no-from-params-in-adapters": "error", // Prevent ad-hoc provider creation in adapter layer (mt#788)
       "custom/no-ignored-command-context": "error", // Flags commands with DI-requiring params (session) that ignore context (mt#929)
-      "custom/no-validation-error-in-execute": "warn", // ADR-004: ValidationError belongs in validate(), not execute()
+      "custom/no-validation-error-in-execute": "error", // ADR-004: ValidationError belongs in validate(), not execute()
       "custom/no-domain-singleton": [
         "error",
         {

--- a/src/adapters/shared/commands/init.ts
+++ b/src/adapters/shared/commands/init.ts
@@ -83,6 +83,29 @@ export function registerInitCommands() {
       description: "Initialize a project for Minsky",
       parameters: initParams,
       requiresSetup: false,
+      validate: async (params: Record<string, unknown>) => {
+        const backend = params.backend as string | undefined;
+        const githubOwner = params.githubOwner as string | undefined;
+        const githubRepo = params.githubRepo as string | undefined;
+
+        if (!backend && !isInteractive()) {
+          throw new ValidationError(
+            `Backend parameter is required in non-interactive mode. Use --backend to specify: ${TaskBackend.MINSKY} or ${TaskBackend.GITHUB_ISSUES}`
+          );
+        }
+
+        if (backend === TaskBackend.GITHUB_ISSUES && !githubOwner && !isInteractive()) {
+          throw new ValidationError(
+            "GitHub owner is required when using github-issues backend. Use --github-owner to specify."
+          );
+        }
+
+        if (backend === TaskBackend.GITHUB_ISSUES && !githubRepo && !isInteractive()) {
+          throw new ValidationError(
+            "GitHub repository name is required when using github-issues backend. Use --github-repo to specify."
+          );
+        }
+      },
       execute: async (params, _ctx) => {
         try {
           // Map CLI params to domain params
@@ -106,12 +129,7 @@ export function registerInitCommands() {
           // Interactive backend selection if not provided
           let backend = params.backend;
           if (!backend) {
-            // Check if we're in an interactive environment
-            if (!isInteractive()) {
-              throw new ValidationError(
-                `Backend parameter is required in non-interactive mode. Use --backend to specify: ${TaskBackend.MINSKY} or ${TaskBackend.GITHUB_ISSUES}`
-              );
-            }
+            // isInteractive() is guaranteed true here (validate() enforced non-interactive check)
 
             const selectedBackend = await select({
               message: "Select a task backend:",
@@ -139,12 +157,7 @@ export function registerInitCommands() {
 
           if (backend === TaskBackend.GITHUB_ISSUES) {
             if (!githubOwner) {
-              if (!isInteractive()) {
-                throw new ValidationError(
-                  "GitHub owner is required when using github-issues backend. Use --github-owner to specify."
-                );
-              }
-
+              // isInteractive() is guaranteed true here (validate() enforced non-interactive check)
               const ownerInput = await text({
                 message: "Enter GitHub repository owner:",
                 placeholder: "e.g., octocat",
@@ -165,12 +178,7 @@ export function registerInitCommands() {
             }
 
             if (!githubRepo) {
-              if (!isInteractive()) {
-                throw new ValidationError(
-                  "GitHub repository name is required when using github-issues backend. Use --github-repo to specify."
-                );
-              }
-
+              // isInteractive() is guaranteed true here (validate() enforced non-interactive check)
               const repoInput = await text({
                 message: "Enter GitHub repository name:",
                 placeholder: "e.g., my-project",

--- a/src/adapters/shared/commands/mcp/register-command.ts
+++ b/src/adapters/shared/commands/mcp/register-command.ts
@@ -21,7 +21,7 @@ import { isInteractive } from "../../../../utils/interactive";
 import { detectInstalledClients } from "../../../../domain/runtime/harness-detection";
 import { registerWithClient, getRegistrar } from "../../../../domain/mcp/registration";
 import { loadProjectConfiguration } from "../../../../domain/configuration/sources/project";
-import { ValidationError, getErrorMessage } from "../../../../errors/index";
+import { MinskyError, ValidationError, getErrorMessage } from "../../../../errors/index";
 import type { McpConfig } from "../../../../domain/configuration/schemas/mcp";
 
 const mcpRegisterParams = composeParams(
@@ -48,35 +48,51 @@ export function registerMcpRegisterCommand(): void {
       description: "Register Minsky as an MCP server with a supported client",
       parameters: mcpRegisterParams,
       requiresSetup: false,
+      validate: async (params: Record<string, unknown>) => {
+        const repo = params.repo as string | undefined;
+        const workspacePath = params.workspacePath as string | undefined;
+        const client = params.client as string | undefined;
+        const repoPath = repo || workspacePath || process.cwd();
+
+        const configYamlPath = path.join(repoPath, ".minsky", "config.yaml");
+        if (!existsSync(configYamlPath)) {
+          throw new ValidationError(
+            "This project hasn't been initialized. Run `minsky init` first."
+          );
+        }
+
+        if (!client) {
+          const detectedClients = detectInstalledClients();
+
+          if (detectedClients.length === 0) {
+            throw new ValidationError(
+              "No supported MCP clients detected. Use --client to specify."
+            );
+          }
+
+          if (detectedClients.length > 1 && !isInteractive()) {
+            throw new ValidationError(
+              `Multiple MCP clients detected: ${detectedClients.join(", ")}. Use --client to specify one.`
+            );
+          }
+        }
+      },
       execute: async (params, _ctx) => {
         try {
           // 1. Resolve the repo path
           const repoPath = params.repo || params.workspacePath || process.cwd();
 
-          // 2. Check that .minsky/config.yaml exists
-          const configYamlPath = path.join(repoPath, ".minsky", "config.yaml");
-          if (!existsSync(configYamlPath)) {
-            throw new ValidationError(
-              "This project hasn't been initialized. Run `minsky init` first."
-            );
-          }
-
-          // 3. Load the project config and read the `mcp` section
+          // 2. Load the project config and read the `mcp` section
+          // (config.yaml existence already validated in validate())
           const projectConfig = loadProjectConfiguration(repoPath);
           const mcpConfig: McpConfig = (projectConfig as Record<string, unknown>).mcp as McpConfig;
           const resolvedMcpConfig = mcpConfig ?? { transport: "stdio" as const };
 
-          // 4. Determine the client to register with
+          // 3. Determine the client to register with
           let client = params.client;
 
           if (!client) {
             const detectedClients = detectInstalledClients();
-
-            if (detectedClients.length === 0) {
-              throw new ValidationError(
-                "No supported MCP clients detected. Use --client to specify."
-              );
-            }
 
             if (detectedClients.length === 1) {
               const singleClient = detectedClients[0] as string;
@@ -93,20 +109,17 @@ export function registerMcpRegisterCommand(): void {
                 }
 
                 if (!useDetected) {
-                  throw new ValidationError(
-                    "No client selected. Use --client to specify a client."
-                  );
+                  cancel("Registration cancelled.");
+                  return {
+                    success: false,
+                    message: "No client selected. Use --client to specify a client.",
+                  };
                 }
               }
               // In non-interactive mode, use the single detected client directly
               client = singleClient;
             } else {
-              // Multiple clients found
-              if (!isInteractive()) {
-                throw new ValidationError(
-                  `Multiple MCP clients detected: ${detectedClients.join(", ")}. Use --client to specify one.`
-                );
-              }
+              // Multiple clients found — isInteractive() guaranteed true (validate() enforced non-interactive check)
 
               // Prompt user to select in interactive mode
               const selectedClient = await select({
@@ -141,7 +154,10 @@ export function registerMcpRegisterCommand(): void {
           if (error instanceof ValidationError) {
             throw error;
           }
-          throw new ValidationError(getErrorMessage(error));
+          throw new MinskyError(
+            `MCP registration failed: ${getErrorMessage(error)}`,
+            error instanceof Error ? error : undefined
+          );
         }
       },
     })

--- a/src/adapters/shared/commands/setup.ts
+++ b/src/adapters/shared/commands/setup.ts
@@ -51,6 +51,17 @@ export function registerSetupCommands() {
         "Set up developer-local configuration for Minsky (MCP registration + local config)",
       parameters: setupParams,
       requiresSetup: false,
+      validate: async (params: Record<string, unknown>) => {
+        const client = params.client as string | undefined;
+        if (!client) {
+          const installedClients = detectInstalledClients();
+          if (installedClients.length > 1 && !isInteractive()) {
+            throw new ValidationError(
+              `Multiple MCP clients detected (${installedClients.join(", ")}). Use --client to specify one.`
+            );
+          }
+        }
+      },
       execute: async (params, _ctx) => {
         try {
           const repoPath = params.repo || params.workspacePath || process.cwd();
@@ -69,11 +80,7 @@ export function registerSetupCommands() {
               client = installedClients[0];
             } else {
               // Multiple clients detected — prompt if interactive
-              if (!isInteractive()) {
-                throw new ValidationError(
-                  `Multiple MCP clients detected (${installedClients.join(", ")}). Use --client to specify one.`
-                );
-              }
+              // isInteractive() is guaranteed true here (validate() enforced non-interactive check)
 
               const selectedClient = await select({
                 message: "Select an MCP client to register Minsky with:",


### PR DESCRIPTION
## Summary

- Migrate all 9 `throw ValidationError` in `execute()` methods to `validate()` methods
- Escalate ESLint rule `no-validation-error-in-execute` from "warn" to "error" (now blocks CI)
- Update `/review-pr` skill to use `session.pr.review_context` as primary data source
- Exclude `eslint-rules/__fixtures__/` from lint (test fixtures intentionally violate rules)

## Changed files

- `src/adapters/shared/commands/init.ts` — 3 violations → validate()
- `src/adapters/shared/commands/mcp/register-command.ts` — 5 violations → validate() + error type fix
- `src/adapters/shared/commands/setup.ts` — 1 violation → validate()
- `eslint.config.js` — "warn" → "error" + fixture ignore
- `.claude/skills/review-pr/SKILL.md` — use `session.pr.review_context` tool

## Test plan

- [x] `npx eslint --rule 'custom/no-validation-error-in-execute: error' src/` — 0 errors
- [x] Pre-commit hooks pass (typecheck + lint + format)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)