### PR TITLE
fix(mt#1261): [SUPERSEDED by mt#1281] session_pr_create sessionId-shape fix

### DIFF
--- a/src/domain/session/session-pr-operations.ts
+++ b/src/domain/session/session-pr-operations.ts
@@ -241,9 +241,8 @@ Please provide a title for your pull request:
     // so updateSessionImpl doesn't try to create its own sessionProvider.
     await updateSessionImpl(
       {
-        name: sessionId,
+        sessionId,
         repo: params.repo,
-        json: false,
         force: false,
         noStash: false,
         noPush: false,
@@ -251,7 +250,7 @@ Please provide a title for your pull request:
         skipConflictCheck: params.skipConflictCheck,
         autoResolveDeleteConflicts: params.autoResolveDeleteConflicts,
         skipIfAlreadyMerged: true, // Automatically skip if changes already merged
-      } as import("../schemas").SessionUpdateParameters,
+      },
       {
         sessionDB: deps.sessionDB,
         gitService: deps.gitService,

--- a/src/domain/session/session-pr-update-param-shape.test.ts
+++ b/src/domain/session/session-pr-update-param-shape.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression test for mt#1261: session_pr_create was passing `name: sessionId`
+ * to the internal updateSessionImpl call, but updateSessionImpl destructures
+ * `sessionId`. The `as SessionUpdateParameters` cast hid the type mismatch,
+ * and the caller's sessionId was silently stripped, producing "Session ID is
+ * required" at runtime on every PR creation.
+ *
+ * Defense:
+ *   1. The cast was removed in the fix, so TypeScript now catches the wrong shape.
+ *   2. This test guards against re-adding either the buggy key or the cast.
+ */
+import { describe, it, expect } from "bun:test";
+/* eslint-disable custom/no-real-fs-in-tests -- intentional source-text assertion; the check only makes sense against the real file on disk */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("mt#1261 regression: session-pr-operations update-call shape", () => {
+  const source = readFileSync(join(__dirname, "session-pr-operations.ts"), "utf-8");
+
+  it("does not pass `name: sessionId` to updateSessionImpl", () => {
+    // Any occurrence of this exact pattern inside the session-pr-operations
+    // call to updateSessionImpl indicates the bug is back.
+    expect(source).not.toMatch(/name:\s*sessionId,\s*\n\s*repo:\s*params\.repo/);
+  });
+
+  it("does not cast updateSessionImpl params to SessionUpdateParameters", () => {
+    // The cast hid the original bug. Keeping the call uncast preserves type
+    // checking, so any future shape mismatch surfaces at compile time.
+    expect(source).not.toMatch(/as import\("\.\.\/schemas"\)\.SessionUpdateParameters/);
+  });
+});


### PR DESCRIPTION
## Superseded — please close

This PR is a duplicate of **mt#1281**, which already merged the same fix as commit `ffe5a589e fix(mt#1281): Pass sessionId not name to inner updateSessionImpl in session_pr_create`.

I (Claude) didn't search for parallel work on this bug before filing mt#1261 — the bug was independently discovered, fixed, and merged on main while I was working on mt#1253. The pattern matches `feedback_check_parallel_work_before_decomposing.md`: search task specs and open PRs for the bug signature before filing a duplicate.

### Status

- mt#1261 task: marked CLOSED (duplicate of mt#1281)
- This PR: please close via UI (no bot-identity path to close it)

### Original PR body (kept for audit)

Fixes mt#1261 — `session_pr_create` always failed with `Failed to update session before creating PR: Session ID is required` regardless of which identifier the caller passed. Root cause: a field-name mismatch on the internal `updateSessionImpl` call, hidden by a type cast. Fix: rename `name:` to `sessionId:` and drop the cast and the no-op `json: false`. Regression test added.

mt#1281's fix is functionally equivalent; this PR's regression test could be cherry-picked separately if desired.