### PR TITLE
feat(mt#976): Add Opus escalation instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ When spawning subagents, use the appropriate model and type:
 
 **Prompt generation:** Always use `mcp__minsky__session_generate_prompt` — never hand-craft prompts. It enforces correct sessionId, taskId, paths, scope bounds, and guard rails. Dispatch with `suggestedModel` and `suggestedSubagentType` from the result.
 
+**Escalation to Opus:** The default model is Sonnet. When you recognize you're struggling — same fix attempted 3+ times, architectural ambiguity you can't resolve, multi-file reasoning that isn't converging, or a task that requires deep investigation — spawn a subagent with `model: "opus"` to analyze the problem. Let Opus produce the plan or diagnosis, then continue executing with Sonnet. Don't persist on a problem that exceeds your current model's capability.
+
 ## Task Lifecycle
 
 ```


### PR DESCRIPTION
## Summary

- Adds "Escalation to Opus" paragraph to the Subagent Routing section of CLAUDE.md
- Tells Sonnet (now the default model) when to recognize it's struggling and spawn an Opus subagent
- Trigger conditions: 3+ failed attempts at same fix, architectural ambiguity, non-converging reasoning, deep investigation needed
- Pattern: Opus analyzes/plans, Sonnet continues executing

## Context

- Default model changed to Sonnet in user settings
- Subagents default to Sonnet via `CLAUDE_CODE_SUBAGENT_MODEL=sonnet`
- The advisor tool (API-only, not in Claude Code CLI) implements this pattern at the platform level
- In Claude Code, the equivalent is spawning a `model: "opus"` subagent for analysis
- Community research confirms Sonnet + Opus advisor achieves near-Opus quality at 60-70% lower cost

## Test plan

- [ ] CLAUDE.md contains escalation guidance
- [ ] CLAUDE.md stays under 100 lines
- [ ] New sessions on Sonnet see the escalation instructions