### PR TITLE
feat(mt#958): enrich session_get/list with liveness and add task filter to session_list

### DIFF
--- a/src/adapters/shared/commands/session/basic-commands.ts
+++ b/src/adapters/shared/commands/session/basic-commands.ts
@@ -29,6 +29,7 @@ export function createSessionListCommand(getDeps: LazySessionDeps): CommandDefin
       let sessions = await service.list({
         repo: params.repo as string | undefined,
         json: params.json as boolean | undefined,
+        task: params.task as string | undefined,
       });
 
       try {

--- a/src/adapters/shared/commands/session/session-parameters.ts
+++ b/src/adapters/shared/commands/session/session-parameters.ts
@@ -69,6 +69,11 @@ export const commonSessionParams = {
 export const sessionListCommandParams = {
   repo: commonSessionParams.repo,
   json: commonSessionParams.json,
+  task: {
+    schema: z.string(),
+    description: "Filter sessions by task ID (e.g. 'mt#283' or '283')",
+    required: false,
+  },
   since: {
     schema: z.string(),
     description: "Only include sessions created on/after this time (YYYY-MM-DD or 7d/24h/30m)",

--- a/src/domain/session/session-lifecycle-operations.ts
+++ b/src/domain/session/session-lifecycle-operations.ts
@@ -9,6 +9,7 @@ import type {
 import { resolveSessionContextWithFeedback } from "./session-context-resolver";
 import { getCurrentSessionContext } from "../workspace";
 import type { SessionProviderInterface, Session } from "./";
+import { deriveSessionLiveness } from "./types";
 import { log } from "../../utils/logger";
 import { getErrorMessage } from "../../errors";
 import { rmSync, existsSync } from "node:fs";
@@ -40,7 +41,10 @@ export async function getSessionImpl(
     });
 
     // Get the session details using the resolved session ID
-    return deps.sessionDB.getSession(resolvedContext.sessionId) as Promise<Session | null>;
+    const session = await deps.sessionDB.getSession(resolvedContext.sessionId);
+    if (!session) return null;
+    const liveness = deriveSessionLiveness(session);
+    return { ...session, liveness } as Session;
   } catch (error) {
     // If error is about missing session requirements, provide better user guidance
     if (error instanceof ValidationError) {
@@ -57,12 +61,24 @@ export async function getSessionImpl(
  * Using proper dependency injection for better testability
  */
 export async function listSessionsImpl(
-  _params: SessionListParams,
+  params: SessionListParams,
   deps: {
     sessionDB: SessionProviderInterface;
   }
 ): Promise<Session[]> {
-  return deps.sessionDB.listSessions() as Promise<Session[]>;
+  const sessions = await deps.sessionDB.listSessions();
+  let result = sessions.map((s) => ({ ...s, liveness: deriveSessionLiveness(s) })) as Session[];
+
+  // Filter by task ID if provided
+  if (params.task) {
+    const normalizedTaskId = params.task.replace(/^mt#/, "");
+    result = result.filter((s) => {
+      const sessionTaskId = s.taskId?.replace(/^mt#/, "");
+      return sessionTaskId === normalizedTaskId;
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/src/domain/session/types.ts
+++ b/src/domain/session/types.ts
@@ -101,6 +101,8 @@ export interface Session {
   createdAt?: string;
   /** Task ID in storage format (plain number string, e.g., "283") */
   taskId?: string;
+  /** Computed liveness status derived from lastActivityAt and session status */
+  liveness?: SessionLiveness;
   backendType?: "github" | "gitlab" | "bitbucket";
   github?: {
     owner?: string;

--- a/src/schemas/session.ts
+++ b/src/schemas/session.ts
@@ -33,7 +33,9 @@ export const _sessionRecordSchema = z.object({
 /**
  * Schema for session list parameters
  */
-export const sessionListParamsSchema = commonCommandOptionsSchema;
+export const sessionListParamsSchema = commonCommandOptionsSchema.extend({
+  task: taskIdSchema.optional().describe("Filter sessions by task ID"),
+});
 
 /**
  * Type for session list parameters


### PR DESCRIPTION
## Summary

- Adds computed `liveness` field to `Session` interface and enriches `session_get` and `session_list` responses by calling `deriveSessionLiveness()` (already existed in `src/domain/session/types.ts`)
- Adds `task` filter parameter to `session_list` — accepts both `"283"` and `"mt#283"` formats, normalizing before comparison
- The `tasks_get` cross-reference (`includeSession` param) is deferred — wiring `sessionProvider` into `query-commands.ts` would require container changes out of scope for this PR

## Changes

- `src/domain/session/types.ts` — added `liveness?: SessionLiveness` to `Session` interface
- `src/domain/session/session-lifecycle-operations.ts` — `getSessionImpl` and `listSessionsImpl` now compute and attach liveness; `listSessionsImpl` filters by `params.task` when provided
- `src/adapters/shared/commands/session/session-parameters.ts` — added `task` parameter to `sessionListCommandParams`
- `src/adapters/shared/commands/session/basic-commands.ts` — passes `task` from params to `service.list()`

## Backward Compatibility

All new fields and parameters are optional. Existing callers see no breaking changes.

## Deferred

- `tasks_get --includeSession` cross-reference: deferred due to DI complexity in `query-commands.ts`

🤖 Generated with Claude Code (had Claude implement mt#958)