### PR TITLE
fix(mt#964): add missing journal entries for migrations 0018 and 0019

### DIFF
--- a/src/domain/storage/migrations/pg/meta/_journal.json
+++ b/src/domain/storage/migrations/pg/meta/_journal.json
@@ -129,6 +129,20 @@
       "breakpoints": true
     },
     {
+      "idx": 18,
+      "version": "7",
+      "when": 1776499200000,
+      "tag": "0018_add_planning_status",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1776585600000,
+      "tag": "0019_add_ready_status",
+      "breakpoints": true
+    },
+    {
       "idx": 20,
       "version": "7",
       "when": 1745020800000,


### PR DESCRIPTION
## Summary

- Add missing `_journal.json` entries for `0018_add_planning_status` (idx 18) and `0019_add_ready_status` (idx 19)
- Both migrations already applied to DB but were never journaled because `persistence migrate --execute` was silently failing (fixed in mt#908, PR #619)

## Test plan

- [ ] `persistence migrate --dry-run` shows 0 pending migrations
- [ ] Journal idx sequence is contiguous (0-22)