### PR TITLE
feat(mt#962): Configure model routing and thinking budgets for token efficiency

### DIFF
--- a/.claude/agents/refactor.md
+++ b/.claude/agents/refactor.md
@@ -2,7 +2,8 @@
 name: refactor
 description: Use for code refactoring tasks (structural changes that preserve observable behavior). Includes mandatory coherence verification — re-reads modified files end-to-end and reports stale comments, redundant siblings, dead exports, and any code that became orphaned by the refactor.
 tools: Read, Edit, Write, Glob, Grep, Bash, mcp__minsky__session_commit, mcp__minsky__session_pr_create, mcp__minsky__session_dir, mcp__minsky__session_read_file, mcp__minsky__session_edit_file, mcp__minsky__session_write_file, mcp__minsky__session_search_replace, mcp__minsky__session_list_directory, mcp__minsky__session_file_exists, mcp__minsky__session_grep_search, mcp__minsky__session_search
-model: opus
+model: sonnet
+effort: medium
 ---
 
 You are a refactoring specialist subagent. Your job is to make structural code changes (renaming, moving, eliminating layers, consolidating, extracting) while preserving observable behavior — and to leave the codebase in a coherent state, not a half-migrated state.

--- a/.claude/agents/verify-completion.md
+++ b/.claude/agents/verify-completion.md
@@ -3,6 +3,7 @@ name: verify-completion
 description: Use after declaring a task done — verifies each success criterion in the task spec against the current codebase. Catches premature completion claims, scope drift, and unmet criteria. The doer should not verify their own work; this agent provides a fresh perspective.
 tools: Read, Glob, Grep, Bash, mcp__minsky__tasks_get, mcp__minsky__tasks_spec_get
 model: sonnet
+effort: low
 ---
 
 You are a completion verifier. Your job is to objectively assess whether a task's success criteria are met by examining the current codebase. You are NOT the doer — you bring a fresh perspective.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

- Sets `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` in project settings so all subagents default to Sonnet
- Changes refactor agent from `model: opus` to `model: sonnet` (structural work is bounded scope)
- Adds `effort` frontmatter to agent definitions (medium for refactor, low for verify-completion)

Addresses the finding that 99.6% of API calls used Opus. With this change:
- Main conversation stays on Opus (complex orchestration, investigation)
- All subagents default to Sonnet via `CLAUDE_CODE_SUBAGENT_MODEL` env var
- Individual agent defs can override (reviewer already has `model: sonnet` on main)
- Thinking budgets tuned per agent type via `effort` frontmatter

Expected impact: ~60-70% of API calls should now use Sonnet instead of Opus.

## Test plan

- [ ] Verify `CLAUDE_CODE_SUBAGENT_MODEL` is respected by Claude Code (spawn a test subagent)
- [ ] Verify refactor agent uses Sonnet after this change
- [ ] Verify effort levels appear in agent sessions
- [ ] Main conversation still uses Opus (not affected by subagent env var)