### PR TITLE
feat(mt#957): wire session activity state into all mutation operations

### DIFF
--- a/src/domain/repository/github-pr-operations.ts
+++ b/src/domain/repository/github-pr-operations.ts
@@ -23,6 +23,7 @@ import {
 } from "./github-error-handler";
 import type { AuthorshipTier } from "../provenance/types";
 import { ensureAuthorshipLabelsExist, addAuthorshipLabel } from "../provenance/authorship-labels";
+import { SessionStatus } from "../session/types";
 
 // ── Shared helpers ──────────────────────────────────────────────────────
 
@@ -168,6 +169,8 @@ export async function createPullRequest(
         if (sessionRecord) {
           const updatedSession = {
             ...sessionRecord,
+            lastActivityAt: new Date().toISOString(),
+            status: SessionStatus.PR_OPEN,
             pullRequest: {
               number: pr.number,
               url: pr.html_url,

--- a/src/domain/session/session-approval-operations.ts
+++ b/src/domain/session/session-approval-operations.ts
@@ -17,6 +17,7 @@ import {
   type RepositoryBackendConfig,
 } from "../repository/index";
 import type { SessionRecord } from "./types";
+import { SessionStatus } from "./types";
 import { assertSessionMutable } from "./session-mutability";
 import type { ApprovalInfo } from "../repository/approval-types";
 import type { GitServiceInterface } from "../git/types";
@@ -197,6 +198,16 @@ export async function approveSessionPr(
   }
 
   const approvalInfo = await repositoryBackend.review.approve(prIdentifier, params.reviewComment);
+
+  // Update session activity state after successful approval
+  try {
+    await sessionDB.updateSession(sessionIdToUse, {
+      lastActivityAt: new Date().toISOString(),
+      status: SessionStatus.PR_APPROVED,
+    });
+  } catch (e) {
+    log.debug("Failed to update session activity state on PR approve", { error: e });
+  }
 
   // Note: Repository backend handles approval storage:
   // - GitHub backend: stores approval in GitHub

--- a/src/domain/session/session-commands.ts
+++ b/src/domain/session/session-commands.ts
@@ -265,6 +265,25 @@ export async function sessionCommit(
       });
     }
 
+    // Update session activity state after successful commit+push
+    try {
+      const { SessionStatus } = await import("./types");
+      const currentSession = await sessionProvider.getSession(params.session);
+      const newCommitCount = (currentSession?.commitCount ?? 0) + 1;
+      await sessionProvider.updateSession(params.session, {
+        lastActivityAt: new Date().toISOString(),
+        lastCommitHash: commitResult.commitHash,
+        lastCommitMessage: params.message,
+        commitCount: newCommitCount,
+        status:
+          currentSession?.status === SessionStatus.CREATED
+            ? SessionStatus.ACTIVE
+            : currentSession?.status,
+      });
+    } catch (e) {
+      log.debug("Failed to update session activity state", { error: e });
+    }
+
     return {
       success: true,
       commitHash: commitResult.commitHash,

--- a/src/domain/session/session-merge-operations.ts
+++ b/src/domain/session/session-merge-operations.ts
@@ -26,6 +26,7 @@ import type { GitServiceInterface } from "../git/types";
 import { TASK_STATUS } from "../tasks/taskConstants";
 import { getErrorMessage } from "../../errors";
 import type { SessionRecord } from "./types";
+import { SessionStatus } from "./types";
 import { cleanupSessionImpl } from "./session-lifecycle-operations";
 import { cleanupLocalBranches } from "./session-approve-operations";
 import { resolveRepository } from "../repository";
@@ -483,6 +484,16 @@ export async function mergeSessionPr(
         log.cli(`⚠️  Warning: ${errorMsg}`);
       }
     }
+  }
+
+  // Update session activity state to MERGED before cleanup
+  try {
+    await sessionDB.updateSession(sessionIdToUse, {
+      lastActivityAt: new Date().toISOString(),
+      status: SessionStatus.MERGED,
+    });
+  } catch (e) {
+    log.debug("Failed to update session activity state on PR merge", { error: e });
   }
 
   // Session cleanup after successful merge (default: enabled)

--- a/src/domain/session/session-workspace-service.ts
+++ b/src/domain/session/session-workspace-service.ts
@@ -144,7 +144,22 @@ export class SessionWorkspaceService {
       contentLength: content.length,
     });
 
-    return this.workspaceBackend.writeFile(workspace.workspaceDir, validatedPath, content);
+    const result = await this.workspaceBackend.writeFile(
+      workspace.workspaceDir,
+      validatedPath,
+      content
+    );
+
+    // Update session activity state after successful write (best-effort)
+    try {
+      await this.sessionProvider.updateSession(workspace.session, {
+        lastActivityAt: new Date().toISOString(),
+      });
+    } catch (e) {
+      // Activity tracking is best-effort — don't fail the file operation
+    }
+
+    return result;
   }
 
   /**

--- a/src/domain/session/start-session-operations.ts
+++ b/src/domain/session/start-session-operations.ts
@@ -19,6 +19,7 @@ import type { SessionProviderInterface, SessionRecord, Session } from "../sessio
 import { validateQualifiedTaskId, formatTaskIdForDisplay } from "../tasks/task-id-utils";
 import { RepositoryBackendType } from "../repository";
 import { generateSessionId, taskIdToBranchName } from "../tasks/task-id";
+import { SessionStatus } from "./types";
 
 export interface StartSessionDependencies {
   sessionDB: SessionProviderInterface;
@@ -310,6 +311,8 @@ async function executeMutations(
     taskId,
     backendType,
     branch: branchName,
+    lastActivityAt: new Date().toISOString(),
+    status: SessionStatus.CREATED,
   };
 
   let sessionAdded = false;


### PR DESCRIPTION
## Summary

- Adds `lastActivityAt` and `status: CREATED` to the session record on session start (`start-session-operations.ts`)
- Updates `lastActivityAt`, `lastCommitHash`, `lastCommitMessage`, `commitCount`, and `status` (CREATED→ACTIVE) after a successful `sessionCommit` (`session-commands.ts`)
- Updates `lastActivityAt` and `status: PR_OPEN` in `github-pr-operations.ts` when a GitHub PR is created (augmenting the existing `updateSession` call there)
- Updates `lastActivityAt` and `status: PR_APPROVED` after `approveSessionPr` succeeds (`session-approval-operations.ts`)
- Updates `lastActivityAt` and `status: MERGED` before session cleanup in `mergeSessionPr` (`session-merge-operations.ts`)
- Updates `lastActivityAt` (best-effort) after `writeFile` in `SessionWorkspaceService` (`session-workspace-service.ts`)

## Key constraints honored

- Status only moves forward: `CREATED → ACTIVE → PR_OPEN → PR_APPROVED → MERGED`
- `commitCount` is incremental: reads current value and adds 1
- All activity updates are wrapped in `try/catch` with `log.debug` on failure — tracking failures never block core operations
- `lastActivityAt` is updated on every operation regardless of status changes

## Test plan

- [ ] Start a session: record should have `status: CREATED` and `lastActivityAt` set
- [ ] Commit in a session: `status` transitions to `ACTIVE`, `commitCount` increments, `lastCommitHash`/`lastCommitMessage` are set
- [ ] Create a PR: `status` transitions to `PR_OPEN`
- [ ] Approve a PR: `status` transitions to `PR_APPROVED`
- [ ] Merge a PR: `status` transitions to `MERGED`
- [ ] Write a file via MCP: `lastActivityAt` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)