### PR TITLE
feat(mt#963): Add compaction instructions, .claudeignore, and context optimizations

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,15 @@
+# Build artifacts
+node_modules/
+dist/
+coverage/
+.tsbuildinfo
+
+# Session workspaces (large, irrelevant to main project)
+~/.local/state/minsky/sessions/
+
+# Generated files
+*.tsbuildinfo
+*.d.ts.map
+
+# Large data files
+*.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@ All `.claude/hooks/*.ts` files must have execute permission (`chmod +x`). The `W
 - Max 400 lines per file (warn), 1500 (error)
 - 10 custom ESLint rules enforce architectural patterns
 
+## Compact Instructions
+
+When compacting, preserve: current task ID and session path, file paths being edited, architectural decisions made this session, test failure details, and the current plan. Drop: full tool outputs (keep summaries), resolved debugging steps, verbose error messages already fixed.
+
 ## Key Architecture
 
 - Clean architecture: Domain → Adapters → Infrastructure


### PR DESCRIPTION
## Summary

- Adds compaction instructions to CLAUDE.md guiding what to preserve/drop during auto-compaction
- Creates `.claudeignore` to exclude irrelevant directories from Claude's search scope
- User-level: sets `opusplan` model (Opus for planning, Sonnet for execution)

## Research basis

Community best practices from multiple sources:
- [MindStudio guide](https://www.mindstudio.ai/blog/claude-code-compact-command-context-management): compact at 60% context, not 95%
- [Post-compaction hooks article](https://medium.com/@porter.nicholas/claude-code-post-compaction-hooks-for-context-renewal-7b616dcaa204): re-inject critical context after compaction
- [Token optimizer](https://github.com/alexgreensh/token-optimizer): structural waste (bloated configs, stale entries) accounts for 75-85% of waste
- [ECC guide](https://github.com/affaan-m/everything-claude-code/blob/main/docs/token-optimization.md): model routing and compaction strategy

## What was NOT added and why

- **`MAX_THINKING_TOKENS`**: With adaptive reasoning (default since Feb 2026), fixed thinking budgets are overridden. Effort levels (configured in mt#962) are the correct modern control.
- **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`**: Can only lower the threshold due to a Math.min clamp ([GitHub issue #31806](https://github.com/anthropics/claude-code/issues/31806)). Manual `/compact` at logical breakpoints is more effective.
- **Post-compaction hook**: Could re-inject context-essentials.md after compaction, but our CLAUDE.md is already lean (84 lines). Deferred unless compaction quality proves insufficient.

## Test plan

- [ ] Verify `.claudeignore` prevents `node_modules/` from appearing in search results
- [ ] Verify compaction instructions are respected (run `/compact` and check summary)
- [ ] Verify `opusplan` activates (check `/model` shows opusplan in new session)