### PR TITLE
feat(mt#1048): orchestrate skill uses liveness pre-check before session_start

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -27,7 +27,19 @@ Optional: task ID (e.g., `/orchestrate mt#123`). If omitted, lists available tas
 
 ### 2. Session creation
 
-- Start a session: `mcp__minsky__session_start` with `task: "<task-id>"`, `repo: "https://github.com/edobry/minsky.git"`
+**First check for existing sessions on this task:**
+
+- `mcp__minsky__session_list` with `task: "<task-id>"` — returns sessions with their `status` and `liveness` (from mt#951)
+- Interpret liveness before proceeding:
+  - **`healthy`** (active commits within 30 min): Another agent is working on this task. **Do not proceed.** Report back to the user; do not dispatch a competing session.
+  - **`idle`** (30 min – 2 hours inactive): Likely paused. Report back to the user and ask whether to wait, monitor, or force-recover. Do not dispatch without confirmation.
+  - **`stale` / `orphaned`** (>2 hours inactive, no commits): Abandoned. Proceed with `session_start --recover true` (from mt#1044) to delete the stale session and create fresh.
+  - **Status `MERGED` or `CLOSED`**: The previous session is terminal. Either delete it manually (`session_delete`) or pick a different task — `--recover` will not override this.
+  - **No session**: Normal flow, just `session_start` without `recover`.
+
+Then start the session:
+
+- `mcp__minsky__session_start` with `task: "<task-id>"`, `repo: "https://github.com/edobry/minsky.git"` (add `recover: true` if recovering from a stale session)
 - This automatically sets task status to IN-PROGRESS
 - Note the session ID and directory path for subagent dispatch
 


### PR DESCRIPTION
## Summary

Adds a liveness-aware pre-check step to the `orchestrate` skill workflow, making it the first real consumer of the mesh observability data from mt#951. Before `session_start`, the skill now checks for existing sessions on the task and interprets their liveness to decide whether to proceed.

## Design

Section 2 (Session creation) now starts with a pre-check:

1. `session_list --task <id>` — returns sessions with `status` and `liveness`
2. Interpret liveness:
   - **`healthy`** (active, <30min): Another agent working — do NOT dispatch. Report back.
   - **`idle`** (30min–2h): Likely paused — ask user before proceeding.
   - **`stale` / `orphaned`** (>2h inactive, no commits): Abandoned — use `session_start --recover true` (from mt#1044).
   - **MERGED/CLOSED**: Terminal — require manual `session_delete` or pick different task.
   - **No session**: Normal flow.

## Why this matters

This completes the mesh observability loop: data layer (mt#951) → visibility (mt#1046) → recovery flow (mt#1044) → orchestration consumer (this PR). An orchestrator dispatching work can now detect and respect concurrent sessions on the same task without trial-and-error.

## Test plan

- [ ] Orchestrate on task with no session → normal flow
- [ ] Orchestrate on task with healthy session → skill halts, reports to user
- [ ] Orchestrate on task with stale session → uses `session_start --recover`
- [ ] Orchestrate on task with MERGED session → rejects with guidance

🤖 Had Claude look into this — AI-assisted.