### PR TITLE
fix(mt#951): include session cross-reference in tasks_get text output

### DIFF
--- a/src/adapters/shared/commands/tasks/crud-commands.ts
+++ b/src/adapters/shared/commands/tasks/crud-commands.ts
@@ -421,6 +421,20 @@ export class TasksGetCommand extends BaseTaskCommand<TasksGetParams> {
       if (params.includeSpec && extras.spec !== undefined) {
         message += extras.spec ? `\n\nSpec:\n${extras.spec}` : `\n\nSpec: (not found)`;
       }
+      if (params.includeSession && extras.session) {
+        const s = extras.session as {
+          sessionId: string;
+          status?: string;
+          lastActivityAt?: string;
+          liveness?: string;
+        };
+        message += `\n\nSession: ${s.sessionId} [${s.status || "unknown"}] (${s.liveness || "unknown"})`;
+        if (s.lastActivityAt) {
+          message += `\n  Last activity: ${s.lastActivityAt}`;
+        }
+      } else if (params.includeSession) {
+        message += `\n\nSession: (none)`;
+      }
 
       const result = this.formatResult(
         this.createSuccessResult(validatedTaskId, message, extras),


### PR DESCRIPTION
## Problem

When `tasks_get --includeSession true` was called via MCP (text format), the session cross-reference data was computed and stored in `extras.session` but never appeared in the response. The text formatter only returned the `message` string, which wasn't updated to include session info.

Discovered during live verification — `mcp__minsky__tasks_get` returned only "Task mt#951 retrieved" with no visible session block, even though the data was being computed.

## Fix

Added a message-append block for session data in `TasksGetCommand.execute`:

```typescript
if (params.includeSession && extras.session) {
  message += `\n\nSession: ${s.sessionId} [${s.status}] (${s.liveness})`;
  if (s.lastActivityAt) message += `\n  Last activity: ${s.lastActivityAt}`;
} else if (params.includeSession) {
  message += `\n\nSession: (none)`;
}
```

Mirrors the existing pattern for `includeSpec`.

## Test plan

- [ ] `tasks_get --taskId mt#951 --includeSession true` shows session ID, status, liveness, last activity
- [ ] `tasks_get --taskId <task-without-session> --includeSession true` shows "Session: (none)"
- [ ] `tasks_get --taskId mt#951` without `includeSession` unchanged

🤖 Had Claude look into this — AI-assisted.