### PR TITLE
feat(mt#948): Add session.exec MCP tool for executing shell commands in session workspaces

### DIFF
--- a/src/adapters/shared/commands/session.ts
+++ b/src/adapters/shared/commands/session.ts
@@ -12,6 +12,7 @@ import {
   createSessionStartCommand,
   createSessionDirCommand,
   createSessionSearchCommand,
+  createSessionExecCommand,
 } from "./session/basic-commands";
 import {
   createSessionDeleteCommand,
@@ -70,6 +71,7 @@ export async function registerSessionCommands(
     createSessionStartCommand(getDeps),
     createSessionDirCommand(getDeps),
     createSessionSearchCommand(getDeps),
+    createSessionExecCommand(getDeps),
 
     // Management
     createSessionDeleteCommand(getDeps),

--- a/src/adapters/shared/commands/session/basic-commands.ts
+++ b/src/adapters/shared/commands/session/basic-commands.ts
@@ -11,6 +11,7 @@ import {
   sessionStartCommandParams,
   sessionDirCommandParams,
   sessionSearchCommandParams,
+  sessionExecCommandParams,
 } from "./session-parameters";
 
 export function createSessionListCommand(getDeps: LazySessionDeps): CommandDefinition {
@@ -207,6 +208,54 @@ export function createSessionSearchCommand(getDeps: LazySessionDeps): CommandDef
         totalSessions: sessions.length,
         limit,
       };
+    }),
+  };
+}
+
+export function createSessionExecCommand(getDeps: LazySessionDeps): CommandDefinition {
+  return {
+    id: "session.exec",
+    category: CommandCategory.SESSION,
+    name: "exec",
+    description: "Execute a shell command in a session's working directory",
+    parameters: sessionExecCommandParams,
+    execute: withErrorLogging("session.exec", async (params: Record<string, unknown>) => {
+      const { executeCommand } = await import("../../../../utils/exec");
+      const { SessionService } = await import("../../../../domain/session/session-service");
+      const deps = await getDeps();
+      const service = new SessionService(deps);
+
+      const workdir = await service.getDir({
+        name: params.name as string | undefined,
+        task: params.task as string | undefined,
+        repo: params.repo as string | undefined,
+      });
+
+      const timeout = Math.min((params.timeout as number | undefined) ?? 30000, 120000);
+
+      try {
+        const { stdout, stderr } = await executeCommand(params.command as string, {
+          cwd: workdir,
+          timeout,
+        });
+        return {
+          success: true,
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          workdir,
+          exitCode: 0,
+        };
+      } catch (error) {
+        const execError = error as { code?: number; stdout?: string; stderr?: string };
+        return {
+          success: false,
+          stdout: (execError.stdout ?? "").trim(),
+          stderr: (execError.stderr ?? "").trim(),
+          exitCode: execError.code ?? 1,
+          workdir,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     }),
   };
 }

--- a/src/adapters/shared/commands/session/session-parameters.ts
+++ b/src/adapters/shared/commands/session/session-parameters.ts
@@ -648,6 +648,26 @@ export const sessionPrReviewSubmitCommandParams = {
 };
 
 /**
+ * Session exec command parameters
+ * Executes a shell command in a session's working directory
+ */
+export const sessionExecCommandParams = {
+  name: commonSessionParams.name,
+  task: commonSessionParams.task,
+  repo: commonSessionParams.repo,
+  command: {
+    schema: z.string().min(1),
+    description: "Shell command to execute",
+    required: true,
+  },
+  timeout: {
+    schema: z.number().int().positive().max(120000).optional(),
+    description: "Timeout in milliseconds (default: 30000, max: 120000)",
+    required: false,
+  },
+};
+
+/**
  * Session repair command parameters
  * Repairs various session state issues
  */


### PR DESCRIPTION
Implements the `session.exec` command (exposed as `mcp__minsky__session_exec` via the shared command registry) that executes a shell command inside a session's working directory.

## Changes

- `src/adapters/shared/commands/session/session-parameters.ts` — adds `sessionExecCommandParams` with `name`, `task`, `repo`, `command` (required), and `timeout` (optional, default 30s, max 120s)
- `src/adapters/shared/commands/session/basic-commands.ts` — adds `createSessionExecCommand` factory following the `createSessionDirCommand` pattern; resolves session workdir via `SessionService.getDir`, runs the command via `executeCommand` from `src/utils/exec.ts`, returns `{ success, stdout, stderr, exitCode, workdir }` on both success and failure
- `src/adapters/shared/commands/session.ts` — imports `createSessionExecCommand` and registers it in the commands array

## Error handling

Non-zero exit codes are caught and returned as `{ success: false, stdout, stderr, exitCode, workdir, error }` rather than thrown, so callers get structured output regardless of exit status.