### PR TITLE
refactor(mt#973): Clean up IIFE pattern, remove ctx! assertions, add session_exec guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Use MCP tools for all operations — never shell out to git/gh CLI:
 - `mcp__minsky__rules_*` — project rules
 - `mcp__minsky__persistence_*` — database operations
 
+**Use `session_exec` for running commands in sessions** from the main agent context. Instead of `SESSION=... && cd "$SESSION" && <command>`, use the MCP tool: `mcp__minsky__session_exec(task: "mt#123", command: "git status")`. This resolves the session directory automatically.
+
 ## Build & Test
 
 - **Runtime**: Bun (not Node.js)

--- a/src/adapters/shared/commands/session/changeset-aliases.ts
+++ b/src/adapters/shared/commands/session/changeset-aliases.ts
@@ -348,8 +348,7 @@ export function registerSessionChangesetCommands(): void {
         // Delegate to existing session.pr.create
         const prCreateCommand = sharedCommandRegistry.getCommand("session.pr.create");
         if (prCreateCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prCreateCommand.execute(params, ctx!);
+          return await prCreateCommand.execute(params, ctx);
         }
         throw new Error("session.pr.create command not available");
       },
@@ -367,8 +366,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prApproveCommand = sharedCommandRegistry.getCommand("session.pr.approve");
         if (prApproveCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prApproveCommand.execute(params, ctx!);
+          return await prApproveCommand.execute(params, ctx);
         }
         throw new Error("session.pr.approve command not available");
       },
@@ -386,8 +384,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prMergeCommand = sharedCommandRegistry.getCommand("session.pr.merge");
         if (prMergeCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prMergeCommand.execute(params, ctx!);
+          return await prMergeCommand.execute(params, ctx);
         }
         throw new Error("session.pr.merge command not available");
       },
@@ -405,8 +402,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prEditCommand = sharedCommandRegistry.getCommand("session.pr.edit");
         if (prEditCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prEditCommand.execute(params, ctx!);
+          return await prEditCommand.execute(params, ctx);
         }
         throw new Error("session.pr.edit command not available");
       },
@@ -424,8 +420,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prCreateCommand = sharedCommandRegistry.getCommand("session.pr.create");
         if (prCreateCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prCreateCommand.execute(params, ctx!);
+          return await prCreateCommand.execute(params, ctx);
         }
         throw new Error("session.pr.create command not available");
       },
@@ -442,8 +437,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prApproveCommand = sharedCommandRegistry.getCommand("session.pr.approve");
         if (prApproveCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prApproveCommand.execute(params, ctx!);
+          return await prApproveCommand.execute(params, ctx);
         }
         throw new Error("session.pr.approve command not available");
       },
@@ -460,8 +454,7 @@ export function registerSessionChangesetCommands(): void {
       execute: async (params, ctx) => {
         const prMergeCommand = sharedCommandRegistry.getCommand("session.pr.merge");
         if (prMergeCommand) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return await prMergeCommand.execute(params, ctx!);
+          return await prMergeCommand.execute(params, ctx);
         }
         throw new Error("session.pr.merge command not available");
       },

--- a/src/adapters/shared/commands/tools/similarity-commands.ts
+++ b/src/adapters/shared/commands/tools/similarity-commands.ts
@@ -166,14 +166,9 @@ export class ToolsSimilarCommand {
     const { createToolSimilarityService } = await import(
       "../../../../domain/tools/similarity/tool-similarity-service"
     );
-    const service = await createToolSimilarityService(
-      {},
-      (() => {
-        if (!this.getPersistenceProvider)
-          throw new Error("Persistence provider required for tool similarity search");
-        return this.getPersistenceProvider();
-      })()
-    );
+    if (!this.getPersistenceProvider)
+      throw new Error("Persistence provider required for tool similarity search");
+    const service = await createToolSimilarityService({}, this.getPersistenceProvider());
 
     const searchResults = await service.similarToTool(toolId, limit, threshold);
 
@@ -275,14 +270,9 @@ export class ToolsSearchCommand {
     const { createToolSimilarityService } = await import(
       "../../../../domain/tools/similarity/tool-similarity-service"
     );
-    const service = await createToolSimilarityService(
-      {},
-      (() => {
-        if (!this.getPersistenceProvider)
-          throw new Error("Persistence provider required for tool search");
-        return this.getPersistenceProvider();
-      })()
-    );
+    if (!this.getPersistenceProvider)
+      throw new Error("Persistence provider required for tool search");
+    const service = await createToolSimilarityService({}, this.getPersistenceProvider());
 
     // Immediate progress hint to stderr unless JSON/quiet
     if (!params.quiet && !params.json && ctx?.format !== "json") {


### PR DESCRIPTION
## Summary

- **Fix 1**: Remove IIFE pattern in `similarity-commands.ts` (both `ToolsSimilarCommand` and `ToolsSearchCommand`). The guard is now a plain early-return throw before the `createToolSimilarityService` call, making the control flow explicit and readable.
- **Fix 2**: Remove 7 `eslint-disable-next-line @typescript-eslint/no-non-null-assertion` / `ctx!` pairs in `changeset-aliases.ts`. Since delegated `execute` methods accept `ctx?: CommandExecutionContext`, passing `ctx` directly (which may be `undefined`) is type-safe and correct.
- **Fix 3**: Add `session_exec` guidance to CLAUDE.md's MCP Tools section, replacing the shell-based workaround pattern.

## Coherence Verification

**Files re-read**: 
- `/src/adapters/shared/commands/tools/similarity-commands.ts`
- `/src/adapters/shared/commands/session/changeset-aliases.ts`
- `CLAUDE.md`

**Q1 single purpose**: pass
**Q2 comment honesty**: pass — all existing comments remain accurate; no stale references introduced
**Q3 naming honesty**: pass — no renames needed
**Q4 redundant siblings**: pass — no new duplication
**Q5 dead exports**: pass — `createToolsSimilarCommand` and `createToolsSearchCommand` remain exported and unchanged; `registerSessionChangesetCommands` unchanged
**Q6 orphan code**: pass — IIFE removal left no orphan helpers; `ctx!` removal left no orphan code
**Q7 stray artifacts**: pass — no backup/tmp files

**Items fixed in this PR (beyond original scope)**: none
**Items deferred (with justification)**: none

🤖 Generated with Claude (Sonnet)