### PR TITLE
refactor(mt#959): Slim CLAUDE.md from 222 to 78 lines for token efficiency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,121 +1,16 @@
 # Minsky — Claude Code Instructions
 
-## Subagent Model Routing
+## Subagent Routing
 
-When spawning subagents via the Agent tool, use the appropriate model to balance capability with rate limit consumption:
+When spawning subagents, use the appropriate model and type:
 
-- **`model: "sonnet"`** — Well-defined implementation tasks: applying known fixes, editing specific lines, running tests, committing, file exploration, search, any task with clear instructions and bounded scope.
-- **`model: "opus"` (default)** — Complex bug investigation, architectural design and review, multi-step reasoning across many files, tasks where the approach isn't yet clear.
+**Models:** `"sonnet"` for bounded tasks (implementation, refactoring, search, committing). `"opus"` (default) for complex investigation, architectural design, multi-step reasoning. `"haiku"` for simple search/formatting.
 
-### Subagent Type Routing
+**Types:** `"refactor"` for structural changes (built-in coherence verification). `"verify-completion"` for spec verification. `"reviewer"` for read-only PR review. `"Explore"` for codebase search. `"Plan"` for design. `"general-purpose"` as fallback.
 
-Prefer specialized subagent types over `general-purpose` when one fits:
+**Capacity:** Subagents have limited context/tool budgets with no graceful degradation. Scope to 8–12 files per wave. Instruct to commit incrementally. For multi-phase work, use subtasks (`tasks_create` with `parent`). If a subagent returns incomplete work, check session `git diff`/`git status` and finish from main agent.
 
-- **`subagent_type: "refactor"`** — Structural code changes (renaming, moving, eliminating layers, consolidating, extracting). Has built-in coherence verification: re-reads modified files end-to-end and reports stale comments, redundant siblings, dead exports, and orphan code. Use whenever the task is a refactor rather than feature work. _Why_: relying on a remembered "verify the result is coherent" rule is structurally weak; the verification belongs in the agent's identity, not in your prompt.
-- **`subagent_type: "verify-completion"`** — Task completion verification. Reads the task spec, checks each success criterion against the current codebase, returns structured pass/fail. Use before marking any task DONE. _Why_: the doer is biased toward "I did what was asked." A fresh agent objectively evaluates completion.
-- **`subagent_type: "reviewer"`** — Read-only PR review analysis. Reads a section of diff, verifies each change against actual source files, reports structured findings (blocking/non-blocking). Dispatched by `/review-pr` for large PRs (~25 files per agent). Cannot modify code. _Why_: reviews require reading 100% of the diff — reviewer agents enable parallel coverage without blowing the main context.
-- **`subagent_type: "Explore"`** — Codebase exploration and search.
-- **`subagent_type: "Plan"`** — Designing implementation plans before coding.
-- **`subagent_type: "general-purpose"`** — Fallback for work that doesn't fit a specialized type.
-
-### Subagent Capacity
-
-Subagents have limited tool-call budgets and context windows. They cannot detect when they're approaching limits and get no cleanup chance when cut off. Uncommitted work is lost.
-
-- **Scope subagent work to fit within capacity.** A subagent touching 15+ files is at risk. For large refactors, split into waves of 8–12 files each.
-- **Instruct subagents to commit incrementally**, not in one final commit. The refactor subagent already has this in its system prompt.
-- **If a subagent returns incomplete work** (changes applied but not committed/PR'd), check the session's `git diff` and `git status`, then finish the commit/PR from the main agent.
-- **For multi-phase work, use subtasks.** If a subagent completes Phase 1 and there's remaining work, create a subtask for the next phase (`tasks_create` with `parent: "<task-id>"`). Each subtask gets its own session and PR. Do NOT reuse the same session or do delete-restart.
-- **Pre-decompose large tasks** before farming them out. If a task clearly has multiple phases, create subtasks upfront and dispatch each to its own subagent with its own session.
-- **For cascading changes** (where editing one file forces changes in its callers), the blast radius is unpredictable. Err on the side of smaller scope and let the cascade determine one wave's natural boundary.
-
-### Subagent Prompt Generation
-
-**Always use `session.generate_prompt`** to generate subagent prompts instead of hand-crafting them. The tool ensures correct sessionId, taskId, absolute paths, scope bounds, and guard rails — eliminating the class of failures seen in mt#672 (wrong task IDs, missing sessionIds, unbounded scope).
-
-**Workflow:**
-
-1. **Assess scope**: If the task has multiple phases, create subtasks first (`tasks_create` with `parent`). Each subtask gets its own session.
-2. Start a session: `mcp__minsky__session_start` (for the task or subtask)
-3. Generate the prompt: `mcp__minsky__session_generate_prompt` with `task`, `type`, and `instructions`
-4. Dispatch: pass the returned `prompt` string to the Agent tool, using `suggestedModel` and `suggestedSubagentType` from the result
-5. Review and merge as normal
-
-**Prompt types:**
-
-- `implementation` — Feature work with commit + PR instructions
-- `refactor` — Structural changes, suggests `subagent_type: "refactor"`
-- `review` — Read-only, no commit/PR instructions
-- `cleanup` — Mechanical fixes with batching guidance
-- `audit` — Post-merge spec verification, suggests `subagent_type: "verify-completion"`
-
-**Scope batching:** When `scope` has > 40 files, the tool returns multiple prompts in the `batches` array (~30 files each). Dispatch each batch as a separate subagent with intermediate commits.
-
-**Do NOT hand-craft subagent prompts.** The tool handles session resolution, metadata injection, guard rails, and scope validation. Hand-crafting bypasses these safety mechanisms.
-
-## Minsky Session Workflow
-
-Minsky sessions are isolated git clones at `~/.local/state/minsky/sessions/<UUID>/` (branch names follow `task/<backend>-<id>` format). The correct working pattern:
-
-1. **ALL code changes go through sessions** — even small fixes. Never edit main workspace directly. Investigation/planning happens before the session (reading main workspace is fine).
-2. **Before starting a session**, the task must go through PLANNING → READY. Pick up the task (`status_set PLANNING`), investigate the codebase, update the spec with findings, then set to READY when planning is complete. Only then call `session_start`.
-3. **Main agent** orchestrates: create tasks, plan, start sessions, launch subagents, review PRs, merge.
-4. **Subagents** do the full workflow in session directories: edit code → `mcp__minsky__session_commit` → `mcp__minsky__session_pr_create`. They do NOT merge — that happens after review.
-5. **Before creating a PR**, always ensure the session is up-to-date with main. `mcp__minsky__session_pr_create` automatically calls `session_update` (which rebases the session on latest main) before creating the PR — this prevents merge-induced formatting drift and ensures clean fast-forward merges. You can also call `mcp__minsky__session_update` explicitly before committing if needed.
-6. **Main agent reviews** the PR using the `/review-pr` skill, which verifies findings against the actual codebase and posts the review to GitHub. Never merge without a posted GitHub review.
-7. **After merging a PR**, the local workspace is stale (merge happens on GitHub). A PostToolUse hook auto-pulls after `session_pr_merge`. If starting a fresh conversation after prior merges, verify the workspace is current before analyzing code.
-8. **When merging multiple PRs sequentially**, each merge may cause conflicts in remaining PRs. Update remaining sessions (`session_update`) after each merge, or resolve conflicts with `session_search_replace` on the conflict markers.
-9. All file operations in sessions MUST use absolute paths.
-10. **NEVER use `skipInstall: true`** when starting sessions. Sessions without `node_modules` cannot pass typecheck hooks, blocking subagent completion. Always let deps install.
-11. **NEVER use bare git CLI** (`git add`, `git commit`, `git push`, `git pull`, `git -C`). Always use MCP tools. Shell `#` in task paths causes parsing issues and permission prompts.
-12. **Always quote all Bash arguments** containing `#`, `$`, or special chars if Bash is unavoidable.
-13. **If MCP session tools fail** (e.g., mt#722 causes session records to vanish), and you must fall back to bare git for commit/push/PR creation, you MUST replicate the safety steps that the MCP tools would have performed: `git fetch origin main && git rebase origin/main` before pushing, to prevent merge conflicts that block CI. A PR with conflicts will not trigger CI — GitHub silently skips it.
-
-### Session lifecycle: one session, one merge
-
-After a session's PR is merged, the session is **frozen** — write operations (`session_pr_create`, `session_pr_edit`, `session_commit`, `session_pr_approve`, `session_update`) will refuse. Read operations still work.
-
-For multi-phase work, **use subtasks** — each phase gets its own task, session, and PR:
-
-```
-mcp__minsky__tasks_create (title: "Next phase", parent: "<parent-task-id>")
-mcp__minsky__session_start (task: "<new-subtask-id>")
-```
-
-This preserves the 1:1 task↔session invariant while giving each phase its own identity, spec, and status tracking. The parent task tracks progress across subtasks.
-
-**Do NOT use the delete-restart pattern** (`session_delete` → `session_start` on the same task). That is an anti-pattern — it loses context, wastes time on re-cloning, and risks branch collisions. Subtasks are the correct decomposition.
-
-### Parallel Task Planning
-
-When launching multiple subagents in parallel, **check for file overlap** between tasks before starting. If two tasks will edit the same file, either:
-
-- Serialize them (run one after the other)
-- Explicitly scope each task to skip the shared file
-- Partition by file set rather than by pattern category
-
-Merging parallel PRs that touch the same files causes cascading conflicts that require session recreation.
-
-### Removal and Deletion PRs
-
-When a PR removes a feature, module, or backend, symbol-level grep ("is the deleted class still imported?") is necessary but **not sufficient**. Code that _serves_ removed functionality often lives in other files without importing the removed module.
-
-**Behavioral residue search** — required before declaring any removal PR complete:
-
-1. **Hardcoded paths/filenames** associated with the removed feature (e.g., `process/tasks.md`, `session-db.json`)
-2. **Concept-name strings** in comments, descriptions, error messages, and docs (e.g., `"markdown"`, `"json-file"`)
-3. **Interface fields** that only make sense with the removed feature (e.g., `sessionDbPath`)
-4. **Inline code blocks** that manipulate data in the removed format (e.g., parsing markdown task lists in a shared service)
-5. **Utility functions** in shared modules that only served the removed feature
-6. **Documentation sections** describing removed behavior
-
-**Subagent instructions for partial removal**: Never use "if shared, leave it." Always: "if shared, identify which exports/functions are dead and refactor to keep only the live parts."
-
-**Task specs for removals** must include a behavioral scope section listing concepts/behaviors being removed, not just files. Include grep patterns that should return zero results after the work is done.
-
-## PR Reviews
-
-**Always use the `/review-pr` skill when reviewing any PR.** This includes "review PR #X", "check this PR", "look at the diff", or reviewing after subagent work. A review that isn't posted to GitHub is not a review.
+**Prompt generation:** Always use `mcp__minsky__session_generate_prompt` — never hand-craft prompts. It enforces correct sessionId, taskId, paths, scope bounds, and guard rails. Dispatch with `suggestedModel` and `suggestedSubagentType` from the result.
 
 ## Task Lifecycle
 
@@ -126,64 +21,26 @@ TODO → PLANNING → READY → IN-PROGRESS → IN-REVIEW → DONE
 Also: BLOCKED (from PLANNING, READY, or IN-PROGRESS), CLOSED (from any state)
 ```
 
-**Status transitions are enforced in the domain layer.** Invalid transitions are rejected with descriptive errors listing valid transitions from the current state.
-
-- **TODO → PLANNING**: Agent picks up the task. Set status to PLANNING before any investigation or session work.
-- **PLANNING** (no session): Read and verify the spec (pre-flight). Investigate the codebase if needed. Persist findings to the spec. No session exists — no code changes yet.
-- **PLANNING → READY**: Agent declares planning complete. Set status to READY when investigation is done and spec is up to date.
-- **READY → IN-PROGRESS**: Only via `session_start` (cannot be set directly). `session_start` blocks from TODO and PLANNING.
-- **IN-PROGRESS → IN-REVIEW**: PR created.
-- **IN-REVIEW → DONE**: Spec verified, PR merged.
-- **IN-PROGRESS → PLANNING**: Go back for more investigation if scope was wrong.
-- **READY → PLANNING**: Go back if more investigation is needed before starting.
-
-## Task Completion Protocol
-
-A PR merging is NOT the same as a task being complete. Before marking any task DONE:
-
-1. **Re-read the task spec** — fetch it with `tasks_spec_get` and review every success criterion
-2. **Check each criterion** — verify the PR/code actually delivers it, not just something adjacent
-3. **If scope was reduced**, update the spec FIRST to reflect actual scope, note what was deferred, and create follow-up tasks for gaps before marking DONE
-4. **If criteria can't be verified**, the task is not DONE — use IN-REVIEW or create follow-up tasks
-
-Never treat "code merged" as equivalent to "task complete." The spec defines completeness, not the PR.
-
-### PLANNING phase: Pre-flight and investigation
-
-During PLANNING (before `session_start`):
-
-1. Fetch the task spec with `tasks_spec_get` and verify against the **current** codebase
-2. If items are already done or no longer applicable, update the spec before starting work
-3. If investigation/audit is needed, do it now and persist findings to the spec **before** presenting in chat. Chat is volatile — session termination loses all findings. The spec is the durable artifact.
-4. Update the task spec with findings (`tasks_edit` with `specContent`) — include file paths, line numbers, and rationale
-5. Mark completed criteria (e.g., `[x] Audit completed`)
-6. When ready, call `session_start` to transition to IN-PROGRESS
-
-### Spec verification and documentation impact gate merge
-
-The `/review-pr` skill requires both a **Spec verification** section and a **Documentation impact** section in every review. The pre-merge hook (`require-review-before-merge.ts`) blocks merges if either section is missing. This ensures:
-
-- Every spec criterion is checked before merge
-- Scope reductions are caught and documented
-- Follow-up tasks are created for deferred work
-- Documentation freshness is assessed for every PR — if docs need updating, the update must be in the same PR (not deferred to a follow-up)
+Transitions are enforced in the domain layer. `session_start` blocks from TODO/PLANNING — task must be READY first. See `/orchestrate` skill for full workflow details.
 
 ## Work Completion
 
-- **Do not defer identified, actionable work.** If the current task's success criteria have unmet items and the work to address them is known (not blocked, not requiring new research), complete it. Do not create follow-up tasks, update specs to reduce scope, or propose partial PRs without explicitly asking the user.
-- **The user decides scope, not the agent.** Never unilaterally decide "this is a good stopping point." If uncertain whether to continue, ask.
-- **Artifact creation is not progress.** Creating tasks, updating specs, writing rules, and process discussion are not substitutes for doing the work. If you can describe exactly what needs to be done, do it.
-- **Before proposing to ship**, check the task spec's success criteria. If items are unmet and actionable, keep working.
-- **Never notice an issue without acting on it.** If you discover a problem, duplication, or architectural concern that's out of scope to fix now, immediately file a task with `mcp__minsky__tasks_create`. Mentioning it in chat is not action — it must become a trackable artifact (task, spec update, or memory). There is no "worth noting for a follow-up" without creating the follow-up.
-- **Process corrections require structural fixes, not memories.** When corrected on a process failure, invoke `/retrospective` to analyze the root cause and produce durable fixes (hooks, skill updates, CLAUDE.md changes). Saving a memory is not enforcement — memories are behavioral guidance that can be ignored. Hooks and skill steps are structural and cannot be bypassed.
+- **Do not defer identified, actionable work.** Complete unmet success criteria before proposing to ship.
+- **The user decides scope, not the agent.** Never unilaterally decide "this is a good stopping point."
+- **Artifact creation is not progress.** Creating tasks/specs/rules is not a substitute for doing the work.
+- **Never notice an issue without acting on it.** File a task, update a spec, or save a memory — mentioning in chat is not action.
+- **Process corrections require structural fixes.** Invoke `/retrospective` for durable fixes (hooks, skills), not just memories.
 
-## Task Creation
+## Key Workflows (via skills)
 
-**Always use the `/create-task` skill when creating tasks.** This ensures every task has a structured spec with required sections (Summary, Success Criteria, Scope, Acceptance Tests, Context). A PostToolUse hook on `tasks_create` blocks creation if specs over 100 chars are missing `## Success Criteria` or `## Acceptance Tests`.
+- **`/orchestrate`** — Full task lifecycle: selection, session, subagent dispatch, review, merge, completion
+- **`/implement-task`** — Implementation within a session: spec verification, coding, testing, PR creation
+- **`/review-pr`** — PR review with codebase verification, posted to GitHub. Required before any merge.
+- **`/create-task`** — Task creation with structured spec (Summary, Success Criteria, Scope, Acceptance Tests)
 
 ## MCP Tools
 
-Minsky exposes 80+ MCP tools. Use them for all task and session operations instead of shelling out to the CLI:
+Use MCP tools for all operations — never shell out to git/gh CLI:
 
 - `mcp__minsky__tasks_*` — task CRUD, status, specs, deps
 - `mcp__minsky__session_*` — session lifecycle, PRs, file operations
@@ -193,16 +50,15 @@ Minsky exposes 80+ MCP tools. Use them for all task and session operations inste
 ## Build & Test
 
 - **Runtime**: Bun (not Node.js)
-- **Type checking**: Handled automatically by hooks (`tsgo` native compiler). PostToolUse hook runs after every edit; Stop hook blocks if errors remain. For explicit checks, use `mcp__minsky__validate_typecheck`. **Never run `bun run tsc` manually.**
-- **Lint**: Handled automatically by hooks. For explicit checks, use `mcp__minsky__validate_lint`. **Never run `bun run lint` manually.**
+- **Type checking**: Automated by hooks (`tsgo`). Use `mcp__minsky__validate_typecheck` for explicit checks. **Never run `bun run tsc` manually.**
+- **Lint**: Automated by hooks. Use `mcp__minsky__validate_lint` for explicit checks.
 - **Tests**: `bun test --preload ./tests/setup.ts --timeout=15000 src tests/adapters tests/domain`
 - **Format**: `bun run format:check` / `bun run format:all`
 - **All checks**: `bun run validate-all`
 
 ## Hook Files
 
-- **All `.claude/hooks/*.ts` files must have execute permission** (`chmod +x`). The `Write` tool creates files with `644` by default — always run `chmod +x` after creating a hook file.
-- The pre-commit hook enforces this: commits with non-executable hook files are rejected.
+All `.claude/hooks/*.ts` files must have execute permission (`chmod +x`). The `Write` tool creates `644` by default. Pre-commit hook enforces this.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- Reduces CLAUDE.md from 222 lines (17.3KB, ~4,300 tokens) to 78 lines (4.2KB, ~1,050 tokens)
- Saves ~3,250 tokens per API call across every session and subagent
- No behavioral coverage lost — all extracted content already exists in skills

## What was removed

| Section | Lines | Now covered by |
|---------|-------|----------------|
| Minsky Session Workflow | 56-97 | `/orchestrate` + `/implement-task` skills |
| Session lifecycle (one session, one merge) | 74-87 | `/orchestrate` skill (key principles) |
| Parallel Task Planning | 89-97 | `/orchestrate` skill (step 3) |
| Removal and Deletion PRs | 99-114 | `feedback_investigation_planning.md` memory |
| Task Lifecycle details | 120-169 | `/orchestrate` skill (steps 1-7) |
| Task Completion Protocol | 140-160 | `/orchestrate` skill (step 7) |
| PLANNING phase details | 151-160 | `/orchestrate` skill (step 1) |
| Spec verification gate | 162-169 | `/review-pr` skill |

## What was kept (compressed)

- Subagent routing (model, type, capacity, prompt generation) — 15 lines
- Task lifecycle state machine diagram — 7 lines
- Work completion rules — 7 lines
- Key workflow skill pointers — 6 lines
- MCP tools, Build & Test, Hook files, Code Style, Architecture — 30 lines

## Test plan

- [ ] Verify `/orchestrate` skill contains session workflow details
- [ ] Verify `/implement-task` skill contains implementation lifecycle
- [ ] Verify `/review-pr` skill contains spec verification gate
- [ ] Verify new CLAUDE.md loads correctly in fresh session
- [ ] Spot-check that agent behavior is unchanged (subagent routing, task lifecycle)