### PR TITLE
feat(mt#955): wire reviewer agent into CLAUDE.md routing and review-pr skill

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -35,6 +35,17 @@ Extract the task ID from the PR title or branch name (e.g., `mt#671` from `task/
 
 If the diff was not already returned by step 1, use `mcp__github__pull_request_read` with `method: "get_diff"`. For large diffs, the result will be saved to a file — read it in sequential chunks until 100% is covered.
 
+**Proportionality rule:** For PRs with > 20 changed files, you MUST dispatch multiple `reviewer` agents (`.claude/agents/reviewer.md`) in parallel, each covering a distinct portion of the diff (~25 files per agent). Use `subagent_type: "reviewer"` when dispatching. A single read pass or a spot-check of selected files is NEVER acceptable for large PRs. The number of reviewer agents should scale with the diff size:
+
+- 1–20 files: Read the diff yourself (single pass is acceptable)
+- 21–50 files: Dispatch 2 reviewer agents
+- 51–100 files: Dispatch 4 reviewer agents
+- 100+ files: Dispatch 5+ reviewer agents
+
+Each reviewer agent receives: the diff file path + line range, the PR's purpose/context, and any specific concerns to watch for. Collect all agent findings before proceeding.
+
+**Coverage gate:** Before proceeding to step 7 (Post to GitHub), you MUST have read or had agents read 100% of the diff. State explicitly: "Coverage: X/Y files reviewed." If coverage is not 100%, do NOT post. Sampling is not reviewing — it is performing diligence theater.
+
 ### 4. Analyze changes
 
 For each file changed, understand:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Prefer specialized subagent types over `general-purpose` when one fits:
 
 - **`subagent_type: "refactor"`** — Structural code changes (renaming, moving, eliminating layers, consolidating, extracting). Has built-in coherence verification: re-reads modified files end-to-end and reports stale comments, redundant siblings, dead exports, and orphan code. Use whenever the task is a refactor rather than feature work. _Why_: relying on a remembered "verify the result is coherent" rule is structurally weak; the verification belongs in the agent's identity, not in your prompt.
 - **`subagent_type: "verify-completion"`** — Task completion verification. Reads the task spec, checks each success criterion against the current codebase, returns structured pass/fail. Use before marking any task DONE. _Why_: the doer is biased toward "I did what was asked." A fresh agent objectively evaluates completion.
+- **`subagent_type: "reviewer"`** — Read-only PR review analysis. Reads a section of diff, verifies each change against actual source files, reports structured findings (blocking/non-blocking). Dispatched by `/review-pr` for large PRs (~25 files per agent). Cannot modify code. _Why_: reviews require reading 100% of the diff — reviewer agents enable parallel coverage without blowing the main context.
 - **`subagent_type: "Explore"`** — Codebase exploration and search.
 - **`subagent_type: "Plan"`** — Designing implementation plans before coding.
 - **`subagent_type: "general-purpose"`** — Fallback for work that doesn't fit a specialized type.


### PR DESCRIPTION
## Summary

- Adds `reviewer` to CLAUDE.md subagent type routing table
- Updates review-pr skill with proportionality rule (file count → agent count thresholds) and coverage gate (must state "Coverage: X/Y files" before posting)
- Agent definition (`.claude/agents/reviewer.md`) was created in a prior conversation and already exists

## Context

Motivated by PR #614 review failure: a 100-file PR was reviewed by sampling 6 spots. The retrospective identified an enforcement gap — nothing prevented posting a review without reading the full diff. These changes make the review-pr skill structurally require proportional reviewer agent dispatch for large PRs.

## Test plan

- [x] `reviewer` agent type resolves when dispatched with `subagent_type: "reviewer"` (verified via smoke test)
- [x] Agent uses read-only tools (Read, Glob, Grep, Bash) — no Edit/Write
- [x] Agent produces structured findings in expected format
- [ ] `grep 'reviewer' CLAUDE.md` shows routing entry
- [ ] `grep 'Proportionality' .claude/skills/review-pr/SKILL.md` shows dispatch rule
- [ ] `grep 'Coverage gate' .claude/skills/review-pr/SKILL.md` shows posting gate