### PR TITLE
fix(mt#971): fix out-of-order timestamps in migration journal for 0020-0022

### DIFF
--- a/src/domain/storage/migrations/pg/meta/_journal.json
+++ b/src/domain/storage/migrations/pg/meta/_journal.json
@@ -145,21 +145,21 @@
     {
       "idx": 20,
       "version": "7",
-      "when": 1745020800000,
+      "when": 1776672000000,
       "tag": "0020_knowledge_embeddings",
       "breakpoints": true
     },
     {
       "idx": 21,
       "version": "7",
-      "when": 1745107200000,
+      "when": 1776758400000,
       "tag": "0021_provenance_chain",
       "breakpoints": true
     },
     {
       "idx": 22,
       "version": "7",
-      "when": 1745193600000,
+      "when": 1776844800000,
       "tag": "0022_session_liveness_fields",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

- Fix `when` timestamps for migration journal entries 0020-0022 to be monotonically increasing after 0019
- Entries 0020-0022 had timestamps from 2025-04-19 which predated 0018-0019 (2026-04-16), causing drizzle-orm's migrator to process them out of order and skip pending migrations

**Root cause:** When entries 0020-0022 were added by other PRs, they used timestamps that predated the 0018-0019 entries added in mt#964. Drizzle-orm's migrator uses `created_at` (derived from journal `when`) to order migrations, so out-of-order timestamps caused it to report "Applied 0 migration(s)" even with pending work.

## Test plan

- [ ] `persistence migrate --dry-run` shows 0 pending migrations
- [ ] Journal timestamps are monotonically increasing (verified by `jq`)