### PR TITLE
fix(mt#1271): omit persistence.backend default so legacy fallback can run

### DIFF
--- a/src/domain/configuration/sources/defaults.ts
+++ b/src/domain/configuration/sources/defaults.ts
@@ -7,7 +7,6 @@
  */
 
 import type { PartialConfiguration } from "../schemas";
-import { getDefaultSqliteDbPath } from "../../../utils/paths";
 
 /**
  * Application default configuration
@@ -23,14 +22,18 @@ export const defaultConfiguration: PartialConfiguration = {
     "github-issues": undefined,
   },
 
-  // Modern persistence configuration
-  persistence: {
-    backend: "sqlite",
-    sqlite: {
-      dbPath: getDefaultSqliteDbPath(),
-    },
-    postgres: undefined,
-  },
+  // Modern persistence configuration is intentionally omitted from defaults.
+  //
+  // Reason: the `persistence` schema requires a `backend` value when the
+  // object is present. If we set a default `backend: "sqlite"` here, the
+  // legacy `sessiondb.backend` fallback in `getEffectivePersistenceConfig`
+  // never runs (the `??` chain falls through only on undefined). That
+  // silently broke hosted deploys configured via MINSKY_SESSIONDB_BACKEND
+  // env var, which is the contract the deploy runbook documents.
+  //
+  // The resolver provides both the final `?? "sqlite"` backend fallback and
+  // the SQLite dbPath fallback, so omitting the whole block here is safe and
+  // makes the legacy-fallback path actually reachable. See mt#1271.
 
   // GitHub configuration (all optional)
   github: {


### PR DESCRIPTION
## Summary

Follow-up to PR #780. That PR routed `PersistenceService.loadConfiguration` through `getEffectivePersistenceConfig`, but I missed that the resolver itself has the same precedence pattern (`config.persistence.backend ?? legacy.backend ?? "sqlite"`). With `defaults.ts` providing `persistence.backend: "sqlite"`, the `??` chain still falls through immediately and never consults `sessiondb.backend`.

End-to-end verification against the Railway container after #780 merged confirmed the bug persisted: `tasks.spec.get mt#1271` still returned `no such table: tasks`.

## Fix

Omit the `persistence` block from defaults entirely. The resolver provides both fallbacks itself:
- `backend` falls through to `"sqlite"` at the bottom of the `??` chain
- `dbPath` falls through to `getDefaultSqliteDbPath()` when `backend === "sqlite"` and no path is set

Removed the now-unused `getDefaultSqliteDbPath` import from `defaults.ts`.

## Verification

Local repro from a clean cwd with no project-local config:

```
env -i HOME=/tmp/nohome MINSKY_SESSIONDB_BACKEND=postgres MINSKY_SESSIONDB_POSTGRES_URL=postgresql://... bun [diag]
```

Before this PR: `backend: sqlite` (wrong)
After this PR: `backend: postgres` (correct)

With nothing set: `backend: sqlite, dbPath: /tmp/nohome/.local/state/minsky/sessions.db` (still correct via resolver fallback).

Tests still 10/10. Will redeploy on Railway after merge.

## Related

- mt#1271 — original task
- PR #780 — first attempt; this is the completion
- mt#1224 — still BLOCKED on this; will unblock automatically after Railway redeploys