### PR TITLE
feat(mt#1045): post-commit hook updates session activity for direct git commits

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Post-commit hook: update session activity state (best-effort)
+# Allows direct `git commit` to be visible to liveness tracking.
+bun src/hooks/post-commit.ts || true

--- a/src/hooks/post-commit.ts
+++ b/src/hooks/post-commit.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+
+/**
+ * Post-commit hook: update session activity state (best-effort)
+ *
+ * Fires after every `git commit` in a session workspace, making direct CLI commits
+ * visible to liveness tracking (lastActivityAt, lastCommitHash, lastCommitMessage,
+ * commitCount, status CREATED→ACTIVE).
+ *
+ * Must always exit 0 — errors are written to stderr but must never block commits.
+ */
+
+import { execGitWithTimeout } from "../utils/git-exec";
+import { getSessionsDir } from "../utils/paths";
+import { SessionStatus } from "../domain/session/types";
+
+/**
+ * Detect whether CWD is inside a Minsky session workspace and extract the session ID.
+ *
+ * Uses git to find the repo root, then checks if that root lives under the sessions dir.
+ * Returns null if not in a session (or if detection fails).
+ */
+async function detectSessionId(cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execGitWithTimeout("rev-parse", "rev-parse --show-toplevel", {
+      workdir: cwd,
+      timeout: 5000,
+    });
+    const gitRoot = stdout.trim();
+    const sessionsDir = getSessionsDir();
+
+    if (!gitRoot.startsWith(sessionsDir)) {
+      return null;
+    }
+
+    // Path structure: <sessionsDir>/<sessionId>/...
+    const relativePath = gitRoot.substring(sessionsDir.length + 1);
+    const sessionId = relativePath.split("/")[0];
+
+    return sessionId || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the latest commit hash and message from the current repo.
+ */
+async function getLatestCommitInfo(cwd: string): Promise<{ hash: string; message: string } | null> {
+  try {
+    const hashResult = await execGitWithTimeout("rev-parse", "rev-parse HEAD", {
+      workdir: cwd,
+      timeout: 5000,
+    });
+    const hash = hashResult.stdout.trim();
+
+    const msgResult = await execGitWithTimeout("log", "log -1 --pretty=format:%s", {
+      workdir: cwd,
+      timeout: 5000,
+    });
+    const message = msgResult.stdout.trim();
+
+    return { hash, message };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Main post-commit hook logic.
+ */
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+
+  // Step 1: Detect if we're in a session workspace
+  const sessionId = await detectSessionId(cwd);
+  if (!sessionId) {
+    // Not in a session — nothing to do, exit silently
+    return;
+  }
+
+  // Step 2: Get commit info
+  const commitInfo = await getLatestCommitInfo(cwd);
+  if (!commitInfo) {
+    process.stderr.write(
+      `[post-commit] Warning: could not read commit info for session ${sessionId}\n`
+    );
+    return;
+  }
+
+  // Step 3: Initialize session provider via the standard CLI composition pattern
+  const { PersistenceService } = await import("../domain/persistence/service");
+  const persistenceService = new PersistenceService();
+  let sessionProvider: import("../domain/session/types").SessionProviderInterface;
+  try {
+    await persistenceService.initialize();
+    const persistenceProvider = persistenceService.getProvider();
+
+    const { createSessionProvider } = await import("../domain/session/session-db-adapter");
+    sessionProvider = await createSessionProvider(undefined, persistenceProvider);
+  } catch (err) {
+    process.stderr.write(`[post-commit] Warning: could not initialize session provider: ${err}\n`);
+    return;
+  }
+
+  // Step 4: Update session activity fields
+  try {
+    const currentSession = await sessionProvider.getSession(sessionId);
+    if (!currentSession) {
+      process.stderr.write(`[post-commit] Warning: session record not found for ID ${sessionId}\n`);
+      return;
+    }
+
+    const newCommitCount = (currentSession.commitCount ?? 0) + 1;
+
+    // Status only moves forward — CREATED→ACTIVE; never downgrade from PR_OPEN etc.
+    const newStatus =
+      currentSession.status === SessionStatus.CREATED
+        ? SessionStatus.ACTIVE
+        : currentSession.status;
+
+    await sessionProvider.updateSession(sessionId, {
+      lastActivityAt: new Date().toISOString(),
+      lastCommitHash: commitInfo.hash,
+      lastCommitMessage: commitInfo.message,
+      commitCount: newCommitCount,
+      status: newStatus,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `[post-commit] Warning: failed to update session activity for ${sessionId}: ${err}\n`
+    );
+  } finally {
+    // Step 5: Close persistence connection (best-effort)
+    try {
+      await persistenceService.close();
+    } catch {
+      // Ignore close errors
+    }
+  }
+}
+
+// Entry point — catch ALL errors and always exit 0
+if (import.meta.main) {
+  main().catch((err) => {
+    process.stderr.write(`[post-commit] Unexpected error: ${err}\n`);
+  });
+}

--- a/src/hooks/post-commit.ts
+++ b/src/hooks/post-commit.ts
@@ -10,6 +10,9 @@
  * Must always exit 0 — errors are written to stderr but must never block commits.
  */
 
+// tsyringe (used by PersistenceService) requires reflect-metadata polyfill
+import "reflect-metadata";
+
 import { execGitWithTimeout } from "../utils/git-exec";
 import { getSessionsDir } from "../utils/paths";
 import { SessionStatus } from "../domain/session/types";

--- a/src/hooks/post-commit.ts
+++ b/src/hooks/post-commit.ts
@@ -92,10 +92,13 @@ async function main(): Promise<void> {
   }
 
   // Step 3: Initialize session provider via the standard CLI composition pattern
+  // Must initialize configuration first — PersistenceService depends on it
+  const { setupConfiguration } = await import("../config-setup");
   const { PersistenceService } = await import("../domain/persistence/service");
   const persistenceService = new PersistenceService();
   let sessionProvider: import("../domain/session/types").SessionProviderInterface;
   try {
+    await setupConfiguration();
     await persistenceService.initialize();
     const persistenceProvider = persistenceService.getProvider();
 


### PR DESCRIPTION
## Summary

Closes the tracking gap where `git commit` called directly (bypassing `mcp__minsky__session_commit`) left session activity fields stale. Before this PR, `commitCount` didn't reflect CLI-driven commits (rebase, amend, manual commit) — a common pattern discovered during mt#951 verification.

## How it works

- **`.husky/post-commit`** — Shell wrapper delegating to a TS implementation, with `|| true` to ensure hook failures never block commits
- **`src/hooks/post-commit.ts`** — Best-effort activity updater:
  1. Detects if CWD is inside a session workspace via `git rev-parse --show-toplevel` + sessions dir check
  2. Reads latest commit hash and message
  3. Initializes configuration + PersistenceService + sessionProvider (follows CLI composition pattern)
  4. Updates `lastActivityAt`, `lastCommitHash`, `lastCommitMessage`, increments `commitCount`, transitions `CREATED → ACTIVE`
  5. Status never downgrades (if already PR_OPEN or later, stays there)
  6. Always exits 0 — any error is written to stderr but never blocks the commit

## Live verification

Tested on this PR's own commits:
- `git commit` executed → hook fired
- `session_get --task mt#1045` now shows: `status: "ACTIVE"`, `commitCount: 1`, correct `lastCommitHash` and `lastCommitMessage`, `liveness: "healthy"`

## Test plan

- [x] `git commit` in session workspace → session record updates
- [x] `git commit` outside session → hook exits cleanly (no-op, detected via git root check)
- [x] Hook failures never block commits (errors go to stderr, exit 0)
- [x] Uses `execGitWithTimeout` (satisfies `no-unsafe-git-exec` lint rule)

🤖 Had Claude look into this — AI-assisted.